### PR TITLE
Add README (English + pt-BR)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,217 @@
+# zombie-crab-project
+
+**Run more than one personal AI agent, safely, behind a single front door.**
+
+*[Leia isso em português](./README.pt-br.md)*
+
+## The problem
+
+[PicoClaw](https://github.com/sipeed/picoclaw) is a fantastic ultra-lightweight
+personal AI assistant — a single Go binary, easy to self-host, with a native
+real-time chat protocol ("Pico Protocol") over WebSocket. But it was designed
+around one idea: **one agent, one owner**. There's no concept of roles,
+permissions, or access control between different consumers of the same
+deployment. If you spin up a PicoClaw gateway, *anyone who can reach it can
+talk to it* — there's no built-in way to say "this API key can call the
+sales-team agent" or "that team can only read, not write."
+
+That's fine if you're running PicoClaw for yourself, on your own machine. It
+stops being fine the moment you want to:
+
+- Run **more than one** PicoClaw instance (one per team, client, or project)
+  from the same host, and
+- Expose them over a normal HTTP API (so any OpenAI-compatible client —
+  Open WebUI, LangChain, the official OpenAI SDK — can talk to them), while
+- Making sure each instance is only reachable through **one controlled,
+  authenticated entry point**, not five different ports scattered across
+  your firewall rules.
+
+PicoClaw itself has no answer for that last part. This project is the
+missing piece.
+
+## The idea
+
+Instead of teaching PicoClaw to do something it was never designed for, we
+put a real **API gateway** in front of it — one that already knows how to do
+RBAC, secrets, and routing — and let PicoClaw keep doing what it's good at.
+
+```mermaid
+flowchart LR
+    client(["Client<br/>curl · Open WebUI · SDK"])
+
+    myc["mycelium-gateway<br/>:8080 — the only published port<br/>routing · auth · secret injection"]
+
+    subgraph alpha [Tenant: alpha]
+        direction TB
+        proxyA["picoclaw-alpha-proxy<br/>:8787 · OpenAI-compatible"]
+        pcA["picoclaw-alpha<br/>gateway mode"]
+        proxyA -->|WebSocket, Pico Protocol| pcA
+    end
+
+    subgraph beta [Tenant: beta]
+        direction TB
+        proxyB["picoclaw-beta-proxy<br/>:8787 · OpenAI-compatible"]
+        pcB["picoclaw-beta<br/>gateway mode"]
+        proxyB -->|WebSocket, Pico Protocol| pcB
+    end
+
+    client -->|POST /picoclaw-alpha/...| myc
+    client -->|POST /picoclaw-beta/...| myc
+    myc -->|Bearer token injected| proxyA
+    myc -->|Bearer token injected| proxyB
+
+    classDef gateway fill:#2b6cb0,color:#ffffff,stroke:#1a365d,stroke-width:2px;
+    classDef clientStyle fill:#f6ad55,color:#1a202c,stroke:#c05621,stroke-width:2px;
+    classDef tenant fill:#edf2f7,stroke:#a0aec0,color:#1a202c;
+    class myc gateway;
+    class client clientStyle;
+    class proxyA,pcA,proxyB,pcB tenant;
+```
+
+Every arrow into a tenant subgraph passes through `mycelium-gateway` first —
+there is no other way in.
+
+Three pieces, each doing one job:
+
+| Piece | Job |
+|---|---|
+| [**PicoClaw**](https://github.com/sipeed/picoclaw) (`picoclaw-alpha`, `picoclaw-beta`, ...) | The actual agent. One instance per tenant/team/use case. Talks only its native Pico Protocol over WebSocket. |
+| [**picoclaw-openai-proxy**](https://github.com/sgelias/picoclaw-openai-proxy) | A tiny sidecar that translates a standard OpenAI `/v1/chat/completions` HTTP call into a Pico Protocol WebSocket turn, so any OpenAI-compatible tool can talk to PicoClaw. |
+| [**Mycelium**](https://github.com/LepistaBioinformatics/mycelium) (standalone mode) | The API gateway. The *only* thing exposed to the outside world. Everything downstream of it is unreachable except through it. |
+
+None of the PicoClaw instances or their proxy sidecars publish a port to the
+host — they only exist inside a private Docker network. If you're not
+talking through Mycelium, you're not talking to anything.
+
+## Why Mycelium specifically
+
+This is the part that actually solves the "PicoClaw has no RBAC" problem —
+not by adding RBAC to PicoClaw, but by putting something in front of it that
+already has it:
+
+- **Zero-dependency to get started.** Mycelium's `standalone` mode runs on
+  SQLite and an in-process cache — no Postgres, no Redis, no Vault to stand
+  up first. You get a real API gateway with a single `docker compose up`.
+- **Secrets never touch the client.** Each downstream route can require a
+  secret (a bearer token, in our case) that Mycelium injects on the way to
+  the proxy. The caller talking to the gateway never sees it, and the
+  proxy sidecar rejects anything that doesn't carry it — so even a stray
+  request that somehow reached the internal network directly is turned away.
+- **Security groups, built in.** Mycelium routes can be `public`,
+  `authenticated`, `protected`, or `protectedByRoles` (with per-role
+  read/write permissions). This project's routes are `public` today (the
+  simplest case), but the exact same gateway config format is how you'd
+  layer real per-user, per-role access control on top later — **without
+  ever touching PicoClaw itself.** That's the RBAC PicoClaw doesn't have,
+  living in the layer that's supposed to have it.
+- **One place to look, one place to lock down.** Health checks, routing,
+  authentication, and rate limiting for *every* PicoClaw instance live in
+  one config file and one container, instead of being reinvented per
+  instance.
+- **It scales sideways for free.** Adding a third, fourth, or tenth PicoClaw
+  instance is copy-paste: a new service pair in `docker-compose.yaml` and a
+  new route block in Mycelium's config. The gateway doesn't care how many
+  agents are behind it.
+
+## A first-time walkthrough
+
+If you've never touched PicoClaw or Mycelium before, here's the path from
+zero to a working request:
+
+**1. Clone, with the submodule:**
+
+```bash
+git clone --recurse-submodules https://github.com/sgelias/zombie-crab-project.git
+cd zombie-crab-project
+```
+
+**2. Onboard each PicoClaw instance once.** The very first boot needs to
+generate a `config.json` — do this before the long-running `gateway` service
+starts, or it'll crash-loop on an empty config:
+
+```bash
+docker compose run --rm picoclaw-alpha
+docker compose run --rm picoclaw-beta
+```
+
+**3. Pick a model and drop in your API key.** Edit
+`data/alpha/config.json` and set `agents.defaults.provider` /
+`agents.defaults.model_name` to one of the entries already listed in that
+file's `model_list` (DeepSeek, Anthropic, OpenAI, and a couple dozen others
+are pre-populated). Then create `data/alpha/.security.yml` with the real
+key:
+
+```yaml
+model_list:
+  deepseek-chat:
+    api_keys:
+      - "your-real-api-key"
+```
+
+**4. Turn on the channel the proxy talks to.** Still in
+`data/alpha/config.json`, set `channel_list.pico.enabled` to `true`. Then
+give it a token in `.security.yml` — note it has to be **nested** under
+`settings`, not flat:
+
+```yaml
+channels:
+  pico:
+    settings:
+      token: "some-random-token"
+```
+
+Repeat steps 3–4 for `data/beta/`.
+
+**5. Tell Mycelium about those same tokens.** Copy `.env.example` to `.env`
+and set `MYC_PICOCLAW_ALPHA_TOKEN` / `MYC_PICOCLAW_BETA_TOKEN` — these are
+the bearer tokens Mycelium will inject when calling each proxy, and the
+proxy's own `PROXY_API_KEY` check expects the exact same value.
+
+**6. Bring it all up:**
+
+```bash
+docker compose up -d
+```
+
+**7. Talk to it — through the gateway, on the one port that's published:**
+
+```bash
+curl http://localhost:8080/picoclaw-alpha/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "picoclaw",
+    "user": "alice",
+    "session_id": "conversa-1",
+    "messages": [{"role": "user", "content": "hi"}]
+  }'
+```
+
+Swap `picoclaw-alpha` for `picoclaw-beta` to reach the second instance —
+same gateway, same port, completely separate agent underneath.
+
+## What's what in this repo
+
+```
+docker-compose.yaml       # the whole stack: 2x picoclaw + proxy pairs + gateway
+.env.example              # runtime knobs + per-instance bearer tokens
+mycelium/
+  Dockerfile.standalone   # builds mycelium-api from upstream git, no local source copied in
+  config.standalone.toml  # gateway routes for picoclaw-alpha / picoclaw-beta
+picoclaw-openai-proxy/    # git submodule -- the OpenAI-compat sidecar
+```
+
+## Before you take this to production
+
+This repo is tuned to be easy to read and easy to run locally, not to be a
+hardened production deployment out of the box. A few things worth knowing
+before you expose it beyond your own machine:
+
+- TLS is disabled between the gateway and its downstream services (they
+  all sit on a private Docker network) — terminate TLS at the edge if
+  `mycelium-gateway`'s port ever faces the internet.
+- Every route here uses the `public` security group for simplicity. If you
+  need real per-user access control, that's exactly where Mycelium's
+  `authenticated` / `protected` / `protectedByRoles` groups come in.
+- Rotate the bearer tokens in `.env` and `.security.yml` before sharing this
+  stack with anyone else, and never commit real values (both are already
+  gitignored).

--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -1,0 +1,226 @@
+# zombie-crab-project
+
+**Rode mais de um agente de IA pessoal, com segurança, atrás de uma única porta de entrada.**
+
+*[Read this in English](./README.md)*
+
+## O problema
+
+O [PicoClaw](https://github.com/sipeed/picoclaw) é um assistente de IA
+pessoal ultra-leve e muito bem feito — um único binário em Go, fácil de
+hospedar, com um protocolo de chat em tempo real nativo (o "Pico Protocol")
+via WebSocket. Mas ele foi desenhado em torno de uma ideia só: **um agente,
+um dono**. Não existe conceito de papéis (roles), permissões ou controle de
+acesso entre diferentes consumidores da mesma instância. Se você sobe um
+gateway PicoClaw, *qualquer um que alcançar aquele endereço consegue
+conversar com ele* — não existe um jeito nativo de dizer "essa API key só
+pode chamar o agente do time de vendas" ou "esse time só pode ler, não
+escrever".
+
+Isso é ótimo se você está rodando o PicoClaw só pra você, na sua própria
+máquina. Deixa de ser ótimo no momento em que você quer:
+
+- Rodar **mais de uma** instância do PicoClaw (uma por time, cliente ou
+  projeto) no mesmo host, e
+- Expor elas por uma API HTTP normal (pra que qualquer client
+  OpenAI-compatible — Open WebUI, LangChain, o SDK oficial da OpenAI —
+  consiga conversar com elas), garantindo ao mesmo tempo que
+- Cada instância só seja alcançável através de **um único ponto de entrada
+  controlado e autenticado**, não cinco portas diferentes espalhadas pelas
+  suas regras de firewall.
+
+O PicoClaw, sozinho, não tem resposta pra essa última parte. Este projeto é
+a peça que faltava.
+
+## A ideia
+
+Em vez de ensinar o PicoClaw a fazer algo pra que ele nunca foi desenhado,
+colocamos um **API gateway** de verdade na frente dele — um que já sabe
+fazer RBAC, gerenciar segredos e rotear requisições — e deixamos o PicoClaw
+fazendo só o que ele faz bem.
+
+```mermaid
+flowchart LR
+    cliente(["Cliente<br/>curl · Open WebUI · SDK"])
+
+    myc["mycelium-gateway<br/>:8080 — a única porta publicada<br/>roteamento · autenticação · injeção de segredos"]
+
+    subgraph alpha [Tenant: alpha]
+        direction TB
+        proxyA["picoclaw-alpha-proxy<br/>:8787 · compatível OpenAI"]
+        pcA["picoclaw-alpha<br/>modo gateway"]
+        proxyA -->|WebSocket, Pico Protocol| pcA
+    end
+
+    subgraph beta [Tenant: beta]
+        direction TB
+        proxyB["picoclaw-beta-proxy<br/>:8787 · compatível OpenAI"]
+        pcB["picoclaw-beta<br/>modo gateway"]
+        proxyB -->|WebSocket, Pico Protocol| pcB
+    end
+
+    cliente -->|POST /picoclaw-alpha/...| myc
+    cliente -->|POST /picoclaw-beta/...| myc
+    myc -->|Bearer token injetado| proxyA
+    myc -->|Bearer token injetado| proxyB
+
+    classDef gateway fill:#2b6cb0,color:#ffffff,stroke:#1a365d,stroke-width:2px;
+    classDef clienteStyle fill:#f6ad55,color:#1a202c,stroke:#c05621,stroke-width:2px;
+    classDef tenant fill:#edf2f7,stroke:#a0aec0,color:#1a202c;
+    class myc gateway;
+    class cliente clienteStyle;
+    class proxyA,pcA,proxyB,pcB tenant;
+```
+
+Toda seta que entra num subgrafo de tenant passa primeiro pelo
+`mycelium-gateway` — não existe outra porta de entrada.
+
+Três peças, cada uma com um trabalho só:
+
+| Peça | Trabalho |
+|---|---|
+| [**PicoClaw**](https://github.com/sipeed/picoclaw) (`picoclaw-alpha`, `picoclaw-beta`, ...) | O agente de verdade. Uma instância por tenant/time/caso de uso. Só fala o Pico Protocol nativo, via WebSocket. |
+| [**picoclaw-openai-proxy**](https://github.com/sgelias/picoclaw-openai-proxy) | Um sidecar pequeno que traduz uma chamada HTTP `/v1/chat/completions` no formato OpenAI padrão pra um turno via WebSocket no Pico Protocol, pra que qualquer ferramenta compatível com OpenAI consiga falar com o PicoClaw. |
+| [**Mycelium**](https://github.com/LepistaBioinformatics/mycelium) (modo standalone) | O API gateway. A *única* coisa exposta pro mundo externo. Tudo que está atrás dele é inalcançável exceto através dele. |
+
+Nenhuma das instâncias do PicoClaw ou dos sidecars de proxy publica porta
+pro host — elas só existem dentro de uma rede Docker privada. Se você não
+está falando através do Mycelium, você não está falando com nada.
+
+## Por que o Mycelium especificamente
+
+Essa é a parte que realmente resolve o problema "o PicoClaw não tem RBAC" —
+não adicionando RBAC ao PicoClaw, mas colocando na frente dele algo que já
+tem:
+
+- **Zero dependência pra começar.** O modo `standalone` do Mycelium roda em
+  cima de SQLite e um cache em processo — sem precisar subir Postgres,
+  Redis ou Vault antes. Você tem um API gateway de verdade com um único
+  `docker compose up`.
+- **Segredos nunca chegam ao cliente.** Cada rota downstream pode exigir um
+  segredo (no nosso caso, um bearer token) que o Mycelium injeta no caminho
+  até o proxy. Quem chama o gateway nunca vê esse valor, e o próprio proxy
+  rejeita qualquer coisa que não carregue ele — então mesmo uma requisição
+  perdida que de alguma forma chegasse direto na rede interna seria barrada.
+- **Grupos de segurança, nativos.** Rotas no Mycelium podem ser `public`,
+  `authenticated`, `protected` ou `protectedByRoles` (com permissões de
+  leitura/escrita por papel). As rotas deste projeto são `public` hoje (o
+  caso mais simples), mas o mesmo formato de configuração do gateway é
+  exatamente como você camadaria controle de acesso real por usuário/papel
+  depois — **sem nunca precisar tocar no PicoClaw.** É o RBAC que o
+  PicoClaw não tem, vivendo na camada que deveria ter.
+- **Um lugar só pra olhar, um lugar só pra travar.** Health checks,
+  roteamento, autenticação e rate limiting de *todas* as instâncias do
+  PicoClaw vivem em um arquivo de config e um container só, em vez de
+  serem reinventados a cada instância.
+- **Escala de lado de graça.** Adicionar uma terceira, quarta ou décima
+  instância do PicoClaw é copiar e colar: um novo par de serviços no
+  `docker-compose.yaml` e um novo bloco de rota na config do Mycelium. O
+  gateway não liga pra quantos agentes estão atrás dele.
+
+## Um passo a passo pra quem está vendo isso pela primeira vez
+
+Se você nunca mexeu com PicoClaw ou Mycelium antes, esse é o caminho do
+zero até uma requisição funcionando:
+
+**1. Clone, com o submódulo:**
+
+```bash
+git clone --recurse-submodules https://github.com/sgelias/zombie-crab-project.git
+cd zombie-crab-project
+```
+
+**2. Faça o onboarding de cada instância do PicoClaw uma vez.** O primeiro
+boot precisa gerar um `config.json` — faça isso antes do serviço
+de longa duração (`gateway`) subir, senão ele entra em crash-loop com uma
+config vazia:
+
+```bash
+docker compose run --rm picoclaw-alpha
+docker compose run --rm picoclaw-beta
+```
+
+**3. Escolha um modelo e coloque sua API key de verdade.** Edite
+`data/alpha/config.json` e defina `agents.defaults.provider` /
+`agents.defaults.model_name` como uma das entradas já listadas no
+`model_list` desse mesmo arquivo (DeepSeek, Anthropic, OpenAI e mais umas
+duas dezenas de outros já vêm pré-preenchidos). Depois crie
+`data/alpha/.security.yml` com a chave real:
+
+```yaml
+model_list:
+  deepseek-chat:
+    api_keys:
+      - "sua-api-key-real"
+```
+
+**4. Ligue o canal que o proxy usa pra conversar.** Ainda em
+`data/alpha/config.json`, defina `channel_list.pico.enabled` como `true`.
+Depois dê um token pra ele em `.security.yml` — repare que ele precisa ficar
+**aninhado** dentro de `settings`, não solto:
+
+```yaml
+channels:
+  pico:
+    settings:
+      token: "um-token-aleatorio"
+```
+
+Repita os passos 3–4 para `data/beta/`.
+
+**5. Avise o Mycelium sobre esses mesmos tokens.** Copie `.env.example`
+para `.env` e defina `MYC_PICOCLAW_ALPHA_TOKEN` / `MYC_PICOCLAW_BETA_TOKEN`
+— são os bearer tokens que o Mycelium vai injetar ao chamar cada proxy, e a
+própria checagem `PROXY_API_KEY` do proxy espera exatamente o mesmo valor.
+
+**6. Suba tudo:**
+
+```bash
+docker compose up -d
+```
+
+**7. Converse com ele — através do gateway, na única porta publicada:**
+
+```bash
+curl http://localhost:8080/picoclaw-alpha/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "picoclaw",
+    "user": "alice",
+    "session_id": "conversa-1",
+    "messages": [{"role": "user", "content": "oi"}]
+  }'
+```
+
+Troque `picoclaw-alpha` por `picoclaw-beta` pra alcançar a segunda
+instância — mesmo gateway, mesma porta, agente completamente separado por
+baixo.
+
+## O que é o quê neste repositório
+
+```
+docker-compose.yaml       # a stack inteira: 2x pares picoclaw + proxy + gateway
+.env.example              # parâmetros de runtime + bearer tokens por instância
+mycelium/
+  Dockerfile.standalone   # builda o mycelium-api a partir do git upstream, sem copiar fonte local
+  config.standalone.toml  # rotas do gateway para picoclaw-alpha / picoclaw-beta
+picoclaw-openai-proxy/    # submódulo git -- o sidecar compatível com OpenAI
+```
+
+## Antes de levar isso pra produção
+
+Este repositório é ajustado pra ser fácil de ler e fácil de rodar
+localmente, não pra ser um deployment de produção já pronto e endurecido.
+Algumas coisas que vale saber antes de expor isso além da sua própria
+máquina:
+
+- TLS está desabilitado entre o gateway e os serviços downstream (todos
+  vivem numa rede Docker privada) — termine TLS na borda se a porta do
+  `mycelium-gateway` algum dia encarar a internet.
+- Toda rota aqui usa o grupo de segurança `public`, pela simplicidade. Se
+  você precisa de controle de acesso real por usuário, é exatamente aí que
+  entram os grupos `authenticated` / `protected` / `protectedByRoles` do
+  Mycelium.
+- Rotacione os bearer tokens em `.env` e `.security.yml` antes de
+  compartilhar essa stack com alguém, e nunca commite valores reais (os
+  dois já estão no gitignore).


### PR DESCRIPTION
## Summary
- Adds `README.md` (English) and `README.pt-br.md` explaining the project's purpose: PicoClaw has no RBAC/access-control concept, and this stack puts Mycelium in front of multiple PicoClaw instances to close that gap.
- Covers the three-piece architecture (PicoClaw, picoclaw-openai-proxy, Mycelium), why Mycelium specifically, and a first-time walkthrough from clone to a working `curl` request.
- Diagram is Mermaid (rendered natively by GitHub) instead of static ASCII art.

## Test plan
- [x] Mermaid diagrams render correctly on GitHub (flowchart with tenant subgraphs)
- [x] Cross-links between README.md / README.pt-br.md resolve
- [x] Walkthrough steps match the actual docker-compose.yaml / .env.example / mycelium/config.standalone.toml in this repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)