### PR TITLE
Switch picoclaw routes to protected, verified per-account identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,11 +99,15 @@ already has it:
   request that somehow reached the internal network directly is turned away.
 - **Security groups, built in.** Mycelium routes can be `public`,
   `authenticated`, `protected`, or `protectedByRoles` (with per-role
-  read/write permissions). This project's routes are `public` today (the
-  simplest case), but the exact same gateway config format is how you'd
-  layer real per-user, per-role access control on top later — **without
-  ever touching PicoClaw itself.** That's the RBAC PicoClaw doesn't have,
-  living in the layer that's supposed to have it.
+  read/write permissions). This project's routes are `protected`: Mycelium
+  authenticates the caller itself and injects their verified account
+  profile as an `x-mycelium-profile` header — the proxy decodes it with
+  [`@lepistabioinformatics/mycelium-sdk`](https://www.npmjs.com/package/@lepistabioinformatics/mycelium-sdk)
+  and derives the PicoClaw session key from the caller's real account id,
+  never from a client-declared field. A caller can no longer just put
+  `"user": "someone-else"` in the request body and read someone else's
+  conversation — **without ever touching PicoClaw itself.** That's the RBAC
+  PicoClaw doesn't have, living in the layer that's supposed to have it.
 - **One place to look, one place to lock down.** Health checks, routing,
   authentication, and rate limiting for *every* PicoClaw instance live in
   one config file and one container, instead of being reinvented per
@@ -173,21 +177,29 @@ proxy's own `PROXY_API_KEY` check expects the exact same value.
 docker compose up -d
 ```
 
-**7. Talk to it — through the gateway, on the one port that's published:**
+**7. Get a Mycelium account and a bearer token.** The routes are `protected`,
+so an anonymous `curl` won't get past the gateway anymore — you need a real
+Mycelium account and its issued token. See Mycelium's own
+[authentication flows guide](https://github.com/LepistaBioinformatics/mycelium/blob/main/modules/mycelium-api-gateway/docs/book/src/11-authentication-flows.md)
+for how to register and log in against this same `mycelium-gateway`.
+
+**8. Talk to it — through the gateway, on the one port that's published:**
 
 ```bash
 curl http://localhost:8080/picoclaw-alpha/v1/chat/completions \
   -H "Content-Type: application/json" \
+  -H "Authorization: Bearer <your-mycelium-token>" \
   -d '{
     "model": "picoclaw",
-    "user": "alice",
     "session_id": "conversa-1",
     "messages": [{"role": "user", "content": "hi"}]
   }'
 ```
 
-Swap `picoclaw-alpha` for `picoclaw-beta` to reach the second instance —
-same gateway, same port, completely separate agent underneath.
+There's no `"user"` field anymore — Mycelium resolves who you are from the
+token and injects it; the proxy trusts that, not anything in the body. Swap
+`picoclaw-alpha` for `picoclaw-beta` to reach the second instance — same
+gateway, same port, completely separate agent underneath.
 
 ## What's what in this repo
 
@@ -209,9 +221,10 @@ before you expose it beyond your own machine:
 - TLS is disabled between the gateway and its downstream services (they
   all sit on a private Docker network) — terminate TLS at the edge if
   `mycelium-gateway`'s port ever faces the internet.
-- Every route here uses the `public` security group for simplicity. If you
-  need real per-user access control, that's exactly where Mycelium's
-  `authenticated` / `protected` / `protectedByRoles` groups come in.
+- Routes here use `protected` (verified account identity, no role check).
+  If you need to restrict *which* accounts can reach `picoclaw-alpha` vs
+  `picoclaw-beta` specifically, that's exactly where Mycelium's
+  `protectedByRoles` group comes in.
 - Rotate the bearer tokens in `.env` and `.security.yml` before sharing this
   stack with anyone else, and never commit real values (both are already
   gitignored).

--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -104,11 +104,15 @@ tem:
   perdida que de alguma forma chegasse direto na rede interna seria barrada.
 - **Grupos de segurança, nativos.** Rotas no Mycelium podem ser `public`,
   `authenticated`, `protected` ou `protectedByRoles` (com permissões de
-  leitura/escrita por papel). As rotas deste projeto são `public` hoje (o
-  caso mais simples), mas o mesmo formato de configuração do gateway é
-  exatamente como você camadaria controle de acesso real por usuário/papel
-  depois — **sem nunca precisar tocar no PicoClaw.** É o RBAC que o
-  PicoClaw não tem, vivendo na camada que deveria ter.
+  leitura/escrita por papel). As rotas deste projeto são `protected`: o
+  Mycelium autentica o chamador e injeta o profile verificado da conta num
+  header `x-mycelium-profile` — o proxy decodifica isso com o
+  [`@lepistabioinformatics/mycelium-sdk`](https://www.npmjs.com/package/@lepistabioinformatics/mycelium-sdk)
+  e deriva a chave de sessão do PicoClaw a partir do id de conta real do
+  chamador, nunca de um campo declarado pelo cliente. Ninguém mais consegue
+  simplesmente colocar `"user": "outra-pessoa"` no corpo da requisição e ler
+  a conversa de outra pessoa — **sem nunca precisar tocar no PicoClaw.** É o
+  RBAC que o PicoClaw não tem, vivendo na camada que deveria ter.
 - **Um lugar só pra olhar, um lugar só pra travar.** Health checks,
   roteamento, autenticação e rate limiting de *todas* as instâncias do
   PicoClaw vivem em um arquivo de config e um container só, em vez de
@@ -179,19 +183,28 @@ própria checagem `PROXY_API_KEY` do proxy espera exatamente o mesmo valor.
 docker compose up -d
 ```
 
