### PR TITLE
feat(canvas-timeline-view): spec + webapp submodule bump

### DIFF
--- a/.specs/features/canvas-timeline-view/context.md
+++ b/.specs/features/canvas-timeline-view/context.md
@@ -1,0 +1,54 @@
+# canvas-timeline-view — Context (user decisions)
+
+Gray areas resolved with the user during Specify, after a **feel-first
+standalone prototype** (three visual metaphors) was explored. Prototype:
+`canvas-mode.html` (Artifact) — Deck / Tree(by-metric) / Timeline, pixel-art
+grid background, golden-angle dots reused from the tree.
+
+## Decisions
+
+- **DEC-CANV-01 — Metaphor: Timeline.** Of the three explored (Deck of newest-left
+  columns, Tree branching by metric, left→right Timeline), the user picked the
+  **Timeline** as "o mais amigável". Deck and Tree are *not* built; the Timeline
+  is the sole Canvas view. Time flows left→right (oldest left, newest right).
+
+- **DEC-CANV-02 — Activation: workspace-level toggle.** A `Traditional | Canvas`
+  control at the workspace level (not a third value of the in-sidebar
+  `List | Tree` toggle). Choosing Canvas **replaces both the history sidebar and
+  the chat view** with a full-width canvas. Persisted in the URL fragment as
+  `view=canvas` so a reload / shared link keeps it. The user can return to the
+  traditional chat at any time.
+
+- **DEC-CANV-03 — Data: message `created_at`, capped by time window.** The
+  timeline axis is driven by per-message `created_at` (same source the tree
+  uses), fetched via the existing `getHistory` and collapsed into visits/bursts.
+  Rendering is bounded by a visible **time window** with right-pagination, so a
+  workspace with many conversations/messages stays light.
+
+- **DEC-CANV-04 — Content: preview (last N), transcript on demand.** Each lane
+  shows a light preview (title + last user/agent exchange) on select; the full
+  transcript is not rendered inline. "Full transcript" hands off to the
+  traditional chat opened at that conversation (`setFragmentSid`), and "Solo"
+  isolates a single lane within the timeline.
+
+- **DEC-CANV-05 — Reuse the tree's model + colors.** Burst aggregation and
+  `laneColorFor` (tag color when set, else golden-angle hash) come from
+  `conversation-tree.tsx`; the shared logic is extracted so the timeline and the
+  tree stay identical in "pontinhos" and identity color. The layout is
+  re-derived at 90° (horizontal), not shared.
+
+- **DEC-CANV-06 — "Evolution" affordance: Agent pulse.** An aggregate
+  message-volume-over-time strip sits above the lanes (the "faixa/tree acima"
+  from the brief), conveying the agent getting busier over time — the
+  "inteligência evoluindo" north star. Lane lifespan lines animate drawing
+  left→right on load (reduced-motion aware).
+
+- **DEC-CANV-07 — Background: pixel-art quadriculado.** A fine graph-paper grid
+  (fine cell + stronger every-Nth) via CSS, theme-aware, behind the canvas.
+
+## Pipeline depth
+
+Large — `spec.md` (traceable IDs) → `design.md` → `tasks.md` → execute. Chosen
+by the user; multi-component (new view, fragment key, perf/pagination, toggle).
+Webapp-only: `created_at` is already surfaced end-to-end by
+[[conversation-tree-view]], so **no proxy/Go change is required**.

--- a/.specs/features/canvas-timeline-view/design.md
+++ b/.specs/features/canvas-timeline-view/design.md
@@ -1,0 +1,148 @@
+# canvas-timeline-view — Design & Contract
+
+Decisions (see [[context.md]]): **DEC-CANV-01** timeline only. **DEC-CANV-02**
+workspace-level `view` toggle, replaces sidebar+chat. **DEC-CANV-03** data from
+`created_at` via `getHistory`, capped window. **DEC-CANV-04** preview + handoff.
+**DEC-CANV-05** reuse tree burst model + `laneColorFor`. **DEC-CANV-06** agent
+pulse. **DEC-CANV-07** pixel-art grid.
+
+Webapp-only. **No proxy/BFF/Go change** — `created_at` is already surfaced by
+[[conversation-tree-view]].
+
+## Architecture overview
+
+```
+chat-shell.tsx  ─ reads fragment.view ("chat" | "canvas")
+  ├─ NavSidebar                         (always)
+  ├─ view==="chat":  HistorySidebar + <main> ChatView   (unchanged)
+  └─ view==="canvas": <main> CanvasTimeline (full width, no history sidebar)
+```
+
+New/changed files:
+- `app/chat/fragment.ts` — add `view?: string`; `setView("chat" | "canvas")`.
+- `app/chat/conversation-bursts.ts` *(new)* — extract the shared model from
+  `conversation-tree.tsx`: `TreeEvent`/`Burst` types, `buildEvents`,
+  `aggregateBursts`, and `laneColorFor`/`laneColor`/`tagColorOf`/`withAlpha`.
+- `app/chat/conversation-tree.tsx` — import the extracted helpers (no behavior
+  change; keeps tree & canvas identical by construction — CANV-04).
+- `app/chat/canvas-timeline.tsx` *(new)* — the Canvas view (header toggle,
+  pulse, timeline SVG, preview, solo, pagination, pixel-art bg).
+- `app/chat/chat-shell.tsx` — branch on `view`.
+- `app/chat/chat-view.tsx` — add the `Traditional | Canvas` control to its header.
+
+## Fragment: the `view` key (CANV-01)
+
+- Extend `FragmentState` with `view?: string`; `readFragment` reads `view`.
+- `setView(view)`: `params.set("view","canvas")` for canvas, else delete (default
+  clean), then assign `location.hash` — same native-`hashchange` mechanism as
+  `setHistoryView`/`setFragmentSid`; preserves `t/s/r/sid/hv`, drops transient
+  `msg`.
+- `chat-shell.tsx`: `const canvas = fragment?.view === "canvas" && !!workspace`.
+  When `canvas`, do **not** render the HistorySidebar `ResizablePane`; render
+  `<CanvasTimeline workspace={workspace} />` in `<main>` instead of `<ChatView>`.
+  Mobile: canvas may fall back to chat (out of scope for polish).
+
+## Shared model extraction (CANV-04, DEC-CANV-05)
+
+Move from `conversation-tree.tsx` into `conversation-bursts.ts`, unchanged:
+- `laneColor(id, alpha?)`, `tagColorOf(conv)`, `withAlpha(hex, alpha)`,
+  `laneColorFor(conv, id, alpha?)`.
+- `interface TreeEvent`, `interface Burst`.
+- `buildEvents(lists: {c, messages}[]): TreeEvent[]` — the flatten + `created_at`
+  parse + `updatedAt+seq` fallback + descending sort (NFR-3).
+- `aggregateBursts(events): Burst[]` — the consecutive-run collapse.
+
+`conversation-tree.tsx` imports these; its render/FLIP/lane-packing stay in place.
+This guarantees the canvas's dots/colors equal the tree's (CANV-04) rather than
+re-implementing them.
+
+## CanvasTimeline component (`canvas-timeline.tsx`)
+
+### Data (CANV-10, NFR-2, NFR-3)
+- `conversations` from `listConversations(workspace)`; subscribe to
+  `onConversationsUpdated` (same as sidebar/tree).
+- On mount / conversations-change: `Promise.all(conversations.map(c =>
+  getHistory(workspace, c, c.id === active)))` (reuses the cache; force only the
+  active one). Build events with `buildEvents`, then `aggregateBursts`.
+- Spinner only on workspace change (mirror the tree's `prevWsKey` guard) so
+  refetches don't flash.
+- **Fetch vs. render (NFR-2):** fetch is O(all conversations) through the cached
+  `getHistory` (same as the tree; ships fine at "dozens") — the cap below bounds
+  *drawing*, not the network. Do NOT lazy-fetch per window.
+- **Stable-lane cap (NFR-2):** one lane per conversation, sorted by `firstT`,
+  drawn on a stage as wide as the time range. Lanes **stay put**; paging is
+  horizontal scroll (CANV-08), not a window filter. Bound total lanes with a
+  `MAX_LANES` cap (same spirit as the tree's `MAX_LANE_COLUMNS`) and handle
+  overflow gracefully (e.g. collapse the least-active beyond the cap) — lanes do
+  not pop in/out as the user scrolls.
+
+### Layout (CANV-03)
+- Horizontal SVG stage, `min-width: max-content`, inside a scroll container.
+- `xOf(t) = padL + ((t - tMin) / (tMax - tMin)) * innerW`.
+- One lane per conversation, ordered by `firstT` asc; laneY = `padTop + i*laneH`.
+- Per lane: a lifespan `<line>` (firstT→lastT) + a `<circle>` per burst at
+  `xOf(burst.ts)`, `r = base + min(count,5)*k`, recent bursts scaled up slightly
+  (CANV-04). Leaf `<text>` label (alias||title) at the lane tip.
+- Axis: 4–5 ticks across `innerW` with `fmtDate` labels; faint dashed guides.
+- Colors via `laneColorFor(convById.get(id), id)`.
+
+### Agent pulse (CANV-05)
+- Bucket every burst's `count` into `NBUCKETS` over `[tMin,tMax]`; area+line path
+  (`<linearGradient>` accent fill), sharing `xOf`. A small strip above the lanes.
+
+### Interaction (CANV-06, CANV-07)
+- Hover a lane group → add `dimmed` to the others (CSS opacity), same idea as the
+  tree's focus/dim.
+- Click a lane → inline **preview** panel (title, `total msgs · bursts · last
+  Nd ago`, last 2 bursts' user/agent lines). Actions:
+  - **Solo**: `soloId` state → render only that lane; a "show all" clears it.
+  - **Full transcript**: `setFragmentSid(id)` + `setView("chat")` → hands off to
+    the traditional chat at that conversation.
+
+### Header + time band + pagination (CANV-08)
+- Header bar (mirrors chat-view's header height/border): `agent {r}` + the
+  `Traditional | Canvas` segmented control (leaving Canvas here).
+- Time band: visible range text + `‹ ›` buttons that `scrollBy`/shift the window;
+  horizontal scroll enabled.
+
+### Pixel-art background (CANV-09)
+- CSS `repeating-linear-gradient` fine grid + stronger every-Nth cell on the
+  stage container, using a brand-tinted low-alpha token so it reads in both
+  themes (see the prototype's `--grid`/`--grid-strong`). Not an external image.
+
+### Motion / a11y (NFR-4)
+- Lifespan-line + pulse draw-in via `stroke-dasharray/offset` animation, gated on
+  `@media (prefers-reduced-motion: no-preference)`; burst dots fade/scale in.
+- Lanes are focusable buttons with visible focus; toggle is a real segmented
+  control with `aria-pressed`.
+
+## Toggle placement (CANV-01)
+- **Enter Canvas** from `chat-view.tsx` header (add a `Traditional | Canvas`
+  segmented control next to the secret/files icons — `cva` styled like the
+  sidebar's `viewToggle`).
+- **Leave Canvas** from `canvas-timeline.tsx` header (same control).
+- Both call `setView(...)`. Keeping the control in each view's own header matches
+  how `List | Tree` is owned by the sidebar.
+
+## States / edges
+- Empty workspace → empty state (`"No conversations yet."`).
+- Loading → spinner (no flash on refetch).
+- Missing/unparseable `created_at` → `updatedAt` fallback ordering (NFR-3).
+- `prefers-reduced-motion` → animations off.
+
+## Contract summary
+- **Fragment:** adds optional `view` (`"canvas"`; absent = traditional). No other
+  schema change. Shareable/reloadable.
+- **No network/proxy/BFF contract change.** Reuses `GET /api/chat/[instance]/
+  history` exactly as the tree does.
+
+## Test / gate
+- Webapp: `yarn build` (Next type-check) clean; `yarn test` (vitest) for any
+  extracted-helper unit tests.
+- Unit: `conversation-bursts.ts` — `buildEvents` ordering + `updatedAt` fallback;
+  `aggregateBursts` run-collapse (move/extend coverage from existing tree logic).
+- Manual: log in via magic-link; create an "A → B → A → C" pattern; toggle
+  `Traditional → Canvas`; verify axis/lanes/dots/pulse, colors match the tree,
+  hover-dim, click-preview, Solo, Full-transcript handoff, `‹ ›`/scroll paging,
+  reload persistence (`view=canvas`), return to Traditional intact, empty state,
+  and reduced-motion.

--- a/.specs/features/canvas-timeline-view/spec.md
+++ b/.specs/features/canvas-timeline-view/spec.md
@@ -1,0 +1,203 @@
+# canvas-timeline-view — Specification
+
+## Summary
+
+An alternative, graphics-forward presentation of a workspace's conversations: a
+**Canvas** mode whose sole view is a left→right **Timeline**. Instead of reading
+one chat top-down, the user sees every conversation as a horizontal lane on a
+shared time axis, with activity **bursts** as dots (the same "pontinhos" and
+per-conversation colors as the tree), an aggregate **agent-pulse** strip above,
+and a pixel-art grid backdrop. The goal is to convey the agent's intelligence
+**evolving over time**. Canvas is a workspace-level toggle that replaces the
+history sidebar and the chat view; the user can return to the traditional chat
+at any time. Pure visualization — no new relationships are stored.
+
+## Grounding (verified in source, do not re-derive)
+
+- Per-message `created_at` is **already surfaced end-to-end** (proxy `Message`,
+  BFF `/api/chat/[instance]/history`) by [[conversation-tree-view]]; `getHistory`
+  (`app/chat/history-cache.ts`) returns `HistoryMessage { role, content,
+  created_at? }` and caches per conversation id (invalidated on `updatedAt`).
+  ⇒ **No proxy/Go change is needed here.**
+- The burst model already exists in `app/chat/conversation-tree.tsx`: flatten
+  histories to time-sorted events, collapse consecutive same-conversation runs
+  into visits/bursts; lane color via `laneColorFor` (tag color when set, else a
+  golden-angle hash of the id). This is currently private to that file.
+- Active conversation + workspace + view state live **only in the URL fragment**
+  (`app/chat/fragment.ts`): `t/s/r/sid`, transient `msg` scroll anchor, and
+  `hv` (history sidebar `list|tree`). `setFragmentSid(id, msg?)` navigates and
+  can land the chat on a specific message.
+- Layout shell (`app/chat/chat-shell.tsx`) mounts NavSidebar + (HistorySidebar +
+  `<main>`) only when the fragment carries a workspace; sidebars are
+  resizable/collapsible (persisted `"chat-sidebars"`).
+- The traditional chat view (`app/chat/chat-view.tsx`) owns its own header bar
+  (`agent {r}` + secret/files icons).
+- `listConversations(workspace)` + `onConversationsUpdated` drive the live list;
+  the sidebar already does an N-fetch of histories for content search
+  (`history-sidebar.tsx`), so an N-fetch pattern is established and cached.
+
+## Functional requirements
+
+- **CANV-01** A workspace-level `Traditional | Canvas` toggle. Default is
+  `Traditional` (unchanged behavior). The choice persists in the URL fragment
+  (`view=canvas`), so reload / shared link keeps it, and is reachable from both
+  modes (enter from the chat header; leave from the canvas header).
+- **CANV-02** In Canvas mode the history sidebar **and** the chat view are
+  replaced by a single full-width canvas in `<main>`; NavSidebar (workspace
+  picker) stays. Switching back restores the sidebar + chat exactly as before.
+- **CANV-03** The canvas renders a left→right **timeline**: a horizontal time
+  axis (oldest left, newest right) with tick labels, and **one lane per
+  conversation** (ordered by first activity). Each lane draws a lifespan line
+  from its first to last burst and a **dot per burst** positioned at the burst's
+  time; dot size scales with the burst's message count.
+- **CANV-04** Bursts and per-conversation colors match the tree exactly — reuse
+  the burst aggregation and `laneColorFor` (tag color when set, else golden-angle
+  hash). Recent bursts read slightly larger/brighter (recency emphasis).
+- **CANV-05** An **agent-pulse** strip above the lanes shows aggregate message
+  volume bucketed over the same time range (an area chart), conveying activity
+  accumulating over time. It shares the timeline's x-mapping.
+- **CANV-06** Clicking a lane opens an inline **preview** (title, message count,
+  last N messages — no full transcript inline) with two actions: **Solo**
+  (isolate that single lane in the timeline) and **Full transcript** (leave
+  Canvas → traditional chat opened at that conversation via `setFragmentSid`,
+  setting `view` back to traditional).
+- **CANV-07** Hovering a lane isolates it (others dim). "Solo" persists a single
+  lane until cleared; an explicit "show all" clears it.
+- **CANV-08** A **time band** header shows the range and offers `‹ ›` buttons
+  plus horizontal scroll to page through time. Paging = horizontal scroll of a
+  stable stage (matching the approved prototype); lanes do **not** appear/
+  disappear as you scroll — one stable lane per conversation stays put (see
+  NFR-2).
+- **CANV-09** A **pixel-art quadriculado** background (fine grid + stronger
+  every-Nth cell), theme-aware, sits behind the canvas.
+- **CANV-10** Data is fetched only when Canvas is active (reuse the cached
+  `getHistory` N-fetch) and refreshes on `chat-conversations-updated` (so an
+  update from elsewhere reflects); entering Canvas triggers the fetch, Traditional
+  mode adds no cost. Note: Canvas is **read-only** (no composer) — nothing
+  generates new activity while it is open, so the live-refresh is a
+  correctness/consistency guarantee, not a "live dashboard" claim.
+
+## Non-functional requirements
+
+- **NFR-1** Additive / backward-compatible: the traditional chat, the
+  `List | Tree` sidebar toggle, and the fragment schema are unchanged except for
+  an added optional `view` key. No proxy/Go/BFF change.
+- **NFR-2** Bounded render, **stable lanes**: there is one lane per conversation
+  (sorted by first activity), and lanes stay put — paging is horizontal scroll
+  across the time axis (the approved prototype's model), NOT a window filter that
+  makes lanes pop in/out. Render is bounded by a total `MAX_LANES` cap with
+  graceful overflow (à la the tree's `MAX_LANE_COLUMNS`), and time-scroll only
+  draws the stable stage. **Fetch vs. render:** history fetch is O(all
+  conversations) via the cached `getHistory` N-fetch (same as the tree, ships at
+  "dozens"); the cap bounds what is *drawn*, not the network. Must stay
+  responsive with dozens of conversations.
+- **NFR-3** Robust ordering: `created_at` is parsed to a comparable instant
+  before sorting (never raw-string compared); missing/unparseable timestamps fall
+  back to `updatedAt` ordering (as the tree does) and never crash the render.
+- **NFR-4** Motion is `prefers-reduced-motion`-aware (lifespan-draw + pulse-draw
+  disabled when reduced); keyboard focus visible; theme parity (light/dark).
+
+## Out of scope
+
+| Feature | Reason |
+| --- | --- |
+| Deck and Tree-by-metric canvas metaphors | Explored in the prototype; user chose Timeline only (DEC-CANV-01). |
+| Full transcript rendered inside a lane/card | Preview only; full read hands off to the traditional chat (DEC-CANV-04). |
+| Explicit forking / `parent_id` ancestry | Visualization only, same as [[conversation-tree-view]]. |
+| Rename / delete / alias-tag editing inside Canvas | Stay in List mode (first cut). |
+| Any proxy/picoclaw/transcript-write change | `created_at` already surfaced; webapp-only. |
+| Mobile-optimized canvas | First cut targets desktop; mobile keeps traditional (canvas may be read-only/degraded). |
+
+## User Stories
+
+### P1: See conversations evolve on a timeline ⭐ MVP
+
+**User Story**: As a user of a workspace, I want to switch to a Canvas timeline
+that lays my conversations out over time, so I get a sense of how the agent's
+work has evolved rather than reading one chat at a time.
+
+**Why P1**: This is the whole feature — the alternative visualization and the
+"intelligence evolving" impression.
+
+**Acceptance Criteria**:
+1. WHEN I toggle `Canvas` in a workspace THEN the system SHALL replace the
+   history sidebar + chat view with a full-width timeline and set `view=canvas`
+   in the URL.
+2. WHEN the timeline renders THEN the system SHALL show a left→right time axis,
+   one lane per conversation with a lifespan line and burst dots colored per
+   conversation (same colors as the tree), and an agent-pulse strip above.
+3. WHEN I reload or share the URL THEN the system SHALL restore Canvas mode.
+4. WHEN I toggle `Traditional` THEN the system SHALL restore the sidebar + chat
+   unchanged.
+5. WHEN a conversation has no/unparseable `created_at` THEN the system SHALL
+   order it by `updatedAt` and still render (no crash).
+
+**Independent Test**: Log in, open a workspace with a few conversations, toggle
+Canvas → see lanes/dots/pulse; reload → still Canvas; toggle back → chat intact.
+
+### P2: Preview and drill into a single conversation
+
+**User Story**: As a user, I want to click a lane to preview it and optionally
+isolate or open it, so the timeline is a way in, not just a picture.
+
+**Acceptance Criteria**:
+1. WHEN I click a lane THEN the system SHALL show an inline preview (title, count,
+   last N messages) with Solo and Full-transcript actions.
+2. WHEN I choose Solo THEN the system SHALL show only that lane until I clear it.
+3. WHEN I choose Full transcript THEN the system SHALL leave Canvas and open the
+   traditional chat at that conversation (`setFragmentSid`).
+
+**Independent Test**: Click a lane → preview; Solo → one lane; Full transcript →
+traditional chat on that conversation.
+
+### P3: Page through time without overloading
+
+**User Story**: As a user with many conversations, I want the canvas to stay
+responsive, paging through time rather than rendering everything.
+
+**Acceptance Criteria**:
+1. WHEN a workspace has more activity than the visible window THEN the system
+   SHALL bound what is rendered and reveal more via `‹ ›`/scroll.
+2. WHEN I page/scroll THEN the time band SHALL reflect the visible range.
+
+**Independent Test**: With dozens of conversations, the canvas stays smooth and
+paging reveals older activity.
+
+## Edge Cases
+
+- WHEN a workspace has zero conversations THEN the canvas SHALL show an empty
+  state (reuse the `"No conversations yet."` pattern).
+- WHEN a conversation has one burst THEN its lane SHALL render a single dot (a
+  minimal lifespan line).
+- WHEN histories are still loading THEN the canvas SHALL show a spinner without a
+  layout flash on refetch (mirror the tree's spinner-only-on-workspace-change).
+- WHEN `prefers-reduced-motion` is set THEN draw/pulse animations SHALL be off.
+- WHEN a shared `view=canvas` URL is opened on mobile THEN the system SHALL
+  ignore the `view` key and render the Traditional chat (canvas is desktop-only
+  first cut) — never a broken/garbage canvas.
+
+## Requirement Traceability
+
+| Requirement ID | Story | Phase | Status |
+| --- | --- | --- | --- |
+| CANV-01 | P1 | T03/T08 | Implementing (runtime unverified) |
+| CANV-02 | P1 | T04 | Implementing (runtime unverified) |
+| CANV-03 | P1 | T05 | Implementing (runtime unverified) |
+| CANV-04 | P1 | T01/T05 | Implementing (runtime unverified) |
+| CANV-05 | P1 | T06 | Implementing (runtime unverified) |
+| CANV-06 | P2 | T07 | Implementing (runtime unverified) |
+| CANV-07 | P2 | T07 | Implementing (runtime unverified) |
+| CANV-08 | P3 | T08 | Implementing (runtime unverified) |
+| CANV-09 | P1 | T09 | Implementing (runtime unverified) |
+| CANV-10 | P1/P3 | T04 | Implementing (runtime unverified) |
+
+**ID format:** `CANV-NN`. **Status:** Pending → In Design → In Tasks →
+Implementing → Verified.
+
+## Success Criteria
+
+- [ ] A user can enter Canvas, read the timeline, and return to chat in one click.
+- [ ] Burst dots and colors are visually identical to the tree view.
+- [ ] Canvas mode adds zero fetch/render cost while in Traditional mode.
+- [ ] The canvas stays responsive with dozens of conversations (bounded window).
+- [ ] Light/dark parity and reduced-motion honored.

--- a/.specs/features/canvas-timeline-view/tasks.md
+++ b/.specs/features/canvas-timeline-view/tasks.md
@@ -1,0 +1,137 @@
+# canvas-timeline-view Tasks
+
+Webapp-only (`crab/crab-exoskeleton-webapp`); **no proxy/Go change** —
+`created_at` already surfaced by [[conversation-tree-view]]. Gate: `yarn build`
+(Next type-check) + `yarn test` (vitest). Runtime: log in via magic-link, create
+an "A → B → A → C" usage pattern, toggle Traditional → Canvas. `[P]` =
+parallelizable.
+
+---
+
+## T01 — extract the shared burst model — CANV-04, DEC-CANV-05
+- **What:** create `app/chat/conversation-bursts.ts` and move, unchanged, from
+  `conversation-tree.tsx`: `laneColor`, `tagColorOf`, `withAlpha`, `laneColorFor`,
+  `interface TreeEvent`, `interface Burst`, plus `buildEvents(lists)` (flatten +
+  `created_at` parse + `updatedAt+seq` fallback + desc sort) and
+  `aggregateBursts(events)` (consecutive-run collapse). Re-import them in
+  `conversation-tree.tsx` with no behavior change.
+- **Reuses:** existing logic in `conversation-tree.tsx`.
+- **Done when:** `conversation-tree.tsx` uses the extracted module; `yarn build`
+  green; **manual check** — open the tree view and confirm it renders identically
+  (no existing tree unit test to guard the extraction).
+- **Depends on:** —
+
+## T02 — burst-model unit tests — CANV-04, NFR-3 [P after T01]
+- **What:** unit-test `conversation-bursts.ts`: `buildEvents` sorts by parsed
+  instant and falls back to `updatedAt+seq` for missing/unparseable `created_at`;
+  `aggregateBursts` collapses only consecutive same-conversation runs.
+- **Done when:** `yarn test` green with the new cases.
+- **Depends on:** T01
+
+## T03 — fragment `view` key + setView — CANV-01
+- **What:** in `app/chat/fragment.ts` add `view?: string` to `FragmentState`,
+  read it in `readFragment`; add `setView(view: "chat" | "canvas")` (set
+  `view=canvas` else delete; assign `location.hash`; preserve `t/s/r/sid/hv`,
+  drop `msg`) — mirror `setHistoryView`.
+- **Done when:** `useFragment().view` reflects the hash; navigating doesn't lose
+  `hv`/`sid`; `yarn build` green.
+- **Depends on:** —
+
+## T04 — CanvasTimeline: data + shell wiring — CANV-02, CANV-10, NFR-3
+- **What:** create `app/chat/canvas-timeline.tsx` that takes `{ workspace }`,
+  loads `listConversations` + subscribes to `onConversationsUpdated`, N-fetches
+  via `getHistory` (force only active), builds events+bursts (T01), with the
+  tree's workspace-change spinner guard. Branch `chat-shell.tsx` on
+  `fragment.view === "canvas"`: skip the HistorySidebar pane, render
+  `<CanvasTimeline>` in `<main>`.
+- **Done when:** toggling `view=canvas` (via URL) shows a full-width canvas with
+  no history sidebar and a loaded burst model; Traditional path unchanged.
+- **Depends on:** T01, T03
+
+## T05 — timeline render (axis + lanes + dots) — CANV-03, CANV-04, NFR-2
+- **What:** horizontal SVG stage in `canvas-timeline.tsx`: `xOf` time-map, 4–5
+  axis ticks, one lane per conversation (asc by `firstT`) with a lifespan line +
+  a burst dot each (size by count, recency emphasis), leaf label, colors via
+  `laneColorFor`. Lanes are **stable** (one per conversation, always drawn);
+  paging = horizontal scroll of the stage, NOT a window filter. Bound total lanes
+  with a `MAX_LANES` cap + graceful overflow; fetch stays O(all) via the cache —
+  the cap bounds drawing only.
+- **Done when:** lanes/dots render time-ordered, colors match the tree, lanes
+  stay put while scrolling, and a many-conversation workspace stays responsive.
+- **Depends on:** T04
+
+## T06 — agent-pulse strip — CANV-05 [P after T05]
+- **What:** bucket burst counts over `[tMin,tMax]` into `NBUCKETS`; render an
+  area+line path (accent gradient) above the lanes sharing `xOf`.
+- **Done when:** the pulse reflects aggregate volume and aligns to the axis.
+- **Depends on:** T05
+
+## T07 — interaction: hover-dim, preview, solo, handoff — CANV-06, CANV-07
+- **What:** hover a lane → dim others; click → inline preview panel (title,
+  count/bursts/last-ago, last 2 bursts' user/agent lines) with **Solo**
+  (`soloId` → render one lane; "show all" clears) and **Full transcript**
+  (`setFragmentSid(id)` + `setView("chat")`).
+- **Done when:** preview/solo/handoff work; Full-transcript lands the traditional
+  chat on the right conversation.
+- **Depends on:** T05
+
+## T08 — header toggle + time band + pagination — CANV-01, CANV-08
+- **What:** `Traditional | Canvas` segmented control (`cva`, like the sidebar's
+  `viewToggle`) in **both** the canvas header and the `chat-view.tsx` header, both
+  calling `setView`. Time band with visible-range text + `‹ ›` paging and
+  horizontal scroll shifting the window.
+- **Done when:** entering from chat and leaving from canvas both work and persist
+  (`view=canvas` on reload); paging updates the visible range.
+- **Depends on:** T03, T05
+
+## T09 — pixel-art background + motion/a11y polish — CANV-09, NFR-4
+- **What:** theme-aware `repeating-linear-gradient` grid (fine + every-Nth) on the
+  stage; lifespan/pulse draw-in gated on `prefers-reduced-motion`; focusable lanes
+  with visible focus; light/dark parity.
+- **Done when:** grid reads in both themes, animations off under reduced-motion,
+  keyboard focus visible; `yarn build` green.
+- **Depends on:** T05, T06
+
+## T10 — empty/loading/edge states — CANV-03, edges
+- **What:** empty workspace → `"No conversations yet."`; loading spinner without
+  refetch flash; single-burst lane renders a dot; missing-`created_at` lane orders
+  by `updatedAt` without crashing.
+- **Done when:** all edge cases render gracefully.
+- **Depends on:** T05
+
+---
+
+## Verification (feature-level)
+- `yarn build` + `yarn test` green.
+- Manual runtime script (design.md Test/gate) passes end-to-end.
+
+---
+
+## Progress (2026-07-20)
+
+Implemented T01–T10 in one pass (webapp-only). Files:
+- NEW `app/chat/conversation-bursts.ts` — shared model (T01).
+- NEW `app/chat/conversation-bursts.test.ts` — 9 unit tests (T02).
+- NEW `app/chat/view-mode-toggle.tsx` — shared Chat|Canvas control (T08).
+- NEW `app/chat/canvas-timeline.tsx` — the Canvas view: data + shell wiring
+  (T04), timeline render (T05), agent pulse (T06), hover-dim/preview/solo/
+  handoff (T07), header toggle + time band + `‹ ›` paging (T08), pixel-art bg +
+  reduced-motion + focus a11y (T09), empty/loading/single-burst/fallback (T10).
+- EDIT `app/chat/conversation-tree.tsx` — imports the extracted model (T01).
+- EDIT `app/chat/fragment.ts` — `view?` key + `setView` (T03).
+- EDIT `app/chat/chat-shell.tsx` — branch on `view==="canvas"` (desktop-only;
+  mobile ignores it), hide history sidebar, render CanvasTimeline (T04).
+- EDIT `app/chat/chat-view.tsx` — `ViewModeToggle` in the header (T08).
+
+**Gate:** `npx tsc --noEmit` clean; `yarn test` 47 passed. `yarn build` could NOT
+run — `.next/` holds root-owned files from a prior docker build (EACCES on
+unlink); used `tsc --noEmit` as the type-check gate instead. `next lint` is not
+configured (interactive prompt), so it was skipped.
+
+**PENDING — manual runtime verification** (needs the running stack: magic-link
+login, create an A→B→A→C pattern, toggle Chat→Canvas): confirm axis/lanes/dots/
+pulse render, colors match the tree, hover-dim, click-preview, Solo, Full-
+transcript handoff, `‹ ›`/scroll paging, reload persistence (`view=canvas`),
+return to Chat intact, empty state, reduced-motion. Not yet done.
+
+**Not committed** (per user's global rule: never commit unless asked).

--- a/.specs/project/ROADMAP.md
+++ b/.specs/project/ROADMAP.md
@@ -128,3 +128,13 @@ Telegram / MS Teams channels.
   lane and each message is a dot, reconciling the agent's continuous per-session
   transcript with the web's recency-first list. Visualization only (no
   `parent_id`/fork). See `.specs/features/conversation-tree-view/`.
+- **canvas-timeline-view** (SPEC READY) — an alternative, graphics-forward
+  "Canvas" mode (workspace-level `Traditional | Canvas` toggle, `view=canvas` in
+  the fragment) whose sole view is a left→right timeline: one lane per
+  conversation on a shared time axis, activity bursts as dots (same colors as the
+  tree), an aggregate "agent pulse" strip above, and a pixel-art grid backdrop —
+  conveying the agent's intelligence evolving over time. Preview-on-click with
+  Solo + hand-off to the traditional chat. Webapp-only (reuses `created_at` from
+  conversation-tree-view; no proxy change). Feel-first prototype validated
+  (Timeline chosen over Deck/Tree metaphors). See
+  `.specs/features/canvas-timeline-view/`.

--- a/.specs/project/STATE.md
+++ b/.specs/project/STATE.md
@@ -157,6 +157,15 @@ invite -> `protectedByRoles` cutover) is unchanged, still not done.
 
 ---
 
+### L-ENV: `yarn build`/`next dev` blocked locally by root-owned `.next` (2026-07-20)
+The webapp's `.next/` holds files owned by `root` from a prior in-container build,
+so `yarn build` and `next dev` fail with `EACCES: unlink .next/server/...` and
+can't be removed without sudo. Use `npx tsc --noEmit` for the type-check gate and
+`yarn test` (vitest) for tests. `next lint` is also unconfigured (interactive
+prompt). Runtime/visual verification of webapp features therefore needs the full
+stack (docker-compose + magic-link) or a `.next` chown. Surfaced while
+implementing canvas-timeline-view.
+
 ### AD-007 (superseded by AD-008): Migrated mycelium-gateway to base mode (Postgres) to create the first Staff account (2026-07-13)
 
 **Decision:** Replaced `standalone` (SQLite) with `base` mode (Postgres, default `postgres-backend`


### PR DESCRIPTION
Parent-repo side of the canvas timeline + chat UX work. Stacked on `feat/admin-shared-skills`.

- Adds the Large-pipeline spec for **canvas-timeline-view** (`context.md`, `spec.md`, `design.md`, `tasks.md`) and records it in the roadmap.
- Notes the local `.next` root-owned build blocker in `STATE.md`.
- Bumps the `crab-exoskeleton-webapp` submodule to the branch carrying the implementation — see companion PR: LepistaBioinformatics/crab-exoskeleton-webapp#4.

(`crab-shell-proxy` submodule left untouched — pre-existing local change, unrelated.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)