### PR TITLE
Fix mycelium health checks: point healthCheckPath at /healthz

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -91,6 +91,15 @@ services:
     depends_on:
       picoclaw-alpha:
         condition: service_healthy
+    healthcheck:
+      # /healthz is unauthenticated on purpose and also proxies picoclaw's
+      # own /health -- this is the same path mycelium-gateway polls (see
+      # mycelium/config.standalone.toml's healthCheckPath).
+      test: ["CMD", "wget", "-q", "--spider", "http://127.0.0.1:8787/healthz"]
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
 
   picoclaw-beta:
     <<: *picoclaw-common
@@ -118,6 +127,12 @@ services:
     depends_on:
       picoclaw-beta:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://127.0.0.1:8787/healthz"]
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
 
   mycelium-gateway:
     build:
@@ -139,8 +154,10 @@ services:
     volumes:
       - mycelium-data:/data
     depends_on:
-      - picoclaw-alpha-proxy
-      - picoclaw-beta-proxy
+      picoclaw-alpha-proxy:
+        condition: service_healthy
+      picoclaw-beta-proxy:
+        condition: service_healthy
 
 volumes:
   mycelium-data:

--- a/mycelium/config.standalone.toml
+++ b/mycelium/config.standalone.toml
@@ -113,6 +113,16 @@ target = "stdout"
 # 9.0.0-rc.2) -- myc-api resolves just the token from that env var at
 # request time, so headerName/prefix stay inline here instead of having to
 # be duplicated inside a JSON secret blob.
+#
+# `healthCheckPath = "/healthz"` (not "/v1/models"): mycelium's health-check
+# dispatcher issues a plain unauthenticated GET
+# (services_health_dispatcher/check_single_host_health.rs), so pointing it
+# at an auth-gated route like /v1/models always fails with "Unable to
+# perform the health check" (every attempt gets a 401, which the dispatcher
+# doesn't treat as a real error, so it falls through all retries with
+# neither a response nor an error recorded). picoclaw-openai-proxy's
+# /healthz is intentionally unauthenticated and also proxies picoclaw's own
+# /health, so one check covers both.
 # ------------------------------------------------------------------------------
 
 [api.services]
@@ -120,7 +130,7 @@ target = "stdout"
 [[picoclaw-alpha]]
 host = "picoclaw-alpha-proxy:8787"
 protocol = "http"
-healthCheckPath = "/v1/models"
+healthCheckPath = "/healthz"
 
 [[picoclaw-alpha.secret]]
 name = "picoclaw-alpha-authorization-header"
@@ -143,7 +153,7 @@ methods = ["ALL"]
 [[picoclaw-beta]]
 host = "picoclaw-beta-proxy:8787"
 protocol = "http"
-healthCheckPath = "/v1/models"
+healthCheckPath = "/healthz"
 
 [[picoclaw-beta.secret]]
 name = "picoclaw-beta-authorization-header"


### PR DESCRIPTION
## Summary
- Root cause: mycelium's health-check dispatcher issues a plain, unauthenticated GET (`services_health_dispatcher/check_single_host_health.rs`). Pointing `healthCheckPath` at `/v1/models` (gated by `PROXY_API_KEY`) made every check return 401, which the dispatcher doesn't record as a clean unhealthy/unavailable status — it just falls through all retries and surfaces as `Error on check host health ... Unable to perform the health check.`
- Bumps the `picoclaw-openai-proxy` submodule to sgelias/picoclaw-openai-proxy#1, which adds an unauthenticated `GET /healthz` that also checks picoclaw's own `/health`.
- Updates `mycelium/config.standalone.toml`'s `healthCheckPath` (both services) from `/v1/models` to `/healthz`.
- Adds a Docker Compose healthcheck on both proxy services using `/healthz`, and makes `mycelium-gateway` depend on them with `condition: service_healthy` instead of a plain `depends_on`.

## Test plan
- [x] Rebuilt and restarted the full stack; `mycelium-gateway` logs no longer show `check_single_host_health` / "Unable to perform the health check" errors
- [x] `docker exec <proxy> wget -qO- http://127.0.0.1:8787/healthz` → `{"proxy":"ok","picoclaw":"ok","picoclaw_status_code":200,...}`
- [x] `curl http://localhost:8080/picoclaw-alpha/v1/models` through the gateway still returns 200 (routing/auth unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)