-**7. Converse com ele — através do gateway, na única porta publicada:**
+**7. Consiga uma conta no Mycelium e um bearer token.** As rotas são
+`protected`, então um `curl` anônimo não passa mais pelo gateway — você
+precisa de uma conta real no Mycelium e do token emitido por ela. Veja o
+[guia de fluxos de autenticação](https://github.com/LepistaBioinformatics/mycelium/blob/main/modules/mycelium-api-gateway/docs/book/src/11-authentication-flows.md)
+do próprio Mycelium pra saber como se registrar e logar contra esse mesmo
+`mycelium-gateway`.
+
+**8. Converse com ele — através do gateway, na única porta publicada:**
 
 ```bash
 curl http://localhost:8080/picoclaw-alpha/v1/chat/completions \
   -H "Content-Type: application/json" \
+  -H "Authorization: Bearer <seu-token-mycelium>" \
   -d '{
     "model": "picoclaw",
-    "user": "alice",
     "session_id": "conversa-1",
     "messages": [{"role": "user", "content": "oi"}]
   }'
 ```
 
+Não tem mais campo `"user"` — o Mycelium resolve quem você é a partir do
+token e injeta isso; o proxy confia nesse dado, não em nada do corpo.
 Troque `picoclaw-alpha` por `picoclaw-beta` pra alcançar a segunda
 instância — mesmo gateway, mesma porta, agente completamente separado por
 baixo.
@@ -217,10 +230,10 @@ máquina:
 - TLS está desabilitado entre o gateway e os serviços downstream (todos
   vivem numa rede Docker privada) — termine TLS na borda se a porta do
   `mycelium-gateway` algum dia encarar a internet.
-- Toda rota aqui usa o grupo de segurança `public`, pela simplicidade. Se
-  você precisa de controle de acesso real por usuário, é exatamente aí que
-  entram os grupos `authenticated` / `protected` / `protectedByRoles` do
-  Mycelium.
+- As rotas aqui usam `protected` (identidade de conta verificada, sem
+  checagem de papel). Se você precisa restringir *quais* contas alcançam
+  `picoclaw-alpha` vs `picoclaw-beta` especificamente, é exatamente aí que
+  entra o grupo `protectedByRoles` do Mycelium.
 - Rotacione os bearer tokens em `.env` e `.security.yml` antes de
   compartilhar essa stack com alguém, e nunca commite valores reais (os
   dois já estão no gitignore).

--- a/mycelium/config.standalone.toml
+++ b/mycelium/config.standalone.toml
@@ -123,6 +123,17 @@ target = "stdout"
 # neither a response nor an error recorded). picoclaw-openai-proxy's
 # /healthz is intentionally unauthenticated and also proxies picoclaw's own
 # /health, so one check covers both.
+#
+# `group = "protected"` (not "public"): mycelium resolves the caller's full
+# profile from their auth token and injects it as x-mycelium-profile only
+# for "protected"/"protectedByRoles" routes (ports/api/src/router/
+# check_security_group.rs -- "authenticated" only injects an email, not the
+# full profile). picoclaw-openai-proxy decodes that header
+# (@lepistabioinformatics/mycelium-sdk) and derives the picoclaw session key
+# from the caller's verified accId -- never from a client-declared "user"
+# field -- so a caller can no longer just declare "I'm someone else" in the
+# request body. See the "public" era's session files under data/*/workspace/
+# sessions/ for what that looked like before this change.
 # ------------------------------------------------------------------------------
 
 [api.services]
@@ -137,14 +148,14 @@ name = "picoclaw-alpha-authorization-header"
 authorizationHeader = { headerName = "Authorization", prefix = "Bearer", token = { env = "MYC_PICOCLAW_ALPHA_TOKEN" } }
 
 [[picoclaw-alpha.path]]
-group = "public"
+group = "protected"
 path = "/v1/chat/completions"
 secretName = "picoclaw-alpha-authorization-header"
 acceptInsecureRouting = true
 methods = ["ALL"]
 
 [[picoclaw-alpha.path]]
-group = "public"
+group = "protected"
 path = "/v1/models"
 secretName = "picoclaw-alpha-authorization-header"
 acceptInsecureRouting = true
@@ -160,14 +171,14 @@ name = "picoclaw-beta-authorization-header"
 authorizationHeader = { headerName = "Authorization", prefix = "Bearer", token = { env = "MYC_PICOCLAW_BETA_TOKEN" } }
 
 [[picoclaw-beta.path]]
-group = "public"
+group = "protected"
 path = "/v1/chat/completions"
 secretName = "picoclaw-beta-authorization-header"
 acceptInsecureRouting = true
 methods = ["ALL"]
 
 [[picoclaw-beta.path]]
-group = "public"
+group = "protected"
 path = "/v1/models"
 secretName = "picoclaw-beta-authorization-header"
 acceptInsecureRouting = true


### PR DESCRIPTION
## Summary
- Switches both `picoclaw-alpha`/`picoclaw-beta` routes' `group` from `public` to `protected` in `mycelium/config.standalone.toml`. Mycelium now authenticates the caller and injects their verified profile (`x-mycelium-profile`) instead of letting any anonymous request through.
- Bumps the `picoclaw-openai-proxy` submodule to sgelias/picoclaw-openai-proxy#2, which decodes that header (`@lepistabioinformatics/mycelium-sdk`) and derives the picoclaw session key from the caller's real `accId` -- closing the impersonation gap where any client could just declare `"user": "someone-else"` in the body.
- Updates both `README.md` and `README.pt-br.md`: the getting-started walkthrough now needs a real Mycelium account/bearer token (linked to Mycelium's own auth flows doc), and the example request no longer sends a `"user"` field.

## Test plan
- [x] Verified end-to-end against the real running stack (see linked proxy PR) with a manually-crafted `x-mycelium-profile` header -- request succeeds and the resulting picoclaw session file's hash matches `sha256(accId::session_id)`
- [x] Both READMEs checked for parity after the edit

Depends on #1 (this PR's base branch, `/healthz`) and sgelias/picoclaw-openai-proxy#2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)