### PR TITLE
feat: multi-harness (Hermes) — mycelium, compose, submodule bumps

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,6 +46,9 @@ MYCELIUM_GIT_REF=009c771770710ee5e42b119544bbada5953b5d56
 # random values per agent, e.g. `openssl rand -hex 32`.
 MYC_PICOCLAW_ALPHA_TOKEN=change-me-alpha
 MYC_PICOCLAW_BETA_TOKEN=change-me-beta
+# hermes-glm agent (harness: hermes). Same contract: mycelium injects it, the
+# proxy validates it against the hermes-glm agent's token.
+MYC_HERMES_GLM_TOKEN=change-me-hermes-glm
 
 # ─── Per-instance LLM API keys (picoclaw provider keys) ──────────────────────
 # Each agent in crab-shell-proxy/config.yaml references its OWN key by env-var
@@ -58,6 +61,10 @@ MYC_PICOCLAW_BETA_TOKEN=change-me-beta
 # Distinct values per instance => alpha and beta use independent keys.
 PICOCLAW_ALPHA_API_KEY=sk-your-alpha-key
 PICOCLAW_BETA_API_KEY=sk-your-beta-key
+# z.ai/GLM key for the hermes-glm agent (config.yaml model.apiKeyEnv =
+# PROXY_GLM_API_KEY). The proxy injects it into the hermes container as
+# GLM_API_KEY (model.keyEnvName) — the name hermes-agent reads for provider zai.
+PROXY_GLM_API_KEY=your-zai-glm-key
 
 # ─── mycelium-gateway staff bootstrap ────────────────────────────────────────
 # Gates the one-time web-based Staff bootstrap flow (see

--- a/.specs/features/admin-model-override/context.md
+++ b/.specs/features/admin-model-override/context.md
@@ -1,0 +1,32 @@
+# admin-model-override — Context (user decisions)
+
+## CTX-AMO-01..04
+See spec.md "Decisions": three-level override (tenant/subscription/user),
+precedence user>sub>tenant>agent-default; authority via the shared-content tier
+check; re-apply to established workspaces immediately (stop/start, no recreate);
+allowed models come from the picoclaw `model_list`.
+
+## CTX-AMO-05: Selectable models are declared per-agent in the proxy config.yaml
+The proxy realizes "the model_list the admin can pick from" as a per-agent
+**list of models in `config.yaml`**, each `{provider, name, apiKeyEnv}` — the
+operator declares which models are switchable and where each one's key lives in
+the environment. The default `agent.Model` remains the fallback.
+
+**Why:** the proxy currently knows only one model+key per agent; a switch needs
+the target model's key. Sourcing the list (and keys-by-env) from config.yaml is
+the only option that satisfies CTX-AMO-06.
+
+## CTX-AMO-06: API keys are backend-only — never transit the API (hard security rule)
+The model-override API and the webapp handle **only `{provider, name}`**. An API
+key MUST NEVER appear in any API response or reach the client. If a key hint is
+ever surfaced to an operator, it is **masked** (only first/last few characters),
+computed server-side; the raw key is never serialized past the proxy. Keys stay
+in environment variables (`apiKeyEnv`), exactly as today.
+
+## Open design points (resolved in design.md)
+- Exact override-file paths + JSON shape.
+- How `resolveModel` maps an override `{provider,name}` to a full `ModelConfig`
+  (must match an entry in the agent's configured selectable list; else fall back
+  to default + log).
+- How to re-apply a changed model to an ESTABLISHED workspace without corrupting
+  the pico token or the merged native secrets in `.security.yml`.

--- a/.specs/features/admin-model-override/design.md
+++ b/.specs/features/admin-model-override/design.md
@@ -1,0 +1,108 @@
+# admin-model-override — Design
+
+Mirrors `admin-shared-content` (tiers/authz/BFF/admin-screen) and adds a model
+override cascade. Keys stay backend-only (CTX-AMO-06).
+
+## Config (proxy `internal/config/config.go`)
+
+Extend `Agent` with a selectable model list (the default `Model` stays):
+```go
+type Agent struct {
+    // ...existing...
+    Model  *ModelConfig   // default (fallback)
+    Models []*ModelConfig // selectable allowlist (each provider/name/apiKeyEnv)
+}
+```
+On load, resolve each `Models[i].APIKey` from its `APIKeyEnv` (like `Model`).
+Validation: each entry needs provider+name; a `{provider,name}` may appear once.
+If `Models` is empty, only `Model` is selectable. Helper:
+`func (a Agent) SelectableModels() []*ModelConfig` (default + Models, deduped by
+provider/name) and `func (a Agent) FindModel(provider, name string) *ModelConfig`.
+
+## Override store (proxy)
+
+Files holding a `{ "provider": "...", "name": "..." }` JSON selection:
+- tenant: `config.TenantModelOverrideFile(root, t)` = `<root>/tenants/<t>/shared/model.json`
+- subscription: `config.SubscriptionModelOverrideFile(root, t, s)` = `<root>/tenants/<t>/subscriptions/<s>/shared/model.json`
+- user: `config.UserModelOverrideFile(root, t, s, role, u)` = `<userWorkspace>/.crab-model.json` (dotfile picoclaw ignores, beside `.crab-owner.json`)
+
+New `internal/docker/model.go`:
+```go
+type ModelSel struct { Provider, Name string }
+func (m *Manager) getModelOverride(path string) (*ModelSel, error)   // nil if absent
+func (m *Manager) setModelOverride(path string, sel ModelSel) error  // validated by caller
+func (m *Manager) clearModelOverride(path string) error
+// resolveModel returns the effective ModelConfig for a workspace: user > sub >
+// tenant override (each mapped to an agent selectable entry) else agent.Model.
+// An override whose {provider,name} is no longer selectable falls back to the
+// default and logs.
+func (m *Manager) resolveModel(agent config.Agent, key WorkspaceKey) *config.ModelConfig
+```
+
+## Apply / re-apply (proxy)
+
+- `provision` uses `resolveModel(agent, key)` in place of the raw `agent.Model`
+  on first provision (so a new workspace under an overridden scope is born with
+  the right model).
+- **Re-apply to established workspaces** — new `reapplyModel(userDir, model)`:
+  rewrite ONLY `config.json`'s `agents.defaults.provider`/`model_name` and the
+  `.security.yml` `model_list` entry for the model's key, **preserving the
+  existing pico token and any merged native secrets** in `.security.yml` (do NOT
+  regenerate the token or drop other model_list entries — read-modify-write, not
+  the overwrite `applyModel` does on first provision). Idempotent.
+- On override change, iterate affected established workspaces (dirs under the
+  scope), `reapplyModel` each, then `RestartScope`-style stop/start of the
+  running ones so picoclaw reloads the model at start. Stopped ones re-apply on
+  next `provision`/start. **No recreate.**
+  - Reuse/extend `RestartScope`: add per-key `reapplyModel(resolveModel(...))`
+    in its loop (next to the secrets/skills sync), and ensure the
+    provision/start path also re-applies (so stopped→started picks it up).
+
+## HTTP API (proxy `internal/httpapi/admin.go` + `handlers.go`)
+
+Reuse `s.resolveSecretCaller`, `s.adminScope`, `authz.AuthorizeSharedScope`.
+```
+GET  /v1/admin/models            -> list SELECTABLE models {provider,name} for the caller's agent (NO keys)
+GET  /v1/admin/model             -> current effective override at a scope/user (+ which level set it)
+PUT  /v1/admin/model             -> set override {scope|user target, provider, name}; validate in allowlist; re-apply + restart
+DELETE /v1/admin/model           -> clear override at a target; re-apply (falls back to next level) + restart
+GET  /v1/admin/model/users       -> per-user overrides under a subscription (mirror /users) for the per-user UI
+```
+- A per-user target adds `user_acc_id` (authorized by authority over that user's
+  subscription).
+- **Never** include any API key in a response (CTX-AMO-06). The models list is
+  provider/name only.
+
+## Gateway (fungi/mycelium both configs, alpha+beta)
+
+Add `[[picoclaw-*.path]]` blocks (`group="protected"`, matching secretName,
+`acceptInsecureRouting=true`): `/v1/admin/models` (GET), `/v1/admin/model`
+(GET,PUT,DELETE), `/v1/admin/model/users` (GET).
+
+## Webapp (crab-exoskeleton-webapp)
+
+- `lib/adminModels.ts` (new, don't touch lib/admin.ts): `SelectableModel{provider,name}`,
+  `listSelectableModels()`, `getModelOverride(target)`, `setModelOverride(target, sel)`,
+  `clearModelOverride(target)`, `listUserModelOverrides(scope)`.
+- BFF routes `app/api/admin/models/route.ts`, `app/api/admin/model/route.ts`
+  (GET/PUT/DELETE), `app/api/admin/model/users/route.ts` — forward via
+  `proxyAdminJson`. Keys never present (backend strips).
+- `app/admin/model-panel.tsx`: a scope-level model picker (dropdown of selectable
+  models; shows current + which level set it; Apply / Reset-to-inherited) plus a
+  per-user override list (each user: current model + override/clear). Wire a
+  `"model"` tab into `admin-screen.tsx`.
+
+## Testing
+
+- Proxy: `resolveModel` precedence (user>sub>tenant>default; stale override →
+  default); override get/set/clear round-trip; `reapplyModel` updates config.json
+  provider/model_name and the .security.yml key WITHOUT changing the pico token
+  or dropping merged secrets (construct a .security.yml with a token + a native
+  secret, reapply, assert token + secret survive); validation rejects a
+  {provider,name} not in the allowlist. Handler test: PUT unauthorized → 403;
+  PUT unknown model → 400; response bodies contain NO api key.
+- Webapp: tsc + build; assert BFF/list responses never carry a key field.
+
+## Out of scope
+Adding models/keys the operator hasn't declared in config.yaml; per-conversation
+end-user switching.

--- a/.specs/features/admin-model-override/spec.md
+++ b/.specs/features/admin-model-override/spec.md
@@ -1,0 +1,95 @@
+# admin-model-override — Specification
+
+## Summary
+
+Let tenant/subscription admins change the LLM **model** of already-established
+workspaces from the admin screen — for a single user, or for everyone at their
+authority level (a tenant admin → all workspaces in the tenant; a subscription
+admin → all in the subscription). Follows the `admin-shared-content` tier/authz
+pattern, adds a **model override** cascade with a **per-user** layer, and
+re-applies to live workspaces immediately.
+
+## Context (how the model works today — verified)
+
+- The model is pinned **per agent** in `config.yaml` (`agent.Model` =
+  `{provider, name, apiKeyEnv}`) and applied at **provision** time into the
+  workspace's `config.json` + `.security.yml` by `applyModel` (`internal/docker/provision.go`).
+  There is no per-workspace/per-user override today; every user of an agent gets
+  that agent's configured model.
+- The model is read from config files at picoclaw **start**, so a re-applied
+  model takes effect on a **stop/start** (no recreate) — unlike bind mounts.
+- Valid models are those in the agent's picoclaw `model_list` (provider+name).
+
+## Decisions (from discuss, 2026-07-20)
+
+- **CTX-AMO-01 Granularity + precedence:** override stored at three levels —
+  **tenant**, **subscription**, **user** — resolved **user > subscription >
+  tenant > agent-default** when provisioning/applying a workspace.
+- **CTX-AMO-02 Authority:** who may set which override reuses the
+  `admin-shared-content` tier check — a Tenant tier may set the tenant override
+  (and any subscription/user under it); a Subscription tier may set the
+  subscription override (and any user under it). "Apply to all at my level" =
+  set the scope-level override (it cascades to all workspaces below without a
+  per-user write). "Change one user" = set that user's override.
+- **CTX-AMO-03 Apply to established workspaces (immediate):** on change, re-apply
+  the resolved model to the affected **already-provisioned** workspaces'
+  `config.json`/`.security.yml` and **restart running containers now**
+  (stop/start, reload config); stopped/scale-to-zero workspaces pick it up on
+  their **next start** (re-apply at provision/start). No recreate.
+- **CTX-AMO-04 Allowed models:** any model in the agent's picoclaw `model_list`
+  (valid provider+name); no new keys introduced.
+
+## Functional requirements
+
+- **FR-1** Store a model override per scope: tenant `<root>/tenants/<t>/shared/model`,
+  subscription `<root>/tenants/<t>/subscriptions/<s>/shared/model`, and per user
+  `<root>/tenants/<t>/subscriptions/<s>/<role>/users/<u>/model` (exact paths in
+  design). Each holds a `{provider, name}` selection.
+- **FR-2** `resolveModel(agent, key)` returns the effective model:
+  user → subscription → tenant → `agent.Model` (default). Used by `provision`
+  in place of the raw `agent.Model`.
+- **FR-3** Admin API to get/set/clear the override at a target level, authorized
+  by the caller's tier vs the target (reuse `authz.AuthorizeSharedScope` for
+  tenant/subscription; a per-user target requires authority over that user's
+  subscription).
+- **FR-4** Setting/clearing an override **re-applies** the resolved model to all
+  affected established workspaces and restarts the running ones (reuse
+  `RestartScope`; extend so the restart/provision path re-runs `applyModel` with
+  the resolved model). Per-user change affects only that workspace.
+- **FR-5** Validation: the chosen `{provider, name}` must exist in the agent's
+  `model_list`; otherwise 400, nothing written.
+- **FR-6** Admin UI: a **Model** control in the admin screen, scoped by the
+  existing scope tree — pick a model and apply at tenant/subscription level, plus
+  a per-user override list (mirrors the members panel for the per-user case).
+- **FR-7** Reading the current effective model + which level set it, for display.
+
+## Non-functional
+
+- **NFR-1** Authorization server-side in the proxy from the injected profile.
+- **NFR-2** Re-apply is stop/start only (never recreate — preserves transcript).
+- **NFR-3** No secrets/keys in the override store (only provider+name); the API
+  key stays sourced from env at apply time as today.
+
+## Out of scope
+
+Adding new models/providers/keys (only what `model_list` already declares);
+per-conversation model switching by end users; model switching for the
+`admin-shared-skills`/agents features.
+
+## Acceptance criteria (EARS)
+
+- **AC-1** WHEN a subscription admin sets the subscription model override to a
+  valid `model_list` entry THEN every established workspace under `S` (that has
+  no user-level override) SHALL be re-applied that model and running ones
+  restarted, and new provisions under `S` SHALL use it.
+- **AC-2** WHEN a tenant admin sets a single user's override THEN only that
+  user's workspace SHALL change; sibling users SHALL be unaffected.
+- **AC-3** WHEN both a subscription override and a user override exist for a
+  workspace THEN the **user** override SHALL win.
+- **AC-4** WHEN the chosen model is not in the agent's `model_list` THEN the
+  system SHALL respond 400 and write nothing.
+- **AC-5** WHEN a caller lacks authority over the target level/branch THEN 403,
+  nothing written.
+- **AC-6** Re-apply SHALL stop/start affected running containers (no recreate).
+
+## Status: spec (design/tasks pending)

--- a/.specs/features/admin-shared-skills/context.md
+++ b/.specs/features/admin-shared-skills/context.md
@@ -1,0 +1,56 @@
+# admin-shared-skills — Context (user decisions)
+
+Decisions captured during the discuss phase (2026-07-20).
+
+## CTX-ASK-01: Scope is skills only; agents deferred
+
+picoclaw agents are config-registered, not injectable files (see project
+`STATE.md` AD-011, verified against upstream source/docs). The user chose to
+ship **skills only** at tenant/subscription scope now, and treat
+admin-provisioned agents as a **separate future feature** with its own design.
+
+**Why:** skills fit the read-only file-cascade pattern exactly; agents do not
+(they need config merge + workspace/routing/spawn provisioning).
+
+## CTX-ASK-02: Tenant + subscription scope, same pattern as files/secrets
+
+The feature reuses `admin-shared-content`'s tiers, authorization, BFF, and
+cascade. Skills are a new content type beside shared files and secrets, at the
+same two scopes (tenant, subscription).
+
+## CTX-ASK-03: Two authoring modes — editor and upload
+
+- **Editor mode:** an in-browser markdown editor that writes a single `SKILL.md`
+  (frontmatter `name`+`description` + body). No supporting files.
+- **Upload mode:** a zip of the whole skill directory, extracted server-side,
+  preserving `references/` and any other supporting files/subdirs.
+
+**Why:** the editor is the fast path for simple skills; the zip covers skills
+that need supporting files. (User: "no modo edição na tela somente SKILL.md;
+se for upload pode ser com pasta references e outras se precisar".)
+
+## CTX-ASK-04: Skills are readable/editable/previewable (not write-only)
+
+Unlike secrets, skill content is manager-visible: list returns metadata, view
+returns the `SKILL.md` content and file manifest, and the skill is downloadable.
+The user-privacy carve-out (never return bytes) applies only to user-scope
+private content, which this feature does not touch.
+
+## CTX-ASK-05: Depth — full pipeline through implementation
+
+The user chose Spec → Design → Tasks → Implement for this feature (verify per
+task). A checkpoint for user review is taken after Tasks, before Execute.
+
+## Open design questions (to resolve in design.md)
+
+- **Mount mechanism & precedence (FR-7/FR-8):** picoclaw discovers workspace
+  skills at `workspace/skills/<name>/`. Options for cascading tenant +
+  subscription skills without collisions: (a) proxy composes a single merged
+  read-only skills view per container applying subscription-over-tenant
+  precedence by name; (b) map scopes to picoclaw's separate skill *sources*
+  (workspace vs global `~/.picoclaw/skills`). Decide in design; must not collide
+  with the user's own `workspace/skills` or the managed `shared-content` skill.
+- **Editor `SKILL.md` frontmatter validation** location (BFF vs proxy) — proxy
+  is authoritative (NFR-1) but the editor may pre-validate for UX.
+- **Zip hardening limits** (max entries, max total size, max per-file) — set
+  concrete numbers in design.

--- a/.specs/features/admin-shared-skills/design.md
+++ b/.specs/features/admin-shared-skills/design.md
@@ -1,0 +1,155 @@
+# admin-shared-skills — Design
+
+Mirrors `admin-shared-content` end-to-end (scope model, tiers, authz, BFF,
+cascade) and adds a **skills** content type. Only the storage/mount layer is
+genuinely new (skills are directory-shaped and support zip upload); everything
+else is a direct clone of the shared-files plumbing.
+
+## Storage layout (proxy)
+
+New `internal/config/config.go` builders (mirror the files/secrets ones):
+
+```go
+func TenantSharedSkillsDir(root, tenantID string) string        // <root>/tenants/<t>/shared/skills
+func SubscriptionSharedSkillsDir(root, tenantID, subsAccID string) string
+                                                                // <root>/tenants/<t>/subscriptions/<s>/shared/skills
+```
+
+A skill is a **directory** `.../shared/skills/<skill-name>/` containing
+`SKILL.md` (+ optional `references/` etc.). `<skill-name>` is a validated slug.
+
+## Skill store (new `internal/docker/skills.go`)
+
+```go
+type SkillMeta struct {
+    Name        string `json:"name"`
+    Description string `json:"description"`
+    Size        int64  `json:"size"`        // total bytes of the skill dir
+    ModifiedAt  string `json:"modifiedAt"`
+    HasFiles    bool   `json:"hasFiles"`    // more than just SKILL.md
+}
+
+func (m *Manager) sharedSkillsDir(scope Scope) string
+func (m *Manager) ListSharedSkills(scope Scope) ([]SkillMeta, error)
+func (m *Manager) ReadSharedSkillDoc(scope Scope, name string) (string, SkillMeta, error) // SKILL.md text
+func (m *Manager) WriteSharedSkillDoc(scope Scope, name, body string) error                // editor mode
+func (m *Manager) WriteSharedSkillZip(scope Scope, name string, r io.Reader) error          // upload mode
+func (m *Manager) ArchiveSharedSkill(scope Scope, name string, w io.Writer) error           // stream .zip
+func (m *Manager) DeleteSharedSkill(scope Scope, name string) error
+```
+
+- **Name validation:** `sanitizeSkillName(raw)` — must be a non-empty slug
+  matching `^[a-z0-9][a-z0-9._-]{0,63}$` (lowercased), rejecting `shared-content`
+  (reserved for the managed skill) and any name that changes under sanitization.
+- **Frontmatter validation:** `parseSkillFrontmatter(skillMD) (name, description string, err)`
+  — reads the leading `---`…`---` block, requires non-empty `name` and
+  `description`. No new YAML dependency: scan fenced lines for `name:` /
+  `description:` (values may be quoted). Reject if `SKILL.md` missing or either
+  field empty.
+- **Editor mode (`WriteSharedSkillDoc`)**: `MkdirAll(dir/<name>, 0700)`,
+  validate frontmatter of `body`, write `SKILL.md` (0600), leave any existing
+  supporting files untouched, `chownTree`.
+- **Upload mode (`WriteSharedSkillZip`)**: read into a size-capped buffer, open
+  with `archive/zip`, **harden** each entry (reject absolute paths, `..`
+  segments, symlinks/irregular modes; enforce caps below), require a top-level
+  `SKILL.md` with valid frontmatter, then atomically replace `dir/<name>`
+  (extract to a temp sibling dir, then `RemoveAll`+`Rename`), `chownTree`.
+- **Delete**: `os.RemoveAll(dir/<name>)` (idempotent).
+- **Archive (download)**: walk `dir/<name>`, stream a zip to `w`.
+
+**Zip hardening caps (NFR-3):** total uncompressed ≤ `MediaMaxBytes` (10 MiB),
+entries ≤ 200, per-file ≤ `MediaMaxBytes`, nesting depth ≤ 8. Any breach → error,
+nothing written.
+
+## Cascade & precedence (proxy `internal/docker/manager.go`)
+
+picoclaw discovers workspace skills at `workspace/skills/<name>/SKILL.md`; the
+managed skill already binds at `workspace/skills/shared-content:ro`. Admin skills
+are **additive per-skill RO binds** at `workspace/skills/<name>:ro`.
+
+- In `create`, after the managed-skill mounts, compute the **effective skill
+  set** for the container's `(tenant, subscription)`:
+  1. list subscription-scope skills of `S`;
+  2. add tenant-scope skills of `T` whose name is **not** already provided by
+     subscription (subscription-over-tenant precedence, FR-8);
+  3. skip the reserved name `shared-content`.
+- Ensure each source dir exists + chowned (mirror the tenant/subs shared-files
+  loop), then append one bind per skill:
+  `<hostSharedSkillsDir>/<name>:<mountDest>/workspace/skills/<name>:ro`.
+- **Propagation (FR-10):** editing an existing mounted skill's files is live
+  (RO bind reflects host writes; picoclaw mtime-tracks). Adding or removing a
+  skill *name* changes the bind set, so create/delete calls invoke the existing
+  `RestartScope(scope)` to stop/start affected containers with the new binds —
+  the same mechanism shared-files writes already use. No image rebuild.
+- **Collision with a user's own skill of the same name:** the admin RO bind at
+  `workspace/skills/<name>` takes precedence (governance) — documented; the
+  reserved `shared-content` name is additionally protected.
+
+## HTTP API (proxy `internal/httpapi/admin.go` + `handlers.go`)
+
+Mirror the shared-files handlers (`s.adminScope`, `authz.AuthorizeSharedScope`
+right after scope resolution). New routes:
+
+```
+GET    /v1/admin/skills            -> handleAdminSkillsList     (list SkillMeta)
+GET    /v1/admin/skills/doc        -> handleAdminSkillsDoc      (SKILL.md text; preview + editor load)
+GET    /v1/admin/skills/archive    -> handleAdminSkillsArchive  (stream .zip download)
+POST   /v1/admin/skills            -> handleAdminSkillsPost      (create/replace)
+DELETE /v1/admin/skills            -> handleAdminSkillsDelete    (delete by name)
+```
+
+`handleAdminSkillsPost` (multipart, mirror `handleAdminSharedPost`): fields
+`scope`, `tenant_id`, `subs_acc_id`, `name`, and **either** `body` (editor
+`SKILL.md` text) **or** `file` (zip). Discriminate by presence of `file`.
+Authorize, then call `WriteSharedSkillDoc` or `WriteSharedSkillZip`; on success
+call `RestartScope`. Same `MaxBytesReader`/`ParseMultipartForm` limits as files.
+`handleAdminSkillsDoc`/`Archive` set `Content-Type`/`Content-Disposition` like
+`handleAdminSharedContent`.
+
+## Gateway (fungi/mycelium `config.standalone.toml`)
+
+Add `[[picoclaw-alpha.path]]` **and** mirrored `[[picoclaw-beta.path]]` blocks
+(`group="protected"`, `secretName="picoclaw-alpha-authorization-header"`/beta,
+`acceptInsecureRouting=true`):
+- `/v1/admin/skills` — `["GET","POST","DELETE"]`
+- `/v1/admin/skills/doc` — `["GET"]`
+- `/v1/admin/skills/archive` — `["GET"]`
+
+## Webapp (crab-exoskeleton-webapp)
+
+- **`lib/admin.ts`** — new `SkillMeta` type + `listSharedSkills(scope)`,
+  `sharedSkillDoc(scope, name)` (text), `saveSharedSkillDoc(scope, name, body)`
+  (editor POST), `uploadSharedSkillZip(scope, name, file)` (zip POST),
+  `sharedSkillArchiveUrl(scope, name)`, `deleteSharedSkill(scope, name)`. Reuse
+  `scopeParams`/FormData patterns.
+- **BFF routes** mirroring shared: `app/api/admin/skills/route.ts` (GET/POST/
+  DELETE via `proxyAdminJson`), `app/api/admin/skills/doc/route.ts` (GET text),
+  `app/api/admin/skills/archive/route.ts` (GET stream, like shared/content).
+- **`app/admin/shared-skills-panel.tsx`** — clone of `shared-files-panel.tsx`:
+  list skills (name + description + size + a "files" badge when `HasFiles`);
+  "New skill" opens an inline markdown editor (`Textarea`) writing `SKILL.md`;
+  "Upload .zip" via hidden file input; each row has Preview (opens the SKILL.md
+  in a read-only view/editor), Download (`sharedSkillArchiveUrl`), and Delete
+  (`ConfirmDialog`). Reuse `Button`/`IconButton`/`Alert`/`Spinner`/`Badge`.
+- **`app/admin/admin-screen.tsx`** — add `"skills"` to the `Tab` union and a
+  `{ key: "skills", label: "Shared skills", icon: <Wrench size={16}/> }` entry
+  in `TABS` (ungated, alongside files/secrets), plus a render branch
+  `: tab === "skills" ? (<SharedSkillsPanel scope={selected} />)`.
+
+## Testing
+
+- **Proxy (Go, `_test.go`):** `sanitizeSkillName` (valid/invalid/reserved);
+  `parseSkillFrontmatter` (missing SKILL.md, missing fields, quoted values);
+  `WriteSharedSkillDoc` round-trips SKILL.md; `WriteSharedSkillZip` extracts a
+  good zip and **rejects** traversal/symlink/oversize/too-many-entries zips
+  (nothing written); precedence: `effectiveSkills` picks subscription over
+  tenant by name and skips `shared-content`; `ArchiveSharedSkill` produces a
+  readable zip; `DeleteSharedSkill` idempotent.
+- **Webapp:** no component-test harness beyond the vitest added earlier; verify
+  `tsc --noEmit` + a production `next build`. Pure helpers in `lib/admin.ts`
+  (e.g. a `scopeParams` addition) get a vitest unit test if logic is added.
+
+## Out of scope
+
+Agents/subagents (AD-011, CTX-ASK-01); user-scope skills; instance-scope UI;
+editing supporting files via the browser editor (zip only); versioning.

--- a/.specs/features/admin-shared-skills/design.md
+++ b/.specs/features/admin-shared-skills/design.md
@@ -63,27 +63,39 @@ nothing written.
 
 ## Cascade & precedence (proxy `internal/docker/manager.go`)
 
-picoclaw discovers workspace skills at `workspace/skills/<name>/SKILL.md`; the
-managed skill already binds at `workspace/skills/shared-content:ro`. Admin skills
-are **additive per-skill RO binds** at `workspace/skills/<name>:ro`.
+**Verified picoclaw skill discovery** (`pkg/skills/loader.go`): three fixed roots
+scanned **one level** (`os.ReadDir(root)` → `<root>/<name>/SKILL.md`), priority
+**workspace > global > builtin**. `workspace = <ws>/skills`; `global =
+~/.picoclaw/skills` = `<mountDest>/skills` (normally empty per-user — the template
+seeds `workspace/skills`, not the global root). Docker binds are fixed at
+container **create**, and admin writes must NOT recreate (that truncates the live
+transcript — `RestartScope` deliberately does stop/start only).
 
-- In `create`, after the managed-skill mounts, compute the **effective skill
-  set** for the container's `(tenant, subscription)`:
-  1. list subscription-scope skills of `S`;
-  2. add tenant-scope skills of `T` whose name is **not** already provided by
-     subscription (subscription-over-tenant precedence, FR-8);
-  3. skip the reserved name `shared-content`.
-- Ensure each source dir exists + chowned (mirror the tenant/subs shared-files
-  loop), then append one bind per skill:
-  `<hostSharedSkillsDir>/<name>:<mountDest>/workspace/skills/<name>:ro`.
-- **Propagation (FR-10):** editing an existing mounted skill's files is live
-  (RO bind reflects host writes; picoclaw mtime-tracks). Adding or removing a
-  skill *name* changes the bind set, so create/delete calls invoke the existing
-  `RestartScope(scope)` to stop/start affected containers with the new binds —
-  the same mechanism shared-files writes already use. No image rebuild.
-- **Collision with a user's own skill of the same name:** the admin RO bind at
-  `workspace/skills/<name>` takes precedence (governance) — documented; the
-  reserved `shared-content` name is additionally protected.
+Therefore admin skills use an **effective merged directory mounted whole at the
+global root**, mirroring the secrets `EffectiveSecretsDir` discipline (whole-dir
+RO mount → new entries appear live on the next stop/start, no recreate):
+
+- `config.EffectiveSkillsDir(root, tenantID, subsAccID)` — one merged dir per
+  `(tenant, subscription)`, shared by all users of that subscription.
+- `syncEffectiveSkills(scope)` materializes it: clear + copy each skill of the
+  **effective set** into `<effectiveSkillsDir>/<name>/` — subscription-scope
+  skills override tenant-scope by name (`mergeSkillNames`), reserved
+  `shared-content` skipped — then `chownTree`. (Copy, not symlink: symlink
+  targets outside the bind are invisible in the container.)
+- In `create`, `syncEffectiveSkills` for the key's scope, then mount it whole
+  read-only at the global root: `<effectiveSkillsHost>:<mountDest>/skills:ro`.
+  This is a nested RO bind (inside the per-user `hostDir` mount), same shape as
+  the existing managed-skill / workspace binds.
+- **Propagation (FR-10):** on any skill create/edit/delete, the handler calls
+  `syncEffectiveSkills(scope)` (updates the mounted dir on disk) then
+  `RestartScope(scope)` (stop/start of running containers → picoclaw re-scans
+  the global root and picks up added/removed/edited skills). Stopped/scale-to-zero
+  containers pick up the change on their next start (the dir is already mounted).
+  **No recreate, no transcript loss** — the exact secrets discipline.
+- **Precedence:** subscription > tenant > (picoclaw builtin). The user's own
+  `workspace/skills` still wins over the global (admin) root per picoclaw's
+  root priority; `shared-content` (managed) stays in `workspace/skills` and is
+  never shadowed.
 
 ## HTTP API (proxy `internal/httpapi/admin.go` + `handlers.go`)
 

--- a/.specs/features/admin-shared-skills/spec.md
+++ b/.specs/features/admin-shared-skills/spec.md
@@ -1,0 +1,161 @@
+# admin-shared-skills — Specification
+
+## Summary
+
+Let managers inject **harness-native skills** into workspaces from the admin
+screen, at **tenant** and **subscription** scope, following the exact
+`admin-shared-content` pattern (scope-aware CRUD in the proxy → read-only cascade
+into every user container below the publishing scope). Skills are picoclaw's
+`SKILL.md`-based capability directories. Two authoring modes: an in-browser
+markdown **editor** (single `SKILL.md`) and a **zip upload** (a full skill
+directory with `references/` and other supporting files).
+
+**Explicitly out of scope: agents/subagents.** Per AD-011, picoclaw agents are
+config-registered entities (the `config.json` `agents` block + per-agent
+workspace + `dispatch`/`spawn`), not injectable markdown files; admin-provisioned
+agents are deferred to a separate future feature.
+
+## Context
+
+- Reuses the tiers, scope model, authorization, BFF, and cascade machinery of
+  the implemented `admin-shared-content` feature (see its spec/design). This
+  feature adds a **skills** content type alongside shared files and secrets.
+- picoclaw skill discovery (verified, AD-011): `~/.picoclaw/workspace/skills/<name>/SKILL.md`
+  (workspace) → `~/.picoclaw/skills` (global) → builtin. A skill is a directory
+  named by the skill, containing `SKILL.md` (YAML frontmatter `name` +
+  `description`, then a markdown body) and optional supporting files/subdirs.
+- The proxy already mounts one operator-managed skill read-only at
+  `workspace/skills/shared-content` (`managed_skills.go`); admin-shared skills
+  are **additive** alongside it.
+
+## Tiers (authority, highest → lowest)
+
+Unchanged from `admin-shared-content`: Instance → Tenant → Subscription → User.
+A caller is authoritative over a target scope iff its tier is at/above the
+scope's tier **and** within the same branch (same tenant / same subscription).
+
+## Scopes (where skills live)
+
+- **Tenant scope** — skills published by a Tenant tier, cascaded to every user
+  container under tenant `T`.
+- **Subscription scope** — skills published by a Subscription tier (or above,
+  within branch), cascaded to every user container under subscription `S`.
+- No user-scope skills (end users don't self-publish skills in v1).
+
+## Functional requirements
+
+### Authoring & storage
+
+- **FR-1** A Tenant-tier (or Instance) caller can **create / list / view / edit /
+  delete** skills in the **tenant scope** of `T`. A Subscription-tier caller (or
+  above, within branch) can do the same in the **subscription scope** of `S`.
+  Authorization reuses the `admin-shared-content` tier-vs-target check.
+- **FR-2** A skill is stored as a **directory** keyed by scope and skill name,
+  containing at minimum a `SKILL.md`. Supporting files/subdirectories
+  (e.g. `references/`) are preserved.
+- **FR-3 (editor mode)** The caller can create/edit a skill by supplying the
+  **`SKILL.md` body text** directly (no file upload). This writes/overwrites
+  only `SKILL.md` in that skill's directory; existing supporting files are left
+  untouched.
+- **FR-4 (upload mode)** The caller can create/replace a skill by uploading a
+  **zip archive** of the skill directory. The archive is validated and extracted
+  server-side, preserving `references/` and other files.
+- **FR-5 (validation)** A skill is rejected (4xx, nothing written) if: it has no
+  `SKILL.md`; the `SKILL.md` frontmatter lacks `name` or `description`; the skill
+  name is not a safe slug; or (upload) the zip contains unsafe paths (absolute,
+  `..` traversal, symlinks) or exceeds size/entry limits.
+- **FR-6** Skill content is **readable/previewable** by managers of that scope
+  and above — listing returns skill metadata (name, description, size,
+  modified-at, source mode) and viewing returns the `SKILL.md` content and the
+  file manifest. (Skills are not secrets; the write-only privacy carve-out does
+  not apply.)
+
+### Cascade (down, read-only)
+
+- **FR-7** Tenant-scope skills of `T` are mounted **read-only** into every user
+  container under `T`; subscription-scope skills of `S` are mounted **read-only**
+  into every user container under `S`, at picoclaw's workspace skill-discovery
+  path so the harness loads them like any workspace skill.
+- **FR-8 (precedence)** When the same skill **name** exists at more than one
+  level, the **most-specific** wins for a given container: subscription-scope
+  overrides tenant-scope, which overrides the operator-managed/builtin skill of
+  the same name. Exactly one directory per skill name is presented to a
+  container. (Exact mechanism decided in design.)
+- **FR-9** Cascaded skills are kernel-enforced read-only (`:ro` bind); the agent
+  cannot modify, rename, or delete them.
+- **FR-10 (propagation)** A create/edit/delete becomes effective in a target
+  container following the same discipline as shared files/secrets (no
+  container *recreate*; stop/start only where required; picoclaw already
+  mtime-tracks skill content at runtime where applicable).
+
+### Discovery & UI
+
+- **FR-11** The admin **scopes** endpoint (from `admin-shared-content`) is
+  reused/extended so the UI knows which scopes the caller may administer for
+  skills.
+- **FR-12** `chat-webapp`'s admin screen gains a **Skills** tab (visible only to
+  callers with manage authority), scoped by the existing scope tree, to: list
+  skills for a scope; create via editor; create/replace via zip upload; preview
+  `SKILL.md`; download the skill; and delete. Mirrors the existing shared-files
+  panel UX.
+
+## Non-functional requirements
+
+- **NFR-1** All authorization is enforced **server-side** in the proxy from the
+  injected profile; the webapp/BFF never decides authority.
+- **NFR-2** Cascade is single-source-of-truth via read-only bind mounts.
+- **NFR-3** Zip extraction is hardened against path traversal, symlink escape,
+  and zip-bombs (entry count, total-size, and per-file-size caps).
+- **NFR-4** Skill names are sanitized/validated to safe slugs before use as
+  directory names (reuse `identity.SanitizeID`-style discipline).
+- **NFR-5** No new runtime dependency in the webapp beyond what shared-files use;
+  proxy zip handling uses the Go stdlib (`archive/zip`).
+
+## Out of scope
+
+| Item | Reason |
+| --- | --- |
+| **Agents/subagents injection** | AD-011: picoclaw agents are config-registered, not files. Separate future feature. |
+| User-scope (end-user self-published) skills | Only managers publish in v1. |
+| Instance-scope skills UI | Instance tier provisions via the same store if needed, but no dedicated UI in v1 (consistent with shared-content). |
+| Editing supporting files (references/) via the browser editor | Editor edits `SKILL.md` only; supporting files come via zip upload. |
+| Skill versioning / history | Same deferral as shared-file versioning. |
+| Live hot-reload guarantees beyond picoclaw's existing behavior | Propagation follows the shared-content discipline. |
+
+## Acceptance criteria (EARS)
+
+- **AC-1 (create via editor)** WHEN a Subscription-tier caller (within branch)
+  POSTs a skill to subscription scope `S` with a name and a `SKILL.md` body whose
+  frontmatter has `name`+`description` THEN the system SHALL create
+  `<subscription S skills dir>/<name>/SKILL.md` and respond `201`.
+- **AC-2 (create via upload)** WHEN the same caller uploads a zip containing
+  `SKILL.md` + `references/foo.md` THEN the system SHALL extract the tree under
+  `<... skills dir>/<name>/` preserving `references/foo.md`, and respond `201`.
+- **AC-3 (validation)** WHEN a skill is submitted without a `SKILL.md`, or its
+  frontmatter lacks `name`/`description`, or (upload) the zip has a `../` entry
+  THEN the system SHALL respond `4xx` and write nothing.
+- **AC-4 (authorization)** WHEN a caller lacks authority over the target scope
+  (wrong branch or lower tier) THEN the system SHALL respond `403` and write
+  nothing.
+- **AC-5 (cascade)** WHEN a tenant-scope skill exists for `T` THEN every user
+  container under `T` SHALL expose it read-only at the workspace skill path such
+  that `/list skills` inside the container includes it, and the agent cannot
+  write to it.
+- **AC-6 (precedence)** WHEN a skill name exists at both tenant and subscription
+  scope for a given container THEN that container SHALL see the
+  **subscription-scope** version only.
+- **AC-7 (preview/list)** WHEN a manager lists/views skills for a scope they
+  administer THEN the system SHALL return skill metadata and the `SKILL.md`
+  content.
+- **AC-8 (delete)** WHEN a manager deletes a skill in a scope they administer
+  THEN the system SHALL remove that skill directory and it SHALL no longer
+  cascade to containers below.
+
+## Requirement traceability
+
+| ID | Requirement | Status |
+| --- | --- | --- |
+| FR-1..FR-6 | Authoring, storage, validation, preview | Spec |
+| FR-7..FR-10 | Read-only cascade, precedence, propagation | Spec |
+| FR-11..FR-12 | Scopes discovery + admin Skills tab | Spec |
+| NFR-1..NFR-5 | Server-side authz, RO cascade, zip hardening, slug safety | Spec |

--- a/.specs/features/admin-shared-skills/tasks.md
+++ b/.specs/features/admin-shared-skills/tasks.md
@@ -1,0 +1,121 @@
+# admin-shared-skills — Tasks
+
+Depends on the implemented `admin-shared-content` plumbing. Two submodules
+(`crab/crab-shell-proxy` Go, `crab/crab-exoskeleton-webapp` Next) + the gateway
+config (`fungi/mycelium`). Each submodule gets its own feature branch
+`feat/admin-shared-skills`.
+
+Legend: `[P]` = parallelizable with siblings.
+
+## Proxy — crab/crab-shell-proxy
+
+### T1: Config builders + skill store
+- **What:** Add `TenantSharedSkillsDir`/`SubscriptionSharedSkillsDir` to
+  `internal/config/config.go`. New `internal/docker/skills.go` with `SkillMeta`,
+  `sharedSkillsDir`, `ListSharedSkills`, `ReadSharedSkillDoc`,
+  `WriteSharedSkillDoc`, `WriteSharedSkillZip`, `ArchiveSharedSkill`,
+  `DeleteSharedSkill`, plus `sanitizeSkillName`, `parseSkillFrontmatter`, and
+  the zip-hardening extractor. Reserve name `shared-content`.
+- **Where:** `internal/config/config.go`, `internal/docker/skills.go`,
+  `internal/docker/skills_test.go`.
+- **Reuses:** `identity.SanitizeID`, `chownTree`, `Scope`, `config.*SharedFilesDir`
+  layout, `MediaMaxBytes`.
+- **Done when:** all store ops work on a temp dir; validation + zip hardening
+  reject bad input writing nothing.
+- **Tests:** `sanitizeSkillName` (valid/invalid/reserved/changed), frontmatter
+  (missing file, missing name/description, quoted), doc round-trip, zip extract
+  good + reject traversal/symlink/oversize/too-many-entries, archive readable,
+  delete idempotent.
+- **Gate:** `go test ./internal/... && go build ./...`.
+
+### T2: Cascade mounts + precedence (depends T1)
+- **What:** In `internal/docker/manager.go` `create`, compute the effective
+  skill set for `(tenant, subscription)` — subscription overrides tenant by
+  name, skip `shared-content` — and append one RO bind per skill
+  `<hostSharedSkillsDir>/<name>:<mountDest>/workspace/skills/<name>:ro`
+  (ensure/chown source dirs, mirror the shared-files loop). Extract
+  `effectiveSkills(scope...)` as a testable pure-ish helper.
+- **Where:** `internal/docker/manager.go`, `internal/docker/manager_test.go`.
+- **Reuses:** managed-skill mount block, `RestartScope`.
+- **Done when:** a created container's `Binds` include the merged skill set with
+  correct precedence; no `shared-content` collision.
+- **Tests:** `effectiveSkills` precedence (subscription over tenant, dedup,
+  skip reserved).
+- **Gate:** `go test ./internal/... && go build ./...`.
+
+### T3: HTTP handlers + routes (depends T1, T2)
+- **What:** In `internal/httpapi/admin.go` add `handleAdminSkillsList`,
+  `handleAdminSkillsDoc`, `handleAdminSkillsArchive`, `handleAdminSkillsPost`
+  (multipart: `scope`/`tenant_id`/`subs_acc_id`/`name` + `body` XOR `file`),
+  `handleAdminSkillsDelete`; authorize via `authz.AuthorizeSharedScope` right
+  after `s.adminScope`; call `RestartScope` after write/delete. Register the 5
+  routes in `internal/httpapi/handlers.go` (mirror the shared block).
+- **Where:** `internal/httpapi/admin.go`, `internal/httpapi/handlers.go`.
+- **Reuses:** `handleAdminSharedPost`/`Content` shapes, `MaxBytesReader`.
+- **Done when:** routes compile and enforce authz; happy-path unit/handler test
+  for list+create(editor)+doc.
+- **Gate:** `go test ./... && go build ./...`.
+
+## Gateway — fungi/mycelium
+
+### T4: Register skill routes [P after T3 contract known]
+- **What:** Add `[[picoclaw-alpha.path]]` and mirrored `[[picoclaw-beta.path]]`
+  blocks for `/v1/admin/skills` (GET,POST,DELETE), `/v1/admin/skills/doc` (GET),
+  `/v1/admin/skills/archive` (GET) — `group="protected"`, matching `secretName`,
+  `acceptInsecureRouting=true`.
+- **Where:** `fungi/mycelium/config.standalone.toml` (and the prod/base config
+  if it carries the same admin routes — check and mirror).
+- **Done when:** TOML parses; routes present for both agents.
+- **Gate:** config loads (proxy/gateway boot or a TOML lint).
+
+## Webapp — crab/crab-exoskeleton-webapp
+
+### T5: Client API [P]
+- **What:** Add `SkillMeta` + `listSharedSkills`, `sharedSkillDoc`,
+  `saveSharedSkillDoc`, `uploadSharedSkillZip`, `sharedSkillArchiveUrl`,
+  `deleteSharedSkill` to `lib/admin.ts` (reuse `scopeParams`/FormData).
+- **Where:** `lib/admin.ts`.
+- **Done when:** `tsc --noEmit` clean; functions target `/api/admin/skills*`.
+- **Gate:** `npx tsc --noEmit`.
+
+### T6: BFF routes (depends T5 contract)
+- **What:** `app/api/admin/skills/route.ts` (GET/POST/DELETE via `proxyAdminJson`,
+  rebuilding FormData for POST), `app/api/admin/skills/doc/route.ts` (GET text),
+  `app/api/admin/skills/archive/route.ts` (GET stream, mirror shared/content).
+- **Where:** those three files.
+- **Reuses:** `requireSession`, `proxyAdminJson`, `forwardAdmin`, the
+  `shared/route.ts` + `shared/content/route.ts` shapes.
+- **Done when:** `tsc --noEmit` clean.
+- **Gate:** `npx tsc --noEmit`.
+
+### T7: Skills panel + tab (depends T5, T6)
+- **What:** `app/admin/shared-skills-panel.tsx` (clone shared-files-panel: list
+  with description + files badge; New-skill inline `Textarea` editor writing
+  SKILL.md; Upload .zip; Preview; Download; Delete via `ConfirmDialog`). Wire a
+  `"skills"` tab into `app/admin/admin-screen.tsx` (`Tab` union + `TABS` entry +
+  render branch).
+- **Where:** `app/admin/shared-skills-panel.tsx`, `app/admin/admin-screen.tsx`.
+- **Reuses:** `shared-files-panel.tsx`, `Button`/`IconButton`/`Alert`/`Spinner`/
+  `Badge`/`Textarea`/`ConfirmDialog`.
+- **Done when:** `tsc --noEmit` + `next build` pass; tab renders for managers.
+- **Gate:** `npx tsc --noEmit`; production `next build` (use a temp `distDir` if
+  a root-owned `.next` blocks it).
+
+## Verification
+
+### T8: Full gates
+- Proxy: `go build ./... && go test ./...`.
+- Webapp: `npx tsc --noEmit && yarn build`.
+- Gateway: config parses.
+
+## Traceability
+
+| Task | Requirements |
+| --- | --- |
+| T1 | FR-2..FR-6, NFR-3/4/5 |
+| T2 | FR-7..FR-10 |
+| T3 | FR-1, FR-3..FR-6, NFR-1 |
+| T4 | FR-1 (transport), NFR-1 |
+| T5,T6 | FR-11, FR-12 (client/BFF) |
+| T7 | FR-12 |
+| T8 | all (gates) |

--- a/.specs/features/canvas-timeline-view/context.md
+++ b/.specs/features/canvas-timeline-view/context.md
@@ -1,0 +1,54 @@
+# canvas-timeline-view — Context (user decisions)
+
+Gray areas resolved with the user during Specify, after a **feel-first
+standalone prototype** (three visual metaphors) was explored. Prototype:
+`canvas-mode.html` (Artifact) — Deck / Tree(by-metric) / Timeline, pixel-art
+grid background, golden-angle dots reused from the tree.
+
+## Decisions
+
+- **DEC-CANV-01 — Metaphor: Timeline.** Of the three explored (Deck of newest-left
+  columns, Tree branching by metric, left→right Timeline), the user picked the
+  **Timeline** as "o mais amigável". Deck and Tree are *not* built; the Timeline
+  is the sole Canvas view. Time flows left→right (oldest left, newest right).
+
+- **DEC-CANV-02 — Activation: workspace-level toggle.** A `Traditional | Canvas`
+  control at the workspace level (not a third value of the in-sidebar
+  `List | Tree` toggle). Choosing Canvas **replaces both the history sidebar and
+  the chat view** with a full-width canvas. Persisted in the URL fragment as
+  `view=canvas` so a reload / shared link keeps it. The user can return to the
+  traditional chat at any time.
+
+- **DEC-CANV-03 — Data: message `created_at`, capped by time window.** The
+  timeline axis is driven by per-message `created_at` (same source the tree
+  uses), fetched via the existing `getHistory` and collapsed into visits/bursts.
+  Rendering is bounded by a visible **time window** with right-pagination, so a
+  workspace with many conversations/messages stays light.
+
+- **DEC-CANV-04 — Content: preview (last N), transcript on demand.** Each lane
+  shows a light preview (title + last user/agent exchange) on select; the full
+  transcript is not rendered inline. "Full transcript" hands off to the
+  traditional chat opened at that conversation (`setFragmentSid`), and "Solo"
+  isolates a single lane within the timeline.
+
+- **DEC-CANV-05 — Reuse the tree's model + colors.** Burst aggregation and
+  `laneColorFor` (tag color when set, else golden-angle hash) come from
+  `conversation-tree.tsx`; the shared logic is extracted so the timeline and the
+  tree stay identical in "pontinhos" and identity color. The layout is
+  re-derived at 90° (horizontal), not shared.
+
+- **DEC-CANV-06 — "Evolution" affordance: Agent pulse.** An aggregate
+  message-volume-over-time strip sits above the lanes (the "faixa/tree acima"
+  from the brief), conveying the agent getting busier over time — the
+  "inteligência evoluindo" north star. Lane lifespan lines animate drawing
+  left→right on load (reduced-motion aware).
+
+- **DEC-CANV-07 — Background: pixel-art quadriculado.** A fine graph-paper grid
+  (fine cell + stronger every-Nth) via CSS, theme-aware, behind the canvas.
+
+## Pipeline depth
+
+Large — `spec.md` (traceable IDs) → `design.md` → `tasks.md` → execute. Chosen
+by the user; multi-component (new view, fragment key, perf/pagination, toggle).
+Webapp-only: `created_at` is already surfaced end-to-end by
+[[conversation-tree-view]], so **no proxy/Go change is required**.

--- a/.specs/features/canvas-timeline-view/design.md
+++ b/.specs/features/canvas-timeline-view/design.md
@@ -1,0 +1,148 @@
+# canvas-timeline-view — Design & Contract
+
+Decisions (see [[context.md]]): **DEC-CANV-01** timeline only. **DEC-CANV-02**
+workspace-level `view` toggle, replaces sidebar+chat. **DEC-CANV-03** data from
+`created_at` via `getHistory`, capped window. **DEC-CANV-04** preview + handoff.
+**DEC-CANV-05** reuse tree burst model + `laneColorFor`. **DEC-CANV-06** agent
+pulse. **DEC-CANV-07** pixel-art grid.
+
+Webapp-only. **No proxy/BFF/Go change** — `created_at` is already surfaced by
+[[conversation-tree-view]].
+
+## Architecture overview
+
+```
+chat-shell.tsx  ─ reads fragment.view ("chat" | "canvas")
+  ├─ NavSidebar                         (always)
+  ├─ view==="chat":  HistorySidebar + <main> ChatView   (unchanged)
+  └─ view==="canvas": <main> CanvasTimeline (full width, no history sidebar)
+```
+
+New/changed files:
+- `app/chat/fragment.ts` — add `view?: string`; `setView("chat" | "canvas")`.
+- `app/chat/conversation-bursts.ts` *(new)* — extract the shared model from
+  `conversation-tree.tsx`: `TreeEvent`/`Burst` types, `buildEvents`,
+  `aggregateBursts`, and `laneColorFor`/`laneColor`/`tagColorOf`/`withAlpha`.
+- `app/chat/conversation-tree.tsx` — import the extracted helpers (no behavior
+  change; keeps tree & canvas identical by construction — CANV-04).
+- `app/chat/canvas-timeline.tsx` *(new)* — the Canvas view (header toggle,
+  pulse, timeline SVG, preview, solo, pagination, pixel-art bg).
+- `app/chat/chat-shell.tsx` — branch on `view`.
+- `app/chat/chat-view.tsx` — add the `Traditional | Canvas` control to its header.
+
+## Fragment: the `view` key (CANV-01)
+
+- Extend `FragmentState` with `view?: string`; `readFragment` reads `view`.
+- `setView(view)`: `params.set("view","canvas")` for canvas, else delete (default
+  clean), then assign `location.hash` — same native-`hashchange` mechanism as
+  `setHistoryView`/`setFragmentSid`; preserves `t/s/r/sid/hv`, drops transient
+  `msg`.
+- `chat-shell.tsx`: `const canvas = fragment?.view === "canvas" && !!workspace`.
+  When `canvas`, do **not** render the HistorySidebar `ResizablePane`; render
+  `<CanvasTimeline workspace={workspace} />` in `<main>` instead of `<ChatView>`.
+  Mobile: canvas may fall back to chat (out of scope for polish).
+
+## Shared model extraction (CANV-04, DEC-CANV-05)
+
+Move from `conversation-tree.tsx` into `conversation-bursts.ts`, unchanged:
+- `laneColor(id, alpha?)`, `tagColorOf(conv)`, `withAlpha(hex, alpha)`,
+  `laneColorFor(conv, id, alpha?)`.
+- `interface TreeEvent`, `interface Burst`.
+- `buildEvents(lists: {c, messages}[]): TreeEvent[]` — the flatten + `created_at`
+  parse + `updatedAt+seq` fallback + descending sort (NFR-3).
+- `aggregateBursts(events): Burst[]` — the consecutive-run collapse.
+
+`conversation-tree.tsx` imports these; its render/FLIP/lane-packing stay in place.
+This guarantees the canvas's dots/colors equal the tree's (CANV-04) rather than
+re-implementing them.
+
+## CanvasTimeline component (`canvas-timeline.tsx`)
+
+### Data (CANV-10, NFR-2, NFR-3)
+- `conversations` from `listConversations(workspace)`; subscribe to
+  `onConversationsUpdated` (same as sidebar/tree).
+- On mount / conversations-change: `Promise.all(conversations.map(c =>
+  getHistory(workspace, c, c.id === active)))` (reuses the cache; force only the
+  active one). Build events with `buildEvents`, then `aggregateBursts`.
+- Spinner only on workspace change (mirror the tree's `prevWsKey` guard) so
+  refetches don't flash.
+- **Fetch vs. render (NFR-2):** fetch is O(all conversations) through the cached
+  `getHistory` (same as the tree; ships fine at "dozens") — the cap below bounds
+  *drawing*, not the network. Do NOT lazy-fetch per window.
+- **Stable-lane cap (NFR-2):** one lane per conversation, sorted by `firstT`,
+  drawn on a stage as wide as the time range. Lanes **stay put**; paging is
+  horizontal scroll (CANV-08), not a window filter. Bound total lanes with a
+  `MAX_LANES` cap (same spirit as the tree's `MAX_LANE_COLUMNS`) and handle
+  overflow gracefully (e.g. collapse the least-active beyond the cap) — lanes do
+  not pop in/out as the user scrolls.
+
+### Layout (CANV-03)
+- Horizontal SVG stage, `min-width: max-content`, inside a scroll container.
+- `xOf(t) = padL + ((t - tMin) / (tMax - tMin)) * innerW`.
+- One lane per conversation, ordered by `firstT` asc; laneY = `padTop + i*laneH`.
+- Per lane: a lifespan `<line>` (firstT→lastT) + a `<circle>` per burst at
+  `xOf(burst.ts)`, `r = base + min(count,5)*k`, recent bursts scaled up slightly
+  (CANV-04). Leaf `<text>` label (alias||title) at the lane tip.
+- Axis: 4–5 ticks across `innerW` with `fmtDate` labels; faint dashed guides.
+- Colors via `laneColorFor(convById.get(id), id)`.
+
+### Agent pulse (CANV-05)
+- Bucket every burst's `count` into `NBUCKETS` over `[tMin,tMax]`; area+line path
+  (`<linearGradient>` accent fill), sharing `xOf`. A small strip above the lanes.
+
+### Interaction (CANV-06, CANV-07)
+- Hover a lane group → add `dimmed` to the others (CSS opacity), same idea as the
+  tree's focus/dim.
+- Click a lane → inline **preview** panel (title, `total msgs · bursts · last
+  Nd ago`, last 2 bursts' user/agent lines). Actions:
+  - **Solo**: `soloId` state → render only that lane; a "show all" clears it.
+  - **Full transcript**: `setFragmentSid(id)` + `setView("chat")` → hands off to
+    the traditional chat at that conversation.
+
+### Header + time band + pagination (CANV-08)
+- Header bar (mirrors chat-view's header height/border): `agent {r}` + the
+  `Traditional | Canvas` segmented control (leaving Canvas here).
+- Time band: visible range text + `‹ ›` buttons that `scrollBy`/shift the window;
+  horizontal scroll enabled.
+
+### Pixel-art background (CANV-09)
+- CSS `repeating-linear-gradient` fine grid + stronger every-Nth cell on the
+  stage container, using a brand-tinted low-alpha token so it reads in both
+  themes (see the prototype's `--grid`/`--grid-strong`). Not an external image.
+
+### Motion / a11y (NFR-4)
+- Lifespan-line + pulse draw-in via `stroke-dasharray/offset` animation, gated on
+  `@media (prefers-reduced-motion: no-preference)`; burst dots fade/scale in.
+- Lanes are focusable buttons with visible focus; toggle is a real segmented
+  control with `aria-pressed`.
+
+## Toggle placement (CANV-01)
+- **Enter Canvas** from `chat-view.tsx` header (add a `Traditional | Canvas`
+  segmented control next to the secret/files icons — `cva` styled like the
+  sidebar's `viewToggle`).
+- **Leave Canvas** from `canvas-timeline.tsx` header (same control).
+- Both call `setView(...)`. Keeping the control in each view's own header matches
+  how `List | Tree` is owned by the sidebar.
+
+## States / edges
+- Empty workspace → empty state (`"No conversations yet."`).
+- Loading → spinner (no flash on refetch).
+- Missing/unparseable `created_at` → `updatedAt` fallback ordering (NFR-3).
+- `prefers-reduced-motion` → animations off.
+
+## Contract summary
+- **Fragment:** adds optional `view` (`"canvas"`; absent = traditional). No other
+  schema change. Shareable/reloadable.
+- **No network/proxy/BFF contract change.** Reuses `GET /api/chat/[instance]/
+  history` exactly as the tree does.
+
+## Test / gate
+- Webapp: `yarn build` (Next type-check) clean; `yarn test` (vitest) for any
+  extracted-helper unit tests.
+- Unit: `conversation-bursts.ts` — `buildEvents` ordering + `updatedAt` fallback;
+  `aggregateBursts` run-collapse (move/extend coverage from existing tree logic).
+- Manual: log in via magic-link; create an "A → B → A → C" pattern; toggle
+  `Traditional → Canvas`; verify axis/lanes/dots/pulse, colors match the tree,
+  hover-dim, click-preview, Solo, Full-transcript handoff, `‹ ›`/scroll paging,
+  reload persistence (`view=canvas`), return to Traditional intact, empty state,
+  and reduced-motion.

--- a/.specs/features/canvas-timeline-view/spec.md
+++ b/.specs/features/canvas-timeline-view/spec.md
@@ -1,0 +1,203 @@
+# canvas-timeline-view — Specification
+
+## Summary
+
+An alternative, graphics-forward presentation of a workspace's conversations: a
+**Canvas** mode whose sole view is a left→right **Timeline**. Instead of reading
+one chat top-down, the user sees every conversation as a horizontal lane on a
+shared time axis, with activity **bursts** as dots (the same "pontinhos" and
+per-conversation colors as the tree), an aggregate **agent-pulse** strip above,
+and a pixel-art grid backdrop. The goal is to convey the agent's intelligence
+**evolving over time**. Canvas is a workspace-level toggle that replaces the
+history sidebar and the chat view; the user can return to the traditional chat
+at any time. Pure visualization — no new relationships are stored.
+
+## Grounding (verified in source, do not re-derive)
+
+- Per-message `created_at` is **already surfaced end-to-end** (proxy `Message`,
+  BFF `/api/chat/[instance]/history`) by [[conversation-tree-view]]; `getHistory`
+  (`app/chat/history-cache.ts`) returns `HistoryMessage { role, content,
+  created_at? }` and caches per conversation id (invalidated on `updatedAt`).
+  ⇒ **No proxy/Go change is needed here.**
+- The burst model already exists in `app/chat/conversation-tree.tsx`: flatten
+  histories to time-sorted events, collapse consecutive same-conversation runs
+  into visits/bursts; lane color via `laneColorFor` (tag color when set, else a
+  golden-angle hash of the id). This is currently private to that file.
+- Active conversation + workspace + view state live **only in the URL fragment**
+  (`app/chat/fragment.ts`): `t/s/r/sid`, transient `msg` scroll anchor, and
+  `hv` (history sidebar `list|tree`). `setFragmentSid(id, msg?)` navigates and
+  can land the chat on a specific message.
+- Layout shell (`app/chat/chat-shell.tsx`) mounts NavSidebar + (HistorySidebar +
+  `<main>`) only when the fragment carries a workspace; sidebars are
+  resizable/collapsible (persisted `"chat-sidebars"`).
+- The traditional chat view (`app/chat/chat-view.tsx`) owns its own header bar
+  (`agent {r}` + secret/files icons).
+- `listConversations(workspace)` + `onConversationsUpdated` drive the live list;
+  the sidebar already does an N-fetch of histories for content search
+  (`history-sidebar.tsx`), so an N-fetch pattern is established and cached.
+
+## Functional requirements
+
+- **CANV-01** A workspace-level `Traditional | Canvas` toggle. Default is
+  `Traditional` (unchanged behavior). The choice persists in the URL fragment
+  (`view=canvas`), so reload / shared link keeps it, and is reachable from both
+  modes (enter from the chat header; leave from the canvas header).
+- **CANV-02** In Canvas mode the history sidebar **and** the chat view are
+  replaced by a single full-width canvas in `<main>`; NavSidebar (workspace
+  picker) stays. Switching back restores the sidebar + chat exactly as before.
+- **CANV-03** The canvas renders a left→right **timeline**: a horizontal time
+  axis (oldest left, newest right) with tick labels, and **one lane per
+  conversation** (ordered by first activity). Each lane draws a lifespan line
+  from its first to last burst and a **dot per burst** positioned at the burst's
+  time; dot size scales with the burst's message count.
+- **CANV-04** Bursts and per-conversation colors match the tree exactly — reuse
+  the burst aggregation and `laneColorFor` (tag color when set, else golden-angle
+  hash). Recent bursts read slightly larger/brighter (recency emphasis).
+- **CANV-05** An **agent-pulse** strip above the lanes shows aggregate message
+  volume bucketed over the same time range (an area chart), conveying activity
+  accumulating over time. It shares the timeline's x-mapping.
+- **CANV-06** Clicking a lane opens an inline **preview** (title, message count,
+  last N messages — no full transcript inline) with two actions: **Solo**
+  (isolate that single lane in the timeline) and **Full transcript** (leave
+  Canvas → traditional chat opened at that conversation via `setFragmentSid`,
+  setting `view` back to traditional).
+- **CANV-07** Hovering a lane isolates it (others dim). "Solo" persists a single
+  lane until cleared; an explicit "show all" clears it.
+- **CANV-08** A **time band** header shows the range and offers `‹ ›` buttons
+  plus horizontal scroll to page through time. Paging = horizontal scroll of a
+  stable stage (matching the approved prototype); lanes do **not** appear/
+  disappear as you scroll — one stable lane per conversation stays put (see
+  NFR-2).
+- **CANV-09** A **pixel-art quadriculado** background (fine grid + stronger
+  every-Nth cell), theme-aware, sits behind the canvas.
+- **CANV-10** Data is fetched only when Canvas is active (reuse the cached
+  `getHistory` N-fetch) and refreshes on `chat-conversations-updated` (so an
+  update from elsewhere reflects); entering Canvas triggers the fetch, Traditional
+  mode adds no cost. Note: Canvas is **read-only** (no composer) — nothing
+  generates new activity while it is open, so the live-refresh is a
+  correctness/consistency guarantee, not a "live dashboard" claim.
+
+## Non-functional requirements
+
+- **NFR-1** Additive / backward-compatible: the traditional chat, the
+  `List | Tree` sidebar toggle, and the fragment schema are unchanged except for
+  an added optional `view` key. No proxy/Go/BFF change.
+- **NFR-2** Bounded render, **stable lanes**: there is one lane per conversation
+  (sorted by first activity), and lanes stay put — paging is horizontal scroll
+  across the time axis (the approved prototype's model), NOT a window filter that
+  makes lanes pop in/out. Render is bounded by a total `MAX_LANES` cap with
+  graceful overflow (à la the tree's `MAX_LANE_COLUMNS`), and time-scroll only
+  draws the stable stage. **Fetch vs. render:** history fetch is O(all
+  conversations) via the cached `getHistory` N-fetch (same as the tree, ships at
+  "dozens"); the cap bounds what is *drawn*, not the network. Must stay
+  responsive with dozens of conversations.
+- **NFR-3** Robust ordering: `created_at` is parsed to a comparable instant
+  before sorting (never raw-string compared); missing/unparseable timestamps fall
+  back to `updatedAt` ordering (as the tree does) and never crash the render.
+- **NFR-4** Motion is `prefers-reduced-motion`-aware (lifespan-draw + pulse-draw
+  disabled when reduced); keyboard focus visible; theme parity (light/dark).
+
+## Out of scope
+
+| Feature | Reason |
+| --- | --- |
+| Deck and Tree-by-metric canvas metaphors | Explored in the prototype; user chose Timeline only (DEC-CANV-01). |
+| Full transcript rendered inside a lane/card | Preview only; full read hands off to the traditional chat (DEC-CANV-04). |
+| Explicit forking / `parent_id` ancestry | Visualization only, same as [[conversation-tree-view]]. |
+| Rename / delete / alias-tag editing inside Canvas | Stay in List mode (first cut). |
+| Any proxy/picoclaw/transcript-write change | `created_at` already surfaced; webapp-only. |
+| Mobile-optimized canvas | First cut targets desktop; mobile keeps traditional (canvas may be read-only/degraded). |
+
+## User Stories
+
+### P1: See conversations evolve on a timeline ⭐ MVP
+
+**User Story**: As a user of a workspace, I want to switch to a Canvas timeline
+that lays my conversations out over time, so I get a sense of how the agent's
+work has evolved rather than reading one chat at a time.
+
+**Why P1**: This is the whole feature — the alternative visualization and the
+"intelligence evolving" impression.
+
+**Acceptance Criteria**:
+1. WHEN I toggle `Canvas` in a workspace THEN the system SHALL replace the
+   history sidebar + chat view with a full-width timeline and set `view=canvas`
+   in the URL.
+2. WHEN the timeline renders THEN the system SHALL show a left→right time axis,
+   one lane per conversation with a lifespan line and burst dots colored per
+   conversation (same colors as the tree), and an agent-pulse strip above.
+3. WHEN I reload or share the URL THEN the system SHALL restore Canvas mode.
+4. WHEN I toggle `Traditional` THEN the system SHALL restore the sidebar + chat
+   unchanged.
+5. WHEN a conversation has no/unparseable `created_at` THEN the system SHALL
+   order it by `updatedAt` and still render (no crash).
+
+**Independent Test**: Log in, open a workspace with a few conversations, toggle
+Canvas → see lanes/dots/pulse; reload → still Canvas; toggle back → chat intact.
+
+### P2: Preview and drill into a single conversation
+
+**User Story**: As a user, I want to click a lane to preview it and optionally
+isolate or open it, so the timeline is a way in, not just a picture.
+
+**Acceptance Criteria**:
+1. WHEN I click a lane THEN the system SHALL show an inline preview (title, count,
+   last N messages) with Solo and Full-transcript actions.
+2. WHEN I choose Solo THEN the system SHALL show only that lane until I clear it.
+3. WHEN I choose Full transcript THEN the system SHALL leave Canvas and open the
+   traditional chat at that conversation (`setFragmentSid`).
+
+**Independent Test**: Click a lane → preview; Solo → one lane; Full transcript →
+traditional chat on that conversation.
+
+### P3: Page through time without overloading
+
+**User Story**: As a user with many conversations, I want the canvas to stay
+responsive, paging through time rather than rendering everything.
+
+**Acceptance Criteria**:
+1. WHEN a workspace has more activity than the visible window THEN the system
+   SHALL bound what is rendered and reveal more via `‹ ›`/scroll.
+2. WHEN I page/scroll THEN the time band SHALL reflect the visible range.
+
+**Independent Test**: With dozens of conversations, the canvas stays smooth and
+paging reveals older activity.
+
+## Edge Cases
+
+- WHEN a workspace has zero conversations THEN the canvas SHALL show an empty
+  state (reuse the `"No conversations yet."` pattern).
+- WHEN a conversation has one burst THEN its lane SHALL render a single dot (a
+  minimal lifespan line).
+- WHEN histories are still loading THEN the canvas SHALL show a spinner without a
+  layout flash on refetch (mirror the tree's spinner-only-on-workspace-change).
+- WHEN `prefers-reduced-motion` is set THEN draw/pulse animations SHALL be off.
+- WHEN a shared `view=canvas` URL is opened on mobile THEN the system SHALL
+  ignore the `view` key and render the Traditional chat (canvas is desktop-only
+  first cut) — never a broken/garbage canvas.
+
+## Requirement Traceability
+
+| Requirement ID | Story | Phase | Status |
+| --- | --- | --- | --- |
+| CANV-01 | P1 | T03/T08 | Implementing (runtime unverified) |
+| CANV-02 | P1 | T04 | Implementing (runtime unverified) |
+| CANV-03 | P1 | T05 | Implementing (runtime unverified) |
+| CANV-04 | P1 | T01/T05 | Implementing (runtime unverified) |
+| CANV-05 | P1 | T06 | Implementing (runtime unverified) |
+| CANV-06 | P2 | T07 | Implementing (runtime unverified) |
+| CANV-07 | P2 | T07 | Implementing (runtime unverified) |
+| CANV-08 | P3 | T08 | Implementing (runtime unverified) |
+| CANV-09 | P1 | T09 | Implementing (runtime unverified) |
+| CANV-10 | P1/P3 | T04 | Implementing (runtime unverified) |
+
+**ID format:** `CANV-NN`. **Status:** Pending → In Design → In Tasks →
+Implementing → Verified.
+
+## Success Criteria
+
+- [ ] A user can enter Canvas, read the timeline, and return to chat in one click.
+- [ ] Burst dots and colors are visually identical to the tree view.
+- [ ] Canvas mode adds zero fetch/render cost while in Traditional mode.
+- [ ] The canvas stays responsive with dozens of conversations (bounded window).
+- [ ] Light/dark parity and reduced-motion honored.

--- a/.specs/features/canvas-timeline-view/tasks.md
+++ b/.specs/features/canvas-timeline-view/tasks.md
@@ -1,0 +1,137 @@
+# canvas-timeline-view Tasks
+
+Webapp-only (`crab/crab-exoskeleton-webapp`); **no proxy/Go change** —
+`created_at` already surfaced by [[conversation-tree-view]]. Gate: `yarn build`
+(Next type-check) + `yarn test` (vitest). Runtime: log in via magic-link, create
+an "A → B → A → C" usage pattern, toggle Traditional → Canvas. `[P]` =
+parallelizable.
+
+---
+
+## T01 — extract the shared burst model — CANV-04, DEC-CANV-05
+- **What:** create `app/chat/conversation-bursts.ts` and move, unchanged, from
+  `conversation-tree.tsx`: `laneColor`, `tagColorOf`, `withAlpha`, `laneColorFor`,
+  `interface TreeEvent`, `interface Burst`, plus `buildEvents(lists)` (flatten +
+  `created_at` parse + `updatedAt+seq` fallback + desc sort) and
+  `aggregateBursts(events)` (consecutive-run collapse). Re-import them in
+  `conversation-tree.tsx` with no behavior change.
+- **Reuses:** existing logic in `conversation-tree.tsx`.
+- **Done when:** `conversation-tree.tsx` uses the extracted module; `yarn build`
+  green; **manual check** — open the tree view and confirm it renders identically
+  (no existing tree unit test to guard the extraction).
+- **Depends on:** —
+
+## T02 — burst-model unit tests — CANV-04, NFR-3 [P after T01]
+- **What:** unit-test `conversation-bursts.ts`: `buildEvents` sorts by parsed
+  instant and falls back to `updatedAt+seq` for missing/unparseable `created_at`;
+  `aggregateBursts` collapses only consecutive same-conversation runs.
+- **Done when:** `yarn test` green with the new cases.
+- **Depends on:** T01
+
+## T03 — fragment `view` key + setView — CANV-01
+- **What:** in `app/chat/fragment.ts` add `view?: string` to `FragmentState`,
+  read it in `readFragment`; add `setView(view: "chat" | "canvas")` (set
+  `view=canvas` else delete; assign `location.hash`; preserve `t/s/r/sid/hv`,
+  drop `msg`) — mirror `setHistoryView`.
+- **Done when:** `useFragment().view` reflects the hash; navigating doesn't lose
+  `hv`/`sid`; `yarn build` green.
+- **Depends on:** —
+
+## T04 — CanvasTimeline: data + shell wiring — CANV-02, CANV-10, NFR-3
+- **What:** create `app/chat/canvas-timeline.tsx` that takes `{ workspace }`,
+  loads `listConversations` + subscribes to `onConversationsUpdated`, N-fetches
+  via `getHistory` (force only active), builds events+bursts (T01), with the
+  tree's workspace-change spinner guard. Branch `chat-shell.tsx` on
+  `fragment.view === "canvas"`: skip the HistorySidebar pane, render
+  `<CanvasTimeline>` in `<main>`.
+- **Done when:** toggling `view=canvas` (via URL) shows a full-width canvas with
+  no history sidebar and a loaded burst model; Traditional path unchanged.
+- **Depends on:** T01, T03
+
+## T05 — timeline render (axis + lanes + dots) — CANV-03, CANV-04, NFR-2
+- **What:** horizontal SVG stage in `canvas-timeline.tsx`: `xOf` time-map, 4–5
+  axis ticks, one lane per conversation (asc by `firstT`) with a lifespan line +
+  a burst dot each (size by count, recency emphasis), leaf label, colors via
+  `laneColorFor`. Lanes are **stable** (one per conversation, always drawn);
+  paging = horizontal scroll of the stage, NOT a window filter. Bound total lanes
+  with a `MAX_LANES` cap + graceful overflow; fetch stays O(all) via the cache —
+  the cap bounds drawing only.
+- **Done when:** lanes/dots render time-ordered, colors match the tree, lanes
+  stay put while scrolling, and a many-conversation workspace stays responsive.
+- **Depends on:** T04
+
+## T06 — agent-pulse strip — CANV-05 [P after T05]
+- **What:** bucket burst counts over `[tMin,tMax]` into `NBUCKETS`; render an
+  area+line path (accent gradient) above the lanes sharing `xOf`.
+- **Done when:** the pulse reflects aggregate volume and aligns to the axis.
+- **Depends on:** T05
+
+## T07 — interaction: hover-dim, preview, solo, handoff — CANV-06, CANV-07
+- **What:** hover a lane → dim others; click → inline preview panel (title,
+  count/bursts/last-ago, last 2 bursts' user/agent lines) with **Solo**
+  (`soloId` → render one lane; "show all" clears) and **Full transcript**
+  (`setFragmentSid(id)` + `setView("chat")`).
+- **Done when:** preview/solo/handoff work; Full-transcript lands the traditional
+  chat on the right conversation.
+- **Depends on:** T05
+
+## T08 — header toggle + time band + pagination — CANV-01, CANV-08
+- **What:** `Traditional | Canvas` segmented control (`cva`, like the sidebar's
+  `viewToggle`) in **both** the canvas header and the `chat-view.tsx` header, both
+  calling `setView`. Time band with visible-range text + `‹ ›` paging and
+  horizontal scroll shifting the window.
+- **Done when:** entering from chat and leaving from canvas both work and persist
+  (`view=canvas` on reload); paging updates the visible range.
+- **Depends on:** T03, T05
+
+## T09 — pixel-art background + motion/a11y polish — CANV-09, NFR-4
+- **What:** theme-aware `repeating-linear-gradient` grid (fine + every-Nth) on the
+  stage; lifespan/pulse draw-in gated on `prefers-reduced-motion`; focusable lanes
+  with visible focus; light/dark parity.
+- **Done when:** grid reads in both themes, animations off under reduced-motion,
+  keyboard focus visible; `yarn build` green.
+- **Depends on:** T05, T06
+
+## T10 — empty/loading/edge states — CANV-03, edges
+- **What:** empty workspace → `"No conversations yet."`; loading spinner without
+  refetch flash; single-burst lane renders a dot; missing-`created_at` lane orders
+  by `updatedAt` without crashing.
+- **Done when:** all edge cases render gracefully.
+- **Depends on:** T05
+
+---
+
+## Verification (feature-level)
+- `yarn build` + `yarn test` green.
+- Manual runtime script (design.md Test/gate) passes end-to-end.
+
+---
+
+## Progress (2026-07-20)
+
+Implemented T01–T10 in one pass (webapp-only). Files:
+- NEW `app/chat/conversation-bursts.ts` — shared model (T01).
+- NEW `app/chat/conversation-bursts.test.ts` — 9 unit tests (T02).
+- NEW `app/chat/view-mode-toggle.tsx` — shared Chat|Canvas control (T08).
+- NEW `app/chat/canvas-timeline.tsx` — the Canvas view: data + shell wiring
+  (T04), timeline render (T05), agent pulse (T06), hover-dim/preview/solo/
+  handoff (T07), header toggle + time band + `‹ ›` paging (T08), pixel-art bg +
+  reduced-motion + focus a11y (T09), empty/loading/single-burst/fallback (T10).
+- EDIT `app/chat/conversation-tree.tsx` — imports the extracted model (T01).
+- EDIT `app/chat/fragment.ts` — `view?` key + `setView` (T03).
+- EDIT `app/chat/chat-shell.tsx` — branch on `view==="canvas"` (desktop-only;
+  mobile ignores it), hide history sidebar, render CanvasTimeline (T04).
+- EDIT `app/chat/chat-view.tsx` — `ViewModeToggle` in the header (T08).
+
+**Gate:** `npx tsc --noEmit` clean; `yarn test` 47 passed. `yarn build` could NOT
+run — `.next/` holds root-owned files from a prior docker build (EACCES on
+unlink); used `tsc --noEmit` as the type-check gate instead. `next lint` is not
+configured (interactive prompt), so it was skipped.
+
+**PENDING — manual runtime verification** (needs the running stack: magic-link
+login, create an A→B→A→C pattern, toggle Chat→Canvas): confirm axis/lanes/dots/
+pulse render, colors match the tree, hover-dim, click-preview, Solo, Full-
+transcript handoff, `‹ ›`/scroll paging, reload persistence (`view=canvas`),
+return to Chat intact, empty state, reduced-motion. Not yet done.
+
+**Not committed** (per user's global rule: never commit unless asked).

--- a/.specs/features/multi-harness-support/investigation.md
+++ b/.specs/features/multi-harness-support/investigation.md
@@ -1,0 +1,189 @@
+# multi-harness-support — Feasibility Investigation
+
+**Status:** Investigation (pre-spec). No implementation committed.
+**Question:** Can `crab-shell-proxy` orchestrate agent runtimes *other than* picoclaw, and
+specifically what does it take to run **Nous Research's Hermes Agent** (`nousresearch/hermes-agent`)?
+**Verdict:** **Feasible, and unusually clean.** Hermes' OpenAI-compatible API server + disk-backed
+session store make it an *easier* integration than picoclaw in the two hardest layers (protocol and
+scale-to-zero). The work is real but mostly a refactor to introduce a "harness kind" seam that does
+not exist today.
+
+---
+
+## 0. Name-collision flag (read first)
+
+There are **two unrelated things called "hermes"** in play:
+
+1. **The pattern** — the repo adapts a scale-to-zero doc named `zero-scale-stateless-hermes-agent.md`.
+   `conversation-tree-view/context.md:94` states plainly: *"'hermes' ... is the name of the
+   stateless/scale-to-zero architecture pattern, not an agent here."* This is the `crab-shell-proxy`
+   architecture, already implemented for picoclaw.
+2. **The product** — `nousresearch/hermes-agent`, an open-source self-hosted AI agent (Nous Research;
+   repo created 2025-07-22, actively developed, ~218k★, image `nousresearch/hermes-agent:latest`
+   verified present), a genuine *alternative harness* to picoclaw.
+
+**This document is about #2** (confirmed with the requester). The name match with #1 is a coincidence.
+The requester's framing — *"outros harness além do picoclaw ... hermes agent especificamente"* — is
+read as: **(a)** introduce a harness-agnostic seam, with **(b)** the Nous product as the first
+concrete non-picoclaw target.
+
+---
+
+## 1. Hermes Agent — the external runtime (facts)
+
+| Aspect | Hermes Agent | picoclaw (today) |
+|---|---|---|
+| Image | `nousresearch/hermes-agent:latest` | `docker.io/sipeed/picoclaw:latest` |
+| Programmatic interface | **OpenAI-compatible HTTP API server** (`API_SERVER_ENABLED=true`) | Pico Protocol (JSON-over-WebSocket) |
+| Port | `8642` (`API_SERVER_PORT`, bind `API_SERVER_HOST=0.0.0.0`) | `18790` (`/pico/ws`) |
+| Auth | Bearer token, `API_SERVER_KEY` (≥8 chars) | WS subprotocol `token.<token>` |
+| Turn endpoint | `POST /v1/chat/completions` (also `/v1/responses`, `/api/sessions/{id}/chat`) | `message.send` frame over WS |
+| Streaming | SSE, standard `chat.completion.chunk` + custom `hermes.tool.progress` | Pico frames (`message.create/update`, `typing.*`) |
+| Health | `GET /health` → `{"status":"ok"}` (also `/v1/health`) | `GET /health` on `18790` |
+| Profile/data dir | single mount `/opt/data` (host `~/.hermes`): `config.yaml`, `.env`, `sessions/`, `skills/`, `memories/`, `state.db` | `<HOME>/.picoclaw/workspace/`: `config.json`, `.security.yml`, `AGENT.md`, `SOUL.md`, `memory/`, `skills/`, `sessions/` |
+| Session persistence | **SQLite `state.db` on disk** — full message history + metadata (FTS5), resumable by ID across restarts | **in-memory** SQLite; **resets on restart** (reason `continuous` mode exists) |
+| Non-root user | `hermes` UID 10000; host mapping via `PUID`/`PGID` or `HERMES_UID`/`HERMES_GID`; `HERMES_ALLOW_ROOT_GATEWAY=1` | `picoclawUser` (`1000:1000`), `HOME=<PicoclawHome>` |
+| Session scoping headers | `X-Hermes-Session-Id` (transcript namespace, rotates on /new), `X-Hermes-Session-Key` (stable long-term memory scope) | derived pico session id (`identity.SessionKey`) |
+| Provider keys | env / `.env` (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, any OpenAI-compatible endpoint) | written into `.security.yml` `model_list.<name>.api_keys` |
+
+**Two facts that drive the verdict (verified against Hermes docs):**
+
+- **Sessions are disk-backed and reloadable.** `state.db` lives inside the mounted profile and holds
+  full history + metadata; sessions resume by id. → A stop/start does **not** lose the transcript.
+- **Session headers map 1:1 onto the proxy's identity model.** `X-Hermes-Session-Key` = stable
+  per-`(user, agent)` scope (what the proxy already derives); `X-Hermes-Session-Id` = per-conversation
+  transcript. The proxy can drive both per turn.
+
+---
+
+## 2. Current coupling in `crab-shell-proxy` (why this is a refactor)
+
+The proxy has **no "harness kind" concept** — "agent" means "a picoclaw instance". picoclaw specifics
+are spread across five layers. Existing seams that a second harness can reuse **as-is**:
+
+- `Docker` interface + generic Engine-API client — `internal/docker/client.go` (fully harness-agnostic;
+  `CreateSpec` already has a generic `Cmd []string`).
+- `HealthChecker` func type — `internal/docker/manager.go:50` (pluggable; default assumes `/health`).
+- `Turner` interface — `internal/httpapi/handlers.go:92` (a "run a turn" seam — but its param names
+  `wsURL`/`picoToken` leak picoclaw).
+- Generic secret sinks `dotenv`/`json`/`file` — `internal/docker/secrets.go` (runtime-neutral; only the
+  `native` `.security.yml` sink is picoclaw-specific).
+- `Resolver` (identity) — `internal/identity/identity.go:48` (mycelium-coupled, harness-neutral).
+
+Where the work lands (no seam today):
+
+| Area | picoclaw-hardcoded today | Ref |
+|---|---|---|
+| **Config / agent kind** | no runtime discriminator; global `PicoclawImage/Port/User/Home`; `Model` maps to picoclaw `model_list` | `internal/config/config.go:92,170,275,487`; `config.yaml:26-68` |
+| **Container spec** | mount `<Home>/.picoclaw`; env `PICOCLAW_GATEWAY_HOST`; `PicoclawUser`; ws path `/pico/ws` | `internal/docker/manager.go:107,185-276` |
+| **Provisioning / config files** | `templateFiles = {config.json, .security.yml}`; writes `channel_list.pico`, `agents.defaults`, `model_list`; `pico-` token | `internal/docker/provision.go:24,89-138,159-194` |
+| **Wire protocol** | full Pico Protocol state machine (frames, `token.<t>` subprotocol, typing grace window) | `internal/pico/turn.go` (whole file) |
+| **History / sessions** | reads `*.jsonl`+`*.meta.json`, `direct:pico:` marker, `durable/` workaround for in-memory reset | `internal/history/history.go:20-117,155-184` |
+
+---
+
+## 3. What needs to be implemented
+
+### 3.1 Harness-agnostic seam (needed for *any* second runtime — interpretation-independent)
+
+1. **Runtime-kind discriminator** on the agent config: `harness: picoclaw | hermes` (default
+   `picoclaw` for back-compat). Move the global `Picoclaw*` fields into a per-harness profile
+   (`image`, `port`, `user`, `home`, `protocol`, `dataMount`, health path). `config.go`/`config.yaml`.
+2. **Generalize `Turner`** — rename `wsURL`/`picoToken` → transport-neutral `endpoint`/`authToken`;
+   make `Target` (`manager.go:52`) carry a generic endpoint+token instead of `WSEndpoint`/`PicoToken`.
+   Select the concrete turner by harness kind.
+3. **Harness-specific container-spec builder** — factor `create()` (`manager.go:185`) so mount path,
+   env, user, and health check come from the harness profile, not constants.
+4. **Harness-specific provisioner** — factor `provision.go` so the template file set and the
+   config-writing logic are per-harness.
+5. **Harness-specific history reader** — behind a small interface, or bypassed entirely for harnesses
+   whose transcripts are readable via API (see 3.2).
+
+### 3.2 Hermes-specific implementation (the concrete first target)
+
+Ordered easiest → hardest:
+
+1. **Turner = near-passthrough (BIG WIN).** The proxy's inbound API is *already* OpenAI-shaped
+   (`sse.go` emits `chat.completion.chunk`), and the original design even ran a `picoclaw-openai-proxy`
+   sidecar doing OpenAI↔Pico translation — now ported into `pico/turn.go`. For Hermes there is **no
+   translation**: forward to `POST http://<container>:8642/v1/chat/completions` with
+   `Authorization: Bearer <API_SERVER_KEY>` and stream the SSE straight through (dropping/relaying
+   `hermes.tool.progress`). This turner is *simpler* than the Pico one.
+2. **Container spec.** Image `nousresearch/hermes-agent:latest`; mount profile at `/opt/data`; env
+   `API_SERVER_ENABLED=true`, `API_SERVER_HOST=0.0.0.0`, `API_SERVER_PORT=8642`, `API_SERVER_KEY=<gen>`;
+   user via `PUID`/`PGID` (or `HERMES_UID`/`HERMES_GID`) → reuse existing `PicoclawUser`-style chown;
+   health `GET /health`.
+3. **Provisioning.** Template = `config.yaml` + `.env` (not `config.json`/`.security.yml`). Provider
+   API keys go into `.env` / env — which the **existing generic `dotenv` secret sink already covers**,
+   so the picoclaw-only `native` sink is simply not used for Hermes.
+4. **Session mapping.** Per turn, set `X-Hermes-Session-Key` = the proxy's stable per-`(user, agent)`
+   key and `X-Hermes-Session-Id` = the conversation id. No custom session-id-in-query hack.
+5. **History.** Two options: (a) read Hermes `state.db`/`sessions/` for the tree/history UI (new
+   format-specific reader), or (b) rely on Hermes server-side history + the proxy's own conversation
+   store. **The fragile `durable/` workaround is not needed** — Hermes persists to disk.
+
+### 3.3 Architectural payoffs unlocked by Hermes
+
+- **Scale-to-zero becomes the clean default** for Hermes: stop/start does not lose the transcript
+  (disk-backed `state.db`), so `continuous` mode + the in-memory-reset workaround are unnecessary.
+- **No sidecar** and **no bespoke wire protocol** — the OpenAI surface collapses the hardest layer.
+- Non-root UID 10000 + `PUID`/`PGID` is a direct analog of the existing `picoclawUser` handling.
+
+---
+
+## 4. Open questions / risks / dependencies
+
+- **OQ-1 — history strategy.** Does the tree/history UI need to read Hermes transcripts directly
+  (parse `state.db`/`sessions/`), or can it rely on the proxy's own conversation records + Hermes API?
+  Decides whether 3.2.5 is a new reader or a no-op. *(Recommend: proxy-owned records; treat Hermes as
+  stateless-per-turn via full `messages` array, or via `X-Hermes-Session-Id` resume.)*
+- **OQ-2 — model/provider config.** Confirm the exact `config.yaml` schema for pinning
+  provider+model (vs. `API_SERVER_MODEL_NAME`) so provisioning writes the right file. *(Fetch the
+  Hermes `configuration` + `docker` docs before implementing 3.2.3.)*
+- **OQ-3 — `state.db` robustness.** Upstream reports exist of `state.db` corruption / session-replay
+  token waste under heavy use (Hermes issue #5563). Validate under the per-`(user, agent)` container
+  model before relying on scale-to-zero in production.
+- **OQ-4 — resource footprint.** Hermes bundles browser automation/vision; docs suggest
+  `--shm-size=1g`, `--memory=4g`. Heavier than picoclaw → revisit per-container limits and the
+  scale-to-zero idle policy.
+- **Dependency — shared-workspaces / Go mycelium SDK.** Per project memory, some workspace/secret work
+  is gated on a Go mycelium SDK being built first. Confirm whether this refactor must wait on or
+  coordinate with that. (See STATE.md and the `shared-workspaces` spec.)
+- **Naming hygiene.** Because the repo already overloads "hermes" (the pattern), the config kind and
+  docs should use an unambiguous label (e.g. `harness: hermes-agent`) to avoid confusion with
+  `zero-scale-stateless-hermes-agent.md`.
+
+---
+
+## 5. Rough effort sizing (indicative, not a commitment)
+
+| Chunk | Size | Notes |
+|---|---|---|
+| Config harness-kind seam (3.1.1) | M | mechanical but touches config surface + defaults/back-compat |
+| Generalize `Turner`/`Target` (3.1.2) | S–M | rename + kind-based selection |
+| Container-spec builder split (3.1.3) | M | factor `create()` by harness profile |
+| Provisioner split (3.1.4) | M | template set + config writer per harness |
+| Hermes turner (3.2.1) | S | near-passthrough to `/v1/chat/completions` |
+| Hermes container + provisioning + sessions (3.2.2–3.2.4) | M | reuses generic dotenv sink + chown |
+| History reader / strategy (3.1.5 + 3.2.5) | M–L | depends on OQ-1 |
+
+**Bottom line:** the blocker was never the protocol — Hermes' OpenAI API makes that the easy part.
+The real cost is introducing the harness-kind abstraction the proxy lacks today (§3.1). Everything
+Hermes-specific then rides on existing seams (Docker client, dotenv secrets, chown, OpenAI SSE).
+
+---
+
+## 6. Sources & confidence
+
+**Confidence:** The `crab-shell-proxy` coupling map (§2) is grounded in the actual code (file:line refs
+verified). The **Hermes facts (§1) are research-grade, not tested against a running instance** —
+sourced from Hermes docs + GitHub on 2026-07-20. Existence ground-truthed: `NousResearch/hermes-agent`
+repo (created 2025-07-22, ~218k★) and image `nousresearch/hermes-agent:latest` both confirmed present.
+Behavioral claims (session persistence, header semantics, exact config schema) should be validated
+against a live container before implementation — see OQ-1..3.
+
+- Hermes docs: `https://hermes-agent.nousresearch.com/docs/` — API server (`/user-guide/features/api-server`),
+  Docker (`/user-guide/docker`), Sessions (`/user-guide/sessions`), Configuration (`/user-guide/configuration/`)
+- Hermes repo: `https://github.com/NousResearch/hermes-agent` (session-key PR #20199; robustness issue #5563)
+- Image: `https://hub.docker.com/r/nousresearch/hermes-agent`
+- picoclaw / Pico Protocol: `https://github.com/sipeed/picoclaw`, `https://docs.picoclaw.io/`

--- a/.specs/features/multi-harness-support/spec.md
+++ b/.specs/features/multi-harness-support/spec.md
@@ -1,0 +1,332 @@
+# multi-harness-support Specification
+
+## Problem Statement
+
+`crab-shell-proxy` orchestrates one agent runtime — **picoclaw** — and its coupling is baked into
+every layer: config field names (`PicoclawImage/Port/User/Home`), the container spec
+(`<HOME>/.picoclaw`, `PICOCLAW_GATEWAY_HOST`), the wire protocol (Pico Protocol over WebSocket), the
+provisioning file set (`config.json` + `.security.yml`), and the history reader (`*.jsonl` +
+`*.meta.json`, plus a `durable/` workaround for picoclaw's in-memory-session reset). "Agent" today
+means "a picoclaw instance" — there is **no notion of a harness kind**.
+
+We want the proxy to orchestrate **other agent runtimes alongside picoclaw**, with **Nous Research's
+Hermes Agent** (`nousresearch/hermes-agent`) as the first concrete target. Hermes fits the existing
+scale-to-zero model unusually well: it exposes an **OpenAI-compatible HTTP API server** (port 8642)
+and persists sessions to **disk** (`state.db`), so the two hardest layers (protocol, scale-to-zero)
+are *simpler* than for picoclaw. The work is introducing the harness-kind seam the proxy lacks and
+implementing the Hermes profile on top of it. See `investigation.md` for the full feasibility map.
+
+## Goals
+
+- [ ] A **harness-kind discriminator** per agent (`harness: picoclaw | hermes-agent`), defaulting to
+      `picoclaw`, so existing agents and behavior are unchanged (zero regression).
+- [ ] Per-harness **runtime profile** (image, port, data-mount path, container user, env, health
+      path, protocol) replacing the global `Picoclaw*` constants.
+- [ ] A signed-in user can chat end-to-end with a **Hermes-backed agent** through the proxy, with the
+      same per-`(agent, user)` container + volume isolation picoclaw already has.
+- [ ] Hermes turns run as a **near-passthrough** to Hermes' OpenAI-compatible `/v1/chat/completions`
+      (streaming + non-streaming), reusing the proxy's existing OpenAI SSE surface.
+- [ ] **Scale-to-zero is clean for Hermes**: stop/start preserves the transcript (disk-backed), so no
+      `continuous` mode and no `durable/` workaround are required for it.
+
+## Out of Scope
+
+| Feature | Reason |
+| --- | --- |
+| Porting picoclaw off the Pico Protocol | picoclaw keeps its existing turner unchanged; the seam is additive |
+| A third harness implementation | Validate the seam with Hermes first; extensibility is proven (P3), not built out |
+| Hermes native channels (Telegram/Discord/Slack/WhatsApp) ingress through the proxy | Same rationale as CTX-01 for picoclaw — those are the agent's own outbound channels |
+| Hermes web dashboard (port 9119) exposure | Not needed for the API chat path; would be a separate operator decision |
+| Building the Go mycelium SDK | Unchanged dependency; this feature consumes whatever profile mycelium injects |
+| Migrating existing picoclaw agents/data | picoclaw remains the default kind; no migration |
+| Kubernetes / non-Docker orchestration | Stack is docker-compose, matching the existing proxy |
+
+---
+
+## User Stories
+
+### P1: Harness-kind config seam (picoclaw unchanged) ⭐ MVP
+
+**User Story**: As the operator, I want to declare an agent's runtime kind in config so the proxy can
+orchestrate a non-picoclaw harness, without changing how existing picoclaw agents behave.
+
+**Why P1**: Nothing else can exist without a way to *select* a harness. This is the seam every other
+story rides on, and it must be back-compatible or it breaks the live stack.
+
+**Acceptance Criteria**:
+
+1. WHEN an agent entry omits `harness` THEN the system SHALL treat it as `picoclaw` and behave exactly
+   as today (image, mount, protocol, provisioning, history all unchanged).
+2. WHEN an agent entry sets `harness: hermes-agent` THEN the system SHALL resolve that agent's runtime
+   profile (image, port, data-mount, user, env, health path, protocol) from the Hermes profile rather
+   than the picoclaw constants.
+3. WHEN an agent entry sets an unknown `harness` value THEN the system SHALL fail fast at config load
+   with a clear error, not at first request.
+4. WHEN the proxy runs the existing picoclaw agents (alpha/beta) after this change THEN their build,
+   unit tests, and runtime behavior SHALL be unchanged (regression guard).
+
+**Independent Test**: Load config with `alpha` (no `harness`) and a new `hermes-x`
+(`harness: hermes-agent`); the picoclaw test suite passes untouched and config validation accepts both;
+an unknown kind is rejected at load.
+
+---
+
+### P1: On-demand Hermes container lifecycle ⭐ MVP
+
+**User Story**: As a signed-in user calling a Hermes-backed agent, I want my own isolated Hermes
+container started on first request and reused after, so my agent state is private to me.
+
+**Why P1**: The core spin-up/isolation slice for the new harness — the picoclaw analog of CSP-01/02/05.
+
+**Acceptance Criteria**:
+
+1. WHEN a chat request arrives for a `hermes-agent` agent `A` and principal email `E` THEN the system
+   SHALL target container `<prefix>-<A>-<userhash>` and create/start it if absent, using image
+   `nousresearch/hermes-agent:latest`, the per-user profile mounted at `/opt/data`, env
+   `API_SERVER_ENABLED=true`, `API_SERVER_HOST=0.0.0.0`, `API_SERVER_PORT=8642`, and a generated
+   `API_SERVER_KEY`.
+2. WHEN the Hermes container is started THEN the system SHALL run it as the non-root `hermes` user
+   (UID 10000) via `PUID`/`PGID` (or `HERMES_UID`/`HERMES_GID`) and chown the per-user dir to that
+   uid, reusing the existing `picoclawUser`-style handling.
+3. WHEN a Hermes container is starting THEN the system SHALL wait until `GET /health` returns
+   `{"status":"ok"}` on port 8642 before proxying, within the configured startup deadline.
+4. WHEN two different principal emails call the same Hermes agent THEN the system SHALL route each to a
+   distinct container + `/opt/data` volume (no cross-user state).
+
+**Independent Test**: With a profile for `alice@x`, POST to the Hermes agent's chat route; observe
+`<prefix>-hermes-x-<hash(alice)>` come up via `docker ps` and become health-ready. Repeat for `bob@x`;
+observe a second, separate container + volume.
+
+---
+
+### P1: Hermes turn via OpenAI passthrough ⭐ MVP
+
+**User Story**: As a signed-in user, I want my chat turn forwarded to the Hermes API server and the
+reply streamed back, so I can actually converse with the agent.
+
+**Why P1**: Without running a turn there is no feature. This is where Hermes is *simpler* than
+picoclaw — no bespoke protocol.
+
+**Acceptance Criteria**:
+
+1. WHEN a turn runs against a `hermes-agent` container THEN the system SHALL POST to
+   `http://<container>:8642/v1/chat/completions` with `Authorization: Bearer <API_SERVER_KEY>` and the
+   OpenAI request body, rather than opening a Pico Protocol WebSocket.
+2. WHEN the request sets `stream: true` THEN the system SHALL relay Hermes' SSE `chat.completion.chunk`
+   events through the proxy's existing SSE surface unchanged, and terminate with `data: [DONE]`.
+3. WHEN Hermes emits `hermes.tool.progress` events THEN the system SHALL handle them without corrupting
+   the OpenAI stream (relay or drop — decided in design).
+4. WHEN a turn runs THEN the shared `Turner`/`Target` contract SHALL carry a transport-neutral
+   endpoint + auth token (not the picoclaw-specific `wsURL`/`picoToken`), selected by harness kind.
+
+**Independent Test**: Send a streaming and a non-streaming chat completion to a Hermes agent; both
+return a real model reply in OpenAI shape; the picoclaw path still returns via Pico-WS.
+
+---
+
+### P1: Hermes provisioning + session identity ⭐ MVP
+
+**User Story**: As the operator, I want a Hermes agent's per-user profile seeded and its provider key
+injected the first time a user chats, and I want the user's conversations scoped correctly.
+
+**Why P1**: A container that can't authenticate to a model or that leaks sessions across users is not
+usable. This is the picoclaw analog of provisioning + session isolation.
+
+**Acceptance Criteria**:
+
+1. WHEN a Hermes user's profile is first created THEN the system SHALL seed the flat default-profile
+   template (`config.yaml`, `SOUL.md`, `memories/`, custom `skills/`) into `/opt/data`, copying only on
+   first provision, and SHALL NOT seed runtime/isolation state (`sessions/`, `state.db*`, `logs/`,
+   `cache/`, `*_cache.json`, `auth.json`/`auth.lock`, `bin/`, `sandboxes/`).
+2. WHEN a Hermes agent pins a provider/model THEN the system SHALL write `model.default`,
+   `model.provider`, and **`model.base_url`** into `config.yaml`, and inject the provider key via the
+   generic env/`dotenv` sink under the **provider-specific env name** the agent declares (e.g.
+   `GLM_API_KEY` for `provider: zai`) — NOT the picoclaw-only `native` `.security.yml` sink.
+3. WHEN a turn runs THEN the system SHALL set `X-Hermes-Session-Key` to the stable per-`(user, agent)`
+   scope the proxy already derives, and `X-Hermes-Session-Id` to the conversation id.
+4. WHEN two conversations for the same user run THEN each SHALL use a distinct `X-Hermes-Session-Id`
+   (isolated transcript) while sharing the same `X-Hermes-Session-Key` (long-term memory scope).
+
+**Independent Test**: First chat seeds `/opt/data` and the key lands in `.env`; two conversations for
+one user stay separate; a second user is fully isolated.
+
+---
+
+### P2: Scale-to-zero for Hermes (no continuous, no durable workaround)
+
+**User Story**: As the operator, I want idle Hermes containers to stop and cold-start cleanly with the
+transcript intact, so Hermes gets scale-to-zero without picoclaw's in-memory caveat.
+
+**Why P2**: A valuable simplification, but the P1 slice (chat works) is demonstrable first.
+
+**Acceptance Criteria**:
+
+1. WHEN a `hermes-agent` container is stopped by the idle timer and later cold-started THEN the user's
+   prior conversation history SHALL still be present and resumable (disk-backed `state.db`).
+2. WHEN a Hermes agent is configured `continuous` THEN it SHALL still work, but continuous SHALL NOT be
+   required for correctness (unlike picoclaw, whose in-memory session forces it).
+3. WHEN turns run for a Hermes agent THEN the proxy SHALL still maintain a durable proxy-owned
+   append-only transcript (the same hybrid pattern as picoclaw, OQ-1) — here as a safety net that also
+   mitigates Hermes `state.db` corruption (OQ-3), not because of an in-memory reset.
+
+**Independent Test**: Set a short idle timeout on a Hermes agent, chat, let it stop, chat again —
+history is intact and no `durable/` files were needed.
+
+---
+
+### P2: Hermes history/`/v1/sessions/history` parity
+
+**User Story**: As the existing chat-webapp, I want conversation history for Hermes agents to render
+the same way it does for picoclaw, so the client needs no per-harness special-casing.
+
+**Why P2**: Parity avoids client churn. OQ-1 is **resolved**: use the **same hybrid, file-based
+strategy as picoclaw** (durable proxy-owned transcript + read from the harness's on-disk session
+store), adapted to Hermes' on-disk format.
+
+**Acceptance Criteria**:
+
+1. WHEN `GET /v1/sessions/history` is called for a Hermes conversation THEN the system SHALL return
+   that conversation's messages for the correct user, read from Hermes' on-disk session store under
+   `/opt/data` (`state.db` / `sessions/`), preferring the durable proxy-owned transcript when present
+   and falling back to Hermes' own files — mirroring picoclaw's `Read()` precedence.
+2. WHEN history is read for a Hermes agent THEN a **harness-appropriate on-disk reader** SHALL be used
+   behind the history seam (Hermes stores full history in SQLite `state.db`, NOT picoclaw's
+   `*.jsonl`/`*.meta.json`); the picoclaw reader SHALL NOT be assumed.
+3. WHEN a turn passes through the proxy THEN the proxy MAY build the durable transcript directly from
+   the passthrough traffic (it sees every user/assistant message), avoiding any dependency on parsing
+   Hermes internals for the durable copy.
+
+**Independent Test**: Chat with a Hermes agent, reload the webapp, history renders identically to a
+picoclaw agent with no client change; after a stop/cold-start the durable transcript still returns the
+full conversation even if `state.db` is unavailable.
+
+---
+
+### P3: Extensible to further OpenAI-compatible harnesses
+
+**User Story**: As the operator, I want a future OpenAI-compatible runtime to be addable mostly by
+config + a small profile, so the seam proves general, not Hermes-specific.
+
+**Why P3**: Confidence in the abstraction; not required to ship Hermes.
+
+**Acceptance Criteria**:
+
+1. WHEN a new OpenAI-compatible harness is added THEN it SHALL reuse the generic Docker client, the
+   OpenAI passthrough turner, the `dotenv` secret sink, and the health-check seam, requiring only a new
+   runtime profile (+ provisioner if its config format differs).
+
+---
+
+## Edge Cases
+
+- WHEN a Hermes cold start exceeds the startup deadline (never health-ready) THEN the system SHALL fail
+  the request `502` and not leak a half-started container (parity with CSP-17).
+- WHEN two concurrent requests for the same `(hermes agent, user)` arrive during a cold start THEN the
+  system SHALL single-flight the start exactly once (parity with CSP-15).
+- WHEN `API_SERVER_KEY` is missing/too short (<8 chars) THEN the system SHALL generate a valid key at
+  provision, never start a Hermes container without auth.
+- WHEN a config sets `harness: hermes-agent` but also picoclaw-only fields (e.g. a `native` secret
+  slot) THEN the system SHALL reject or ignore them with a clear message (no silent misconfig).
+- WHEN Hermes' `state.db` is corrupt on cold start (upstream issue #5563) THEN the system SHALL surface
+  a clear error rather than silently serving an empty/wrong transcript.
+- WHEN the Docker daemon is unreachable THEN behavior SHALL match the existing picoclaw path (`502`,
+  proxy stays up).
+
+---
+
+## Requirement Traceability
+
+| Requirement ID | Story | Phase | Status |
+| --- | --- | --- | --- |
+| MHS-01 | P1: `harness` discriminator, default picoclaw | - | Pending |
+| MHS-02 | P1: per-harness runtime profile resolution | - | Pending |
+| MHS-03 | P1: unknown harness rejected at config load | - | Pending |
+| MHS-04 | P1: picoclaw regression guard (unchanged) | - | Pending |
+| MHS-05 | P1: Hermes container create/start (image/mount/env) | - | Pending |
+| MHS-06 | P1: Hermes non-root user (UID 10000 / PUID-PGID) | - | Pending |
+| MHS-07 | P1: Hermes `/health` health-wait | - | Pending |
+| MHS-08 | P1: Hermes per-user container + volume isolation | - | Pending |
+| MHS-09 | P1: Hermes turn = OpenAI passthrough to :8642 | - | Pending |
+| MHS-10 | P1: SSE relay parity (chunks + [DONE]) | - | Pending |
+| MHS-11 | P1: `hermes.tool.progress` handling | - | Pending |
+| MHS-12 | P1: transport-neutral Turner/Target contract | - | Pending |
+| MHS-13 | P1: Hermes template seed (config.yaml/.env), first-provision-only | - | Pending |
+| MHS-14 | P1: provider key via generic dotenv sink | - | Pending |
+| MHS-15 | P1: X-Hermes-Session-Key / X-Hermes-Session-Id mapping | - | Pending |
+| MHS-16 | P2: Hermes scale-to-zero, transcript intact, no durable workaround | - | Pending |
+| MHS-17 | P2: continuous supported but not required for Hermes | - | Pending |
+| MHS-18 | P2: Hermes history parity (strategy per OQ-1) | - | Pending |
+| MHS-19 | P3: extensible to further OpenAI-compatible harnesses | - | Pending |
+| MHS-20 | Edge: startup-deadline / single-flight / API_SERVER_KEY / state.db-corrupt / daemon-down | - | Pending |
+
+**Status values:** Pending → In Design → In Tasks → Implementing → Verified
+**Coverage:** 20 total, 0 mapped to tasks ⚠️ (spec phase)
+
+---
+
+## Open Questions
+
+- **OQ-1 — history strategy — RESOLVED (2026-07-20):** use the **same hybrid, file-based strategy as
+  picoclaw** — a durable proxy-owned append-only transcript preferred over reading the harness's own
+  on-disk session store. For Hermes the on-disk source is SQLite `state.db` (+ `sessions/`) under
+  `/opt/data`, so the reader is harness-specific (SQLite, not jsonl). See MHS-18.
+
+- **OQ-2 — Hermes `config.yaml`/env schema — RESOLVED (2026-07-20)** by inspecting a real
+  `nousresearch/hermes-agent` profile (GLM/z.ai key, one CLI turn). Confirmed facts:
+  1. **Model pin** (`config.yaml`):
+     ```yaml
+     model:
+       default: glm-4.7-flash        # plain model name (NOT a provider/model slug for zai)
+       provider: zai
+       base_url: https://api.z.ai/api/paas/v4   # REQUIRED for OpenAI-compatible providers
+     ```
+     → the proxy's per-agent model config must carry **`base_url`** too (today's `ModelConfig` only
+     has provider/name/apiKeyEnv — add `base_url`).
+  2. **Provider key env** (`.env`): `GLM_API_KEY=…`. The env name is **provider-specific and not
+     derivable from the provider string** ("zai" → `GLM_API_KEY`); it comes from Hermes' provider
+     registry (`cache/model_catalog.json`). → each Hermes agent config must declare the in-container
+     env var name to inject the key under (MHS-14). Injecting via container `-e` is simpler than
+     writing `.env`.
+  3. **API server is env-driven** — confirmed: no top-level `api_server` section; only
+     `gateway.api_server.max_concurrent_runs`. Enable/host/port/key are env (`API_SERVER_*`), so the
+     container spec (MHS-05) is correct. Note request-level `stream:true` drives SSE; the top-level
+     `streaming.enabled` governs platform edit-in-place, not the API.
+  4. **Seed allowlist** — first-provision seed: `config.yaml`, `.env` (or inject key via env), `SOUL.md`,
+     `memories/`, and custom `skills/` (bundled skills are populated by the image itself). **NEVER
+     seed** (isolation/runtime): `sessions/`, `state.db*`, `logs/`, `cache/`, `*_cache.json`,
+     `auth.json`/`auth.lock`, `bin/`, `sandboxes/`, `workspace/` runtime state.
+  5. **Data-dir layout** — **flat**: the default profile lives directly at `/opt/data`
+     (`/opt/data/{config.yaml,.env,SOUL.md,memories/,skills/,sessions/,state.db}`). Named profiles
+     would go under `/opt/data/profiles/<name>/`. One per-user container → use the flat default profile.
+  6. **History schema** (SQLite `state.db`, schema_version 16):
+     - `sessions(id TEXT PK, source, user_id, model, system_prompt, title, started_at REAL,
+       ended_at REAL, message_count, parent_session_id, archived, …)`. `id` = `YYYYMMDD_HHMMSS_<hex>`
+       (`source='cli'` → 6-hex, api/gateway → 8-hex). `parent_session_id` supports rewind/branching.
+     - `messages(id INTEGER PK, session_id → sessions.id, role, content, tool_call_id, tool_calls,
+       tool_name, timestamp REAL, finish_reason, reasoning*, active, compacted, observed)`, index
+       `(session_id, timestamp)`. FTS5 mirror tables exist for `session_search`.
+     - **History reader query** (OQ-1/MHS-18): `SELECT role, content, timestamp FROM messages WHERE
+       session_id=? AND active=1 AND role IN ('user','assistant') AND content IS NOT NULL AND
+       content<>'' ORDER BY timestamp;` (skip `tool`/empty rows, mirroring picoclaw's filter).
+
+  *Report:* `/tmp/hermess-setup/hermes-report.txt` (operator's machine).
+
+- **OQ-3 — `state.db` robustness under the per-user container model** (informs MHS-16.3, MHS-20 edge).
+  Mitigated in part by the durable proxy-owned transcript (OQ-1).
+- **OQ-4 — resource footprint** (informs idle policy): Hermes bundles browser/vision;
+  `--shm-size=1g`, higher memory limits may be needed.
+- **Dependency** — coordinate with `shared-workspaces` / the Go mycelium SDK where workspace/secret
+  seeding overlaps.
+
+---
+
+## Success Criteria
+
+- [ ] A signed-in user chats end-to-end with a `hermes-agent` agent through the proxy (streaming +
+      non-streaming), with per-user container + volume isolation verified via `docker ps`.
+- [ ] Existing picoclaw agents (alpha/beta) build, test, and run unchanged (zero regression).
+- [ ] A Hermes agent scale-to-zero stops on idle and cold-starts with history intact, using no
+      `durable/` workaround.
+- [ ] The provider key reaches Hermes via `.env`/env (generic sink), never via `.security.yml`.
+- [ ] Two conversations for one user stay isolated (distinct `X-Hermes-Session-Id`) while sharing
+      long-term memory scope (same `X-Hermes-Session-Key`).

--- a/.specs/features/multi-harness-support/spec.md
+++ b/.specs/features/multi-harness-support/spec.md
@@ -1,5 +1,18 @@
 # multi-harness-support Specification
 
+**Status (2026-07-21):** P1 "chat works with a Hermes-backed agent" slice **implemented** in
+`crab-shell-proxy` (working tree; not yet committed). Implementation design/tasks live in the
+submodule: `crab/crab-shell-proxy/.specs/features/multi-harness-support/{design.md,tasks.md}`.
+`go build`/`go vet` green; new hermes turner unit tests pass; the `internal/docker` chown tests
+fail only on a pre-existing sandbox `chown` permission limit (not a regression); live E2E is
+operator-gated.
+
+**Project changes since this spec was written:** the proxy advanced to model-registry /
+model-override / auto-bootstrap, and already scaffolded harness-awareness
+(`defaulttemplate/<harness>/`, `materializeDefaultTemplate(dst, harness, user)` with a "thread
+the harness once multi-harness lands" TODO) — the implementation builds on that seam. New config
+surface: `Agent.harness`, `ModelConfig.baseUrl` + `keyEnvName`, `Config.hermesImage`.
+
 ## Problem Statement
 
 `crab-shell-proxy` orchestrates one agent runtime — **picoclaw** — and its coupling is baked into
@@ -260,7 +273,17 @@ config + a small profile, so the seam proves general, not Hermes-specific.
 | MHS-20 | Edge: startup-deadline / single-flight / API_SERVER_KEY / state.db-corrupt / daemon-down | - | Pending |
 
 **Status values:** Pending → In Design → In Tasks → Implementing → Verified
-**Coverage:** 20 total, 0 mapped to tasks ⚠️ (spec phase)
+**Coverage (2026-07-21):** MHS-01,02,05,06,07,08,09,10,11,12,13,14,15 — **Implemented** in the
+submodule P1 slice (build/vet green; hermes turner unit-tested; picoclaw path exercised at the
+httpapi layer, manager-level assertions compile but don't execute in-sandbox due to the pre-existing
+`chown` limit; live E2E operator-gated). Deferred: MHS-16,17,18 (lifecycle + Hermes history),
+MHS-19 (further harnesses), MHS-20 edges partially (startup-deadline/single-flight reused from
+picoclaw; API_SERVER_KEY ≥8 satisfied by the 48-char generated key).
+
+**Known follow-up risk:** the Hermes model reaches its container via `agent.Model`
+(`baseUrl`/`keyEnvName` intact) on the P1 path. If a future Hermes model-override reconstructs a
+provider/name-only `ModelConfig`, it would drop `base_url`/`keyEnvName` and silently break — wire
+those through before enabling model-override for Hermes.
 
 ---
 

--- a/.specs/project/ROADMAP.md
+++ b/.specs/project/ROADMAP.md
@@ -128,3 +128,13 @@ Telegram / MS Teams channels.
   lane and each message is a dot, reconciling the agent's continuous per-session
   transcript with the web's recency-first list. Visualization only (no
   `parent_id`/fork). See `.specs/features/conversation-tree-view/`.
+- **canvas-timeline-view** (SPEC READY) — an alternative, graphics-forward
+  "Canvas" mode (workspace-level `Traditional | Canvas` toggle, `view=canvas` in
+  the fragment) whose sole view is a left→right timeline: one lane per
+  conversation on a shared time axis, activity bursts as dots (same colors as the
+  tree), an aggregate "agent pulse" strip above, and a pixel-art grid backdrop —
+  conveying the agent's intelligence evolving over time. Preview-on-click with
+  Solo + hand-off to the traditional chat. Webapp-only (reuses `created_at` from
+  conversation-tree-view; no proxy change). Feel-first prototype validated
+  (Timeline chosen over Deck/Tree metaphors). See
+  `.specs/features/canvas-timeline-view/`.

--- a/.specs/project/STATE.md
+++ b/.specs/project/STATE.md
@@ -1,6 +1,6 @@
 # State
 
-**Last Updated:** 2026-07-16T00:00:00-03:00
+**Last Updated:** 2026-07-20T00:00:00-03:00
 **Current Work:** chat-webapp UI refactor (`chat-ui-material-refactor`) -- MUI+Emotion fully ripped
 out, replaced with Tailwind v4 + class-variance-authority; two-rail shell (nav drawer + conditional
 history drawer + chat view) on a single `/chat` route; workspaces deduped/grouped by tenant→account→
@@ -11,6 +11,30 @@ still operator-gated (needs the backend stack). M4 (crab-shell-proxy) live-conta
 ---
 
 ## Recent Decisions (Last 60 days)
+
+### AD-011: picoclaw has NO file-based agent/subagent injection — agents are config-registered (2026-07-20)
+
+**Finding (verified against upstream `sipeed/picoclaw` source + docs):** In picoclaw, **skills**
+are discovered from directories — `~/.picoclaw/workspace/skills/<name>/SKILL.md` (workspace) →
+`~/.picoclaw/skills` (global) → builtin — so a skill is droppable as a read-only directory and fits
+the `admin-shared-content` cascade pattern exactly. **Agents/subagents are NOT files.** They are
+entities **registered via `config.json`** (the `agents` block: id/name/description, per-agent
+workspace, `agents.dispatch.rules`, and `spawn` permissions); a "subagent" is another configured
+agent a parent may `spawn` (`pkg/agent/discovery.go` `AgentRegistry`, `ListSpawnableAgents`). There
+is **no `.claude/agents/*.md` (Claude-Code-style) discovery directory** in picoclaw. In
+`crab-shell-proxy` each agent = its own per-user container.
+
+**Consequence:** "inject a harness-native agent via the admin screen, like files/secrets" does **not**
+map onto the read-only file-cascade. It would require per-tenant/subscription **merging of the
+picoclaw `agents` config** (+ workspace/routing/spawn provisioning) — a much larger feature that
+overlaps the proxy's existing `agent-customization`/`shared-workspaces` specs and the pending Go
+mycelium SDK dependency.
+
+**Decision:** The `admin-shared-skills` feature (2026-07-20) ships **skills only** at tenant/
+subscription scope (clean fit). **Admin-provisioned agents are explicitly deferred** to a separate
+future feature with its own design. Do not attempt to model agents as injectable markdown files.
+
+Sources: github.com/sipeed/picoclaw; deepwiki.com/sipeed/picoclaw/2.2-configuration-guide.
 
 ### AD-010: chat-webapp migrated MUI+Emotion → Tailwind v4 + cva; two-rail workspace shell (2026-07-16)
 

--- a/.specs/project/STATE.md
+++ b/.specs/project/STATE.md
@@ -157,6 +157,15 @@ invite -> `protectedByRoles` cutover) is unchanged, still not done.
 
 ---
 
+### L-ENV: `yarn build`/`next dev` blocked locally by root-owned `.next` (2026-07-20)
+The webapp's `.next/` holds files owned by `root` from a prior in-container build,
+so `yarn build` and `next dev` fail with `EACCES: unlink .next/server/...` and
+can't be removed without sudo. Use `npx tsc --noEmit` for the type-check gate and
+`yarn test` (vitest) for tests. `next lint` is also unconfigured (interactive
+prompt). Runtime/visual verification of webapp features therefore needs the full
+stack (docker-compose + magic-link) or a `.next` chown. Surfaced while
+implementing canvas-timeline-view.
+
 ### AD-007 (superseded by AD-008): Migrated mycelium-gateway to base mode (Postgres) to create the first Staff account (2026-07-13)
 
 **Decision:** Replaced `standalone` (SQLite) with `base` mode (Postgres, default `postgres-backend`

--- a/README.md
+++ b/README.md
@@ -126,21 +126,25 @@ git clone --recurse-submodules https://github.com/LepistaBioinformatics/zombie-c
 cd zombie-crab-project
 ```
 
-**2. Seed one config-only template per agent (non-interactive).** PicoClaw
-scaffolds a default `config.json` on first run in an empty dir and exits — no
-prompts:
+**2. (Optional) Pre-seed a template per agent.** You can skip this — the proxy
+**auto-bootstraps** a default picoclaw template the first time a user chats if
+`data/templates/<agent>/` is missing, so a fresh checkout works out of the box.
+Pre-seed only when you want a **custom persona/skills** from the start:
 
 ```bash
 for a in alpha beta; do
-  mkdir -p "data/agents/templates/$a"
-  docker run --rm -v "$PWD/data/agents/templates/$a":/root/.picoclaw \
+  mkdir -p "data/templates/$a"
+  docker run --rm -v "$PWD/data/templates/$a":/root/.picoclaw \
     docker.io/sipeed/picoclaw:latest >/dev/null 2>&1 || true
 done
 ```
 
-crab-shell-proxy clones this template into each new user's dir and injects the
-provider/model, a fresh pico-channel token, and the API key at provisioning
-time — so the template stays a bare, secret-free scaffold.
+crab-shell-proxy clones the template (yours or the embedded default) into each
+new user's dir and injects the provider/model, a fresh pico-channel token, and
+the API key at provisioning time — so the template stays a bare, secret-free
+scaffold. See [Creating a Custom Agent](./docs/CREATE_CUSTOM_AGENT.md) to shape
+a template, and [Running and resetting from scratch](#running-and-resetting-from-scratch)
+for the self-heal behavior.
 
 **3. Configure `.env`.** Copy `.env.example` to `.env` and set:
 
@@ -181,6 +185,44 @@ cold-starts *your own* container; `docker ps` will show
 > (`http://localhost:${MYCELIUM_WEBAPP_PORT:-8081}`) — Mycelium's own admin UI —
 > via the Staff → tenant → subscription → guest-invite flow.
 
+## Running and resetting from scratch
+
+The walkthrough above brings up a clean stack. To **reset an existing
+environment to zero** — wipe every per-user agent and all templates, and let the
+stack rebuild itself — stop the stack, remove the proxy-spawned containers, wipe
+the on-disk state, and rebuild:
+
+```bash
+docker compose down
+docker rm -f $(docker ps -aq --filter 'name=picoclaw') 2>/dev/null   # agents spawned outside compose
+
+# on-disk state is owned by the spawned (non-root) agents -> sudo
+sudo rm -rf data/templates data/tenants data/effective-secrets \
+            data/effective-skills data/user-secrets data/registered-models
+
+docker compose up -d --build   # --build is REQUIRED: the fallback template is baked into the proxy binary
+```
+
+Then sign in and send a message — the proxy re-provisions your user from
+scratch. The Postgres volume (Mycelium accounts/roles) is **separate** and is
+not wiped, so your login survives; add `-v` to `docker compose down` only if you
+also want to reset accounts (you'd then re-run the Staff bootstrap).
+
+**Why no manual recovery is needed:** the proxy **auto-bootstraps** a missing
+`data/templates/<agent>/` from a default template **embedded in its binary**, so
+a wiped `data/` self-heals on the next chat — no `picoclaw onboard` step. The
+per-agent model and key are re-applied from `config.yaml` + `.env` on every
+provision, so the agent also responds again immediately. To customize the
+embedded default, edit
+`crab/crab-shell-proxy/internal/docker/defaulttemplate/<harness>/` (today:
+`picoclaw`) and rebuild.
+
+## Day-2 administration
+
+Managing models, shared skills, shared secrets, files, members, and branding is
+done from the **chat-webapp admin area** — see the
+[Admin Guide](./docs/ADMIN_GUIDE.md).
+
 ## What's in this repo
 
 ```
@@ -194,15 +236,18 @@ fungi/                     # the mycelium side (gateway + its admin UI)
     Dockerfile.standalone  # builds mycelium-api from upstream git (no local source)
     config.standalone.toml # gateway routes for picoclaw-alpha / picoclaw-beta
   mycelium-webapp/         # Dockerfile for Mycelium's own admin UI (from upstream git)
-docs/                      # task guides (e.g. creating a custom agent)
-data/agents/               # per-agent templates + per-user volumes (gitignored)
+docs/                      # task guides (creating a custom agent · admin guide)
+data/                      # per-agent templates + per-user volumes + shared material (gitignored)
+  templates/<agent>/       #   template cloned into each new user (auto-bootstrapped if missing)
+  tenants/…                #   per-(agent,user) isolated volumes
 ```
 
 `crab-shell-proxy` is a submodule with its own
 [README](./crab/crab-shell-proxy/README.md) going deeper on the isolation model.
 
-The [`docs/`](./docs/) folder holds guides for common tasks — start with
-[**Creating a Custom Agent**](./docs/CREATE_CUSTOM_AGENT.md).
+The [`docs/`](./docs/) folder holds guides for common tasks —
+[**Creating a Custom Agent**](./docs/CREATE_CUSTOM_AGENT.md) and the
+[**Admin Guide**](./docs/ADMIN_GUIDE.md) (models, skills, secrets, members).
 
 ## Before you take this to production
 

--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -127,20 +127,26 @@ git clone --recurse-submodules https://github.com/LepistaBioinformatics/zombie-c
 cd zombie-crab-project
 ```
 
-**2. Semeie um template config-only por agente (não-interativo).** O PicoClaw
-gera um `config.json` default no primeiro boot num dir vazio e sai — sem prompts:
+**2. (Opcional) Pré-semeie um template por agente.** Você pode pular — o proxy
+faz **auto-bootstrap** de um template picoclaw default na primeira vez que um
+usuário conversa, caso `data/templates/<agente>/` não exista; então um checkout
+novo já funciona. Pré-semeie só quando quiser uma **persona/skills customizadas**
+desde o início:
 
 ```bash
 for a in alpha beta; do
-  mkdir -p "data/agents/templates/$a"
-  docker run --rm -v "$PWD/data/agents/templates/$a":/root/.picoclaw \
+  mkdir -p "data/templates/$a"
+  docker run --rm -v "$PWD/data/templates/$a":/root/.picoclaw \
     docker.io/sipeed/picoclaw:latest >/dev/null 2>&1 || true
 done
 ```
 
-O crab-shell-proxy clona esse template no dir de cada novo usuário e injeta o
-provider/model, um token de canal pico novo e a chave de API no
-provisionamento — então o template continua um scaffold cru e sem segredos.
+O crab-shell-proxy clona o template (o seu ou o default embutido) no dir de cada
+novo usuário e injeta o provider/model, um token de canal pico novo e a chave de
+API no provisionamento — então o template continua um scaffold cru e sem
+segredos. Veja [Criando um Agente Customizado](./docs/CREATE_CUSTOM_AGENT.pt-br.md)
+para moldar um template, e [Rodando e resetando do zero](#rodando-e-resetando-do-zero)
+para o comportamento de auto-recuperação.
 
 **3. Configure o `.env`.** Copie `.env.example` para `.env` e defina:
 
@@ -181,6 +187,44 @@ o cold-start do *seu próprio* container; o `docker ps` mostrará
 > (`http://localhost:${MYCELIUM_WEBAPP_PORT:-8081}`) — a UI de admin do próprio
 > Mycelium — via o fluxo Staff → tenant → subscription → guest-invite.
 
+## Rodando e resetando do zero
+
+O passo-a-passo acima sobe uma stack limpa. Para **resetar um ambiente
+existente do zero** — apagar todo agente por-usuário e todos os templates, e
+deixar a stack se reconstruir — derrube a stack, remova os containers que o
+proxy criou, apague o estado em disco e rebuilde:
+
+```bash
+docker compose down
+docker rm -f $(docker ps -aq --filter 'name=picoclaw') 2>/dev/null   # agentes criados fora do compose
+
+# o estado em disco pertence aos agentes (não-root) spawnados -> sudo
+sudo rm -rf data/templates data/tenants data/effective-secrets \
+            data/effective-skills data/user-secrets data/registered-models
+
+docker compose up -d --build   # --build é OBRIGATÓRIO: o template de fallback é embutido no binário do proxy
+```
+
+Depois logue e mande uma mensagem — o proxy re-provisiona seu usuário do zero. O
+volume do Postgres (contas/roles do Mycelium) é **separado** e não é apagado,
+então seu login sobrevive; adicione `-v` ao `docker compose down` só se quiser
+resetar contas também (aí você refaz o bootstrap de Staff).
+
+**Por que não é preciso recuperação manual:** o proxy faz **auto-bootstrap** de
+um `data/templates/<agente>/` ausente a partir de um template default **embutido
+no binário**, então um `data/` apagado se recupera sozinho no próximo chat — sem
+`picoclaw onboard`. O modelo e a chave por-agente são reaplicados do
+`config.yaml` + `.env` em todo provisionamento, então o agente também volta a
+responder na hora. Para customizar o default embutido, edite
+`crab/crab-shell-proxy/internal/docker/defaulttemplate/<harness>/` (hoje:
+`picoclaw`) e rebuilde.
+
+## Administração dia-a-dia
+
+Gerenciar modelos, skills compartilhadas, secrets compartilhados, arquivos,
+membros e branding é feito pela **área de admin do chat-webapp** — veja o
+[Guia do Administrador](./docs/ADMIN_GUIDE.pt-br.md).
+
 ## O que há neste repositório
 
 ```
@@ -194,15 +238,18 @@ fungi/                     # o lado mycelium (gateway + sua UI de admin)
     Dockerfile.standalone  # builda o mycelium-api do git upstream (sem fonte local)
     config.standalone.toml # rotas do gateway para picoclaw-alpha / picoclaw-beta
   mycelium-webapp/         # Dockerfile da UI de admin do Mycelium (do git upstream)
-docs/                      # guias de tarefas (ex.: criar um agente customizado)
-data/agents/               # templates por-agente + volumes por-usuário (gitignored)
+docs/                      # guias de tarefas (criar um agente customizado · guia de admin)
+data/                      # templates por-agente + volumes por-usuário + material compartilhado (gitignored)
+  templates/<agente>/      #   template clonado em cada novo usuário (auto-bootstrap se ausente)
+  tenants/…                #   volumes isolados por-(agente,usuário)
 ```
 
 O `crab-shell-proxy` é um submódulo com seu próprio
 [README](./crab/crab-shell-proxy/README.md) detalhando o modelo de isolamento.
 
-A pasta [`docs/`](./docs/) reúne guias para tarefas comuns — comece por
-[**Criando um Agente Customizado**](./docs/CREATE_CUSTOM_AGENT.pt-br.md).
+A pasta [`docs/`](./docs/) reúne guias para tarefas comuns —
+[**Criando um Agente Customizado**](./docs/CREATE_CUSTOM_AGENT.pt-br.md) e o
+[**Guia do Administrador**](./docs/ADMIN_GUIDE.pt-br.md) (modelos, skills, secrets, membros).
 
 ## Antes de levar isto para produção
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -105,11 +105,17 @@ services:
       CRAB_WEBHOOK_SECRET: ${CRAB_WEBHOOK_SECRET}
       MYC_PICOCLAW_ALPHA_TOKEN: ${MYC_PICOCLAW_ALPHA_TOKEN}
       MYC_PICOCLAW_BETA_TOKEN: ${MYC_PICOCLAW_BETA_TOKEN}
+      # hermes-glm agent (harness: hermes): the same shared bearer mycelium
+      # injects and the proxy validates.
+      MYC_HERMES_GLM_TOKEN: ${MYC_HERMES_GLM_TOKEN}
       # Per-instance LLM API keys (referenced by config.yaml's per-agent
       # model.apiKeyEnv). Real values live only in .env (gitignored) or your
       # secrets manager -- never in config.yaml or the image.
       PICOCLAW_ALPHA_API_KEY: ${PICOCLAW_ALPHA_API_KEY}
       PICOCLAW_BETA_API_KEY: ${PICOCLAW_BETA_API_KEY}
+      # z.ai/GLM key for hermes-glm (config.yaml model.apiKeyEnv). The proxy
+      # injects it into the hermes container as GLM_API_KEY (model.keyEnvName).
+      PROXY_GLM_API_KEY: ${PROXY_GLM_API_KEY}
     # TEMPORARY (direct-to-proxy testing of tenant-scoped-workspaces): the proxy
     # normally publishes no host port (mycelium-gateway is the only entry). This
     # exposes it on :18080 so first calls can be driven directly with a
@@ -156,6 +162,7 @@ services:
       # only in .env (gitignored), never in the committed TOML.
       MYC_PICOCLAW_ALPHA_TOKEN: ${MYC_PICOCLAW_ALPHA_TOKEN}
       MYC_PICOCLAW_BETA_TOKEN: ${MYC_PICOCLAW_BETA_TOKEN}
+      MYC_HERMES_GLM_TOKEN: ${MYC_HERMES_GLM_TOKEN}
       MYC_STANDALONE_BOOTSTRAP_SECRET: ${MYC_STANDALONE_BOOTSTRAP_SECRET}
     volumes:
       - mycelium-data:/data

--- a/docs/ADMIN_GUIDE.md
+++ b/docs/ADMIN_GUIDE.md
@@ -1,0 +1,148 @@
+# Admin Guide
+
+Day-2 operations from the **chat-webapp admin area**: injecting shared files,
+secrets, and skills into users' agents, registering models per agent and
+assigning them to individual users, reviewing members, and setting branding.
+
+For *creating* a new agent, see [Creating a Custom Agent](./CREATE_CUSTOM_AGENT.md).
+For running/resetting the whole stack, see the root
+[README](../README.md#running-and-resetting-from-scratch).
+
+---
+
+## 1. Who can administer, and scopes
+
+The admin area is reachable from **chat-webapp** to accounts that manage a
+**scope**. A scope is one of:
+
+- **Tenant** — everything under a tenant.
+- **Subscription** — one subscription account under a tenant.
+
+Everything in the admin area operates **on the selected scope** (the scope rail
+at the top). Changes cascade down to the picoclaw containers of the users in
+that scope. **Branding** is the exception — it's instance-wide and only staff
+can edit it.
+
+The mental model: you edit **shared** material at a scope, the proxy syncs it
+into an **effective** view, and each user's agent container mounts that view
+read-only. One user never sees another user's private workspace — only the
+shared material you injected at their scope.
+
+---
+
+## 2. Shared files
+
+Inject arbitrary files into every user's agent workspace at the scope.
+
+1. Open **Shared files**.
+2. Pick the scope.
+3. Upload files.
+
+Users' agents see them under their workspace. Use this for reference documents,
+datasets, or any static content the agents should be able to read.
+
+---
+
+## 3. Shared secrets
+
+Provide secrets (API keys, tokens, connection strings) to the agents at a
+scope **without** baking them into templates or images.
+
+Supported formats:
+
+- **dotenv** — `KEY=value` lines.
+- **json** — a flat JSON object of key/value pairs.
+- **file** — upload a secret file as-is.
+
+> The picoclaw-**native** secret format (model API key) is intentionally **not**
+> available here. Model credentials are managed per agent from the **Model** tab
+> (section 5), not as a shared secret.
+
+Secrets are written to the scope's shared-secrets store and synced into the
+effective view mounted read-only into each user's agent.
+
+---
+
+## 4. Shared skills
+
+Push skills (a `SKILL.md` plus optional supporting files) to all users' agents
+at a scope. A skill is a folder with a `SKILL.md` (YAML frontmatter `name` +
+`description`, then a Markdown body) — the same shape used in a template's
+`workspace/skills/<name>/`.
+
+1. Open **Shared skills**, pick the scope.
+2. Add a skill by:
+   - writing/editing its `SKILL.md` document inline, or
+   - uploading a **zip** of the skill folder.
+3. Archive or delete a skill to remove it from the scope.
+
+The proxy syncs the scope's skills into the effective-skills view and mounts it
+read-only into each user's agent. Editing a skill re-syncs it in place (the
+mount inode is preserved so running agents pick it up).
+
+---
+
+## 5. Model — per-agent registry and per-user assignment
+
+The **Model** tab lets an admin register LLM models **per agent** and then
+assign a registered model to **individual users** of that agent. This is
+admin-only: normal users cannot change their own model.
+
+### 5.1 Register a model (per agent)
+
+1. Open **Model**.
+2. Choose the **Agent** (e.g. `alpha`, `beta`) at the top.
+3. Under **Register model**, fill:
+   - **provider** — e.g. `zhipu`, `deepseek`, `openai`.
+   - **model_name** — the picoclaw `model_name` (e.g. `glm-4.7`).
+   - **litellm model** — the provider-side model id (often equal to `model_name`).
+   - **api_base** — the provider base URL (e.g. `https://open.bigmodel.cn/api/paas/v4`).
+   - **api_key** — write-only; stored server-side, never echoed back.
+4. **Register.** The model joins that agent's registry.
+
+Registered models are **per agent and global to the agent** — the same list is
+available to assign to any user of that agent.
+
+### 5.2 Assign a model to a user
+
+In the users list (users of the selected agent), pick a registered model and
+**Apply** it to a user. The proxy writes the model entry — including its
+`api_key` — into that user's picoclaw `config.json`, so the user's agent
+authenticates with the assigned model on its next turn.
+
+> A newly provisioned user starts on the agent's **default** model pinned in
+> `crab/crab-shell-proxy/config.yaml` (with the key from the environment).
+> Assigning a registered model here **overrides** that for the specific user.
+
+### 5.3 Remove a model
+
+Delete a registered model from the agent's registry with its delete action.
+Users already assigned that model keep their current `config.json` until
+reassigned.
+
+---
+
+## 6. Members
+
+The **Members** tab lists the users of the selected **subscription**, grouped by
+agent (role). Use it to see who exists per agent before assigning models
+(section 5) or reviewing shared material. A **tenant** scope has no member list
+(members live at the subscription level).
+
+---
+
+## 7. Branding
+
+Instance-wide branding (logo shown as the tenant avatar in the chat sidebar).
+This tab is **staff-only** and is not per-scope.
+
+---
+
+## 8. How roles gate access to an agent
+
+Reaching an agent at all is a **mycelium** concern, not a chat-webapp one. The
+gateway routes are `protectedByRoles` (roles `alpha` / `beta`), so an account
+must hold the matching guest-role to talk to that agent. Roles are assigned in
+**mycelium-webapp** (Mycelium's own admin UI) via the
+Staff → tenant → subscription → guest-invite flow. Once a user holds the role,
+they appear under **Members** (section 6) and can be assigned a model.

--- a/docs/ADMIN_GUIDE.pt-br.md
+++ b/docs/ADMIN_GUIDE.pt-br.md
@@ -1,0 +1,146 @@
+# Guia do Administrador
+
+Operações do dia-a-dia pela **área de admin do chat-webapp**: injetar arquivos,
+secrets e skills compartilhados nos agentes dos usuários, registrar modelos por
+agente e atribuí-los a usuários individuais, revisar membros e definir branding.
+
+Para *criar* um novo agente, veja [Criando um Agente Customizado](./CREATE_CUSTOM_AGENT.pt-br.md).
+Para subir/resetar o stack inteiro, veja o
+[README](../README.pt-br.md#rodando-e-resetando-do-zero) na raiz.
+
+---
+
+## 1. Quem administra, e escopos
+
+A área de admin fica acessível pelo **chat-webapp** para contas que gerenciam um
+**escopo**. Um escopo é:
+
+- **Tenant** — tudo sob um tenant.
+- **Subscription** — uma conta de subscription sob um tenant.
+
+Tudo na área de admin opera **sobre o escopo selecionado** (a trilha de escopo
+no topo). As mudanças cascateiam para os containers picoclaw dos usuários
+daquele escopo. **Branding** é a exceção — é global à instância e só staff edita.
+
+O modelo mental: você edita material **compartilhado** num escopo, o proxy
+sincroniza numa visão **efetiva**, e o container de cada usuário monta essa
+visão como somente-leitura. Um usuário nunca vê o workspace privado de outro —
+apenas o material compartilhado que você injetou no escopo dele.
+
+---
+
+## 2. Shared files (arquivos compartilhados)
+
+Injeta arquivos arbitrários no workspace do agente de cada usuário do escopo.
+
+1. Abra **Shared files**.
+2. Escolha o escopo.
+3. Faça upload dos arquivos.
+
+Os agentes dos usuários passam a vê-los no workspace. Use para documentos de
+referência, datasets ou qualquer conteúdo estático que os agentes devam ler.
+
+---
+
+## 3. Shared secrets (secrets compartilhados)
+
+Fornece secrets (chaves de API, tokens, strings de conexão) aos agentes de um
+escopo **sem** embuti-los em templates ou imagens.
+
+Formatos suportados:
+
+- **dotenv** — linhas `KEY=value`.
+- **json** — um objeto JSON plano de pares chave/valor.
+- **file** — upload de um arquivo de secret como está.
+
+> O formato **nativo** de secret do picoclaw (model API key) **não** está
+> disponível aqui de propósito. Credenciais de modelo são gerenciadas por agente
+> na aba **Model** (seção 5), não como secret compartilhado.
+
+Os secrets são gravados no store de shared-secrets do escopo e sincronizados na
+visão efetiva montada somente-leitura no agente de cada usuário.
+
+---
+
+## 4. Shared skills (skills compartilhadas)
+
+Envia skills (um `SKILL.md` mais arquivos de apoio opcionais) para os agentes de
+todos os usuários de um escopo. Uma skill é uma pasta com um `SKILL.md`
+(frontmatter YAML `name` + `description`, depois um corpo Markdown) — o mesmo
+formato usado em `workspace/skills/<name>/` de um template.
+
+1. Abra **Shared skills**, escolha o escopo.
+2. Adicione uma skill:
+   - escrevendo/editando o documento `SKILL.md` inline, ou
+   - fazendo upload de um **zip** da pasta da skill.
+3. Arquive ou exclua uma skill para removê-la do escopo.
+
+O proxy sincroniza as skills do escopo na visão effective-skills e a monta
+somente-leitura no agente de cada usuário. Editar uma skill re-sincroniza no
+lugar (o inode do mount é preservado, então agentes em execução a enxergam).
+
+---
+
+## 5. Model — registro por agente e atribuição por usuário
+
+A aba **Model** permite ao admin registrar modelos LLM **por agente** e então
+atribuir um modelo registrado a **usuários individuais** daquele agente. É
+admin-only: usuários comuns não trocam o próprio modelo.
+
+### 5.1 Registrar um modelo (por agente)
+
+1. Abra **Model**.
+2. Escolha o **Agent** (ex.: `alpha`, `beta`) no topo.
+3. Em **Register model**, preencha:
+   - **provider** — ex.: `zhipu`, `deepseek`, `openai`.
+   - **model_name** — o `model_name` do picoclaw (ex.: `glm-4.7`).
+   - **litellm model** — o id do modelo no provedor (frequentemente igual ao `model_name`).
+   - **api_base** — a URL base do provedor (ex.: `https://open.bigmodel.cn/api/paas/v4`).
+   - **api_key** — write-only; guardada no servidor, nunca devolvida.
+4. **Register.** O modelo entra no registry daquele agente.
+
+Modelos registrados são **por agente e globais ao agente** — a mesma lista fica
+disponível para atribuir a qualquer usuário daquele agente.
+
+### 5.2 Atribuir um modelo a um usuário
+
+Na lista de usuários (usuários do agente selecionado), escolha um modelo
+registrado e **Apply** para um usuário. O proxy grava a entrada do modelo —
+incluindo a `api_key` — no `config.json` do picoclaw daquele usuário, então o
+agente dele passa a autenticar com o modelo atribuído no próximo turno.
+
+> Um usuário recém-provisionado começa no modelo **default** do agente, fixado
+> em `crab/crab-shell-proxy/config.yaml` (com a chave do ambiente). Atribuir um
+> modelo registrado aqui **sobrescreve** isso para aquele usuário específico.
+
+### 5.3 Remover um modelo
+
+Exclua um modelo registrado do registry do agente pela ação de delete. Usuários
+já atribuídos mantêm o `config.json` atual até serem reatribuídos.
+
+---
+
+## 6. Members (membros)
+
+A aba **Members** lista os usuários da **subscription** selecionada, agrupados
+por agente (role). Use para ver quem existe por agente antes de atribuir modelos
+(seção 5) ou revisar material compartilhado. Um escopo **tenant** não tem lista
+de membros (membros vivem no nível de subscription).
+
+---
+
+## 7. Branding
+
+Branding global da instância (o logo mostrado como avatar do tenant na sidebar
+do chat). Essa aba é **staff-only** e não é por-escopo.
+
+---
+
+## 8. Como roles liberam acesso a um agente
+
+Alcançar um agente é uma questão do **mycelium**, não do chat-webapp. As rotas
+do gateway são `protectedByRoles` (roles `alpha` / `beta`), então uma conta
+precisa ter a guest-role correspondente para falar com aquele agente. Roles são
+atribuídas no **mycelium-webapp** (a UI de admin do próprio Mycelium) pelo fluxo
+Staff → tenant → subscription → guest-invite. Quando o usuário tem a role, ele
+aparece em **Members** (seção 6) e pode receber a atribuição de um modelo.

--- a/docs/CREATE_CUSTOM_AGENT.md
+++ b/docs/CREATE_CUSTOM_AGENT.md
@@ -83,6 +83,16 @@ workspace/skills/<skill-name>/SKILL.md
 > **Deploy tip:** prepare your templates **before** anyone uses the instance, so
 > everyone is cloned from the final version.
 
+> **Auto-bootstrap (safety net).** If an agent's `data/templates/<name>/` is
+> missing at first provision, the proxy materializes a **default picoclaw
+> template embedded in its binary** so provisioning never fails on a wiped or
+> unseeded `data/`. That default is the stock picoclaw persona — **not** your
+> custom one. So for a custom agent you still create the template below (steps
+> 4.1–4.3); the bootstrap only guarantees a working baseline when you don't. To
+> change the embedded default itself, edit
+> `crab/crab-shell-proxy/internal/docker/defaulttemplate/<harness>/` (today:
+> `picoclaw`) and rebuild the proxy.
+
 ---
 
 ## 4. Step-by-step: add a custom agent

--- a/docs/CREATE_CUSTOM_AGENT.pt-br.md
+++ b/docs/CREATE_CUSTOM_AGENT.pt-br.md
@@ -85,6 +85,17 @@ workspace/skills/<nome-da-skill>/SKILL.md
 > **Dica de deploy:** prepare seus templates **antes** de alguém usar a
 > instância, para que todos sejam clonados da versão final.
 
+> **Auto-bootstrap (rede de segurança).** Se o `data/templates/<name>/` de um
+> agente estiver ausente no primeiro provisionamento, o proxy materializa um
+> **template picoclaw default embutido no binário**, para que o provisionamento
+> nunca falhe num `data/` apagado ou não-semeado. Esse default é a persona
+> picoclaw padrão — **não** a sua customizada. Então, para um agente customizado
+> você ainda cria o template abaixo (passos 4.1–4.3); o bootstrap só garante uma
+> baseline funcional quando você não o faz. Para alterar o próprio default
+> embutido, edite
+> `crab/crab-shell-proxy/internal/docker/defaulttemplate/<harness>/` (hoje:
+> `picoclaw`) e rebuilde o proxy.
+
 ---
 
 ## 4. Passo-a-passo: adicionar um agente customizado

--- a/fungi/mycelium/config.base.toml
+++ b/fungi/mycelium/config.base.toml
@@ -261,6 +261,27 @@ methods = ["GET"]
 
 [[picoclaw-alpha.path]]
 group = "protected"
+path = "/v1/admin/models"
+secretName = "picoclaw-alpha-authorization-header"
+acceptInsecureRouting = true
+methods = ["GET"]
+
+[[picoclaw-alpha.path]]
+group = "protected"
+path = "/v1/admin/model"
+secretName = "picoclaw-alpha-authorization-header"
+acceptInsecureRouting = true
+methods = ["GET", "PUT", "DELETE"]
+
+[[picoclaw-alpha.path]]
+group = "protected"
+path = "/v1/admin/model/users"
+secretName = "picoclaw-alpha-authorization-header"
+acceptInsecureRouting = true
+methods = ["GET"]
+
+[[picoclaw-alpha.path]]
+group = "protected"
 path = "/v1/admin/shared-secrets"
 secretName = "picoclaw-alpha-authorization-header"
 acceptInsecureRouting = true
@@ -383,6 +404,27 @@ methods = ["GET"]
 [[picoclaw-beta.path]]
 group = "protected"
 path = "/v1/admin/skills/archive"
+secretName = "picoclaw-beta-authorization-header"
+acceptInsecureRouting = true
+methods = ["GET"]
+
+[[picoclaw-beta.path]]
+group = "protected"
+path = "/v1/admin/models"
+secretName = "picoclaw-beta-authorization-header"
+acceptInsecureRouting = true
+methods = ["GET"]
+
+[[picoclaw-beta.path]]
+group = "protected"
+path = "/v1/admin/model"
+secretName = "picoclaw-beta-authorization-header"
+acceptInsecureRouting = true
+methods = ["GET", "PUT", "DELETE"]
+
+[[picoclaw-beta.path]]
+group = "protected"
+path = "/v1/admin/model/users"
 secretName = "picoclaw-beta-authorization-header"
 acceptInsecureRouting = true
 methods = ["GET"]

--- a/fungi/mycelium/config.base.toml
+++ b/fungi/mycelium/config.base.toml
@@ -152,328 +152,255 @@ target = "stdout"
 
 [api.services]
 
-[[picoclaw-alpha]]
+[[alpha]]
 host = "crab-shell-proxy:8080"
 protocol = "http"
 healthCheckPath = "/healthz"
+discoverable = true
+serviceType = "rest-api"
+isContextApi = false
+openapiPath = "/doc/openapi.json"
+capabilities = ["chat"]
+description = "PicoClaw agent 'alpha' - an OpenAI-compatible personal chat agent. Each user gets an isolated container; send chat via POST /v1/chat/completions."
 
-[[picoclaw-alpha.secret]]
-name = "picoclaw-alpha-authorization-header"
+[[alpha.secret]]
+name = "alpha-authorization-header"
 authorizationHeader = { headerName = "Authorization", prefix = "Bearer", token = { env = "MYC_PICOCLAW_ALPHA_TOKEN" } }
 
-[[picoclaw-alpha.path]]
+[[alpha.path]]
 group = { protectedByRoles = [{ name = "alpha", permission = "write" }] }
 path = "/v1/chat/completions"
-secretName = "picoclaw-alpha-authorization-header"
+secretName = "alpha-authorization-header"
 acceptInsecureRouting = true
 methods = ["POST"]
 
-[[picoclaw-alpha.path]]
+[[alpha.path]]
 group = { protectedByRoles = [{ name = "alpha" }] }
 path = "/v1/models"
-secretName = "picoclaw-alpha-authorization-header"
+secretName = "alpha-authorization-header"
 acceptInsecureRouting = true
 methods = ["GET"]
 
-[[picoclaw-alpha.path]]
+[[alpha.path]]
 group = { protectedByRoles = [{ name = "alpha" }] }
 path = "/v1/sessions/history"
-secretName = "picoclaw-alpha-authorization-header"
+secretName = "alpha-authorization-header"
 acceptInsecureRouting = true
 methods = ["GET"]
 
-[[picoclaw-alpha.path]]
+[[alpha.path]]
 group = { protectedByRoles = [{ name = "alpha" }] }
 path = "/v1/sessions/resolve"
-secretName = "picoclaw-alpha-authorization-header"
+secretName = "alpha-authorization-header"
 acceptInsecureRouting = true
 methods = ["GET"]
 
-[[picoclaw-alpha.path]]
+[[alpha.path]]
 group = "protected"
 path = "/v1/subscriptions"
-secretName = "picoclaw-alpha-authorization-header"
+secretName = "alpha-authorization-header"
 acceptInsecureRouting = true
 methods = ["GET"]
 
-[[picoclaw-alpha.path]]
+[[alpha.path]]
 group = { protectedByRoles = [{ name = "alpha", permission = "write" }] }
 path = "/v1/secrets"
-secretName = "picoclaw-alpha-authorization-header"
+secretName = "alpha-authorization-header"
 acceptInsecureRouting = true
 methods = ["GET", "POST", "DELETE"]
 
-[[picoclaw-alpha.path]]
+[[alpha.path]]
 group = { protectedByRoles = [{ name = "alpha", permission = "write" }] }
 path = "/v1/media"
-secretName = "picoclaw-alpha-authorization-header"
+secretName = "alpha-authorization-header"
 acceptInsecureRouting = true
 methods = ["GET", "POST", "DELETE"]
 
-[[picoclaw-alpha.path]]
+[[alpha.path]]
 group = { protectedByRoles = [{ name = "alpha", permission = "write" }] }
 path = "/v1/memory"
-secretName = "picoclaw-alpha-authorization-header"
+secretName = "alpha-authorization-header"
 acceptInsecureRouting = true
 methods = ["GET", "PUT"]
 
-[[picoclaw-alpha.path]]
+[[alpha.path]]
+# All /v1/admin/* endpoints share group=protected + this secret; the
+# proxy enforces the exact path+method per route. Collapsed to one
+# wildcard (mycelium matches via the wildmatch crate).
 group = "protected"
-path = "/v1/admin/scopes"
-secretName = "picoclaw-alpha-authorization-header"
+path = "/v1/admin/*"
+secretName = "alpha-authorization-header"
 acceptInsecureRouting = true
-methods = ["GET"]
+methods = ["GET", "POST", "PUT", "DELETE"]
 
-[[picoclaw-alpha.path]]
-group = "protected"
-path = "/v1/admin/shared"
-secretName = "picoclaw-alpha-authorization-header"
-acceptInsecureRouting = true
-methods = ["GET", "POST", "DELETE"]
-
-[[picoclaw-alpha.path]]
-group = "protected"
-path = "/v1/admin/shared/content"
-secretName = "picoclaw-alpha-authorization-header"
-acceptInsecureRouting = true
-methods = ["GET"]
-
-[[picoclaw-alpha.path]]
-group = "protected"
-path = "/v1/admin/skills"
-secretName = "picoclaw-alpha-authorization-header"
-acceptInsecureRouting = true
-methods = ["GET", "POST", "DELETE"]
-
-[[picoclaw-alpha.path]]
-group = "protected"
-path = "/v1/admin/skills/doc"
-secretName = "picoclaw-alpha-authorization-header"
-acceptInsecureRouting = true
-methods = ["GET"]
-
-[[picoclaw-alpha.path]]
-group = "protected"
-path = "/v1/admin/skills/archive"
-secretName = "picoclaw-alpha-authorization-header"
-acceptInsecureRouting = true
-methods = ["GET"]
-
-[[picoclaw-alpha.path]]
-group = "protected"
-path = "/v1/admin/models"
-secretName = "picoclaw-alpha-authorization-header"
-acceptInsecureRouting = true
-methods = ["GET"]
-
-[[picoclaw-alpha.path]]
-group = "protected"
-path = "/v1/admin/model"
-secretName = "picoclaw-alpha-authorization-header"
-acceptInsecureRouting = true
-methods = ["GET", "PUT", "DELETE"]
-
-[[picoclaw-alpha.path]]
-group = "protected"
-path = "/v1/admin/model/users"
-secretName = "picoclaw-alpha-authorization-header"
-acceptInsecureRouting = true
-methods = ["GET"]
-
-[[picoclaw-alpha.path]]
-group = "protected"
-path = "/v1/admin/registered-models"
-secretName = "picoclaw-alpha-authorization-header"
-acceptInsecureRouting = true
-methods = ["GET", "POST", "DELETE"]
-
-[[picoclaw-alpha.path]]
-group = "protected"
-path = "/v1/admin/registered-models/apply"
-secretName = "picoclaw-alpha-authorization-header"
-acceptInsecureRouting = true
-methods = ["POST"]
-
-[[picoclaw-alpha.path]]
-group = "protected"
-path = "/v1/admin/shared-secrets"
-secretName = "picoclaw-alpha-authorization-header"
-acceptInsecureRouting = true
-methods = ["GET", "POST", "DELETE"]
-
-[[picoclaw-alpha.path]]
-group = "protected"
-path = "/v1/admin/users"
-secretName = "picoclaw-alpha-authorization-header"
-acceptInsecureRouting = true
-methods = ["GET"]
-
-[[picoclaw-alpha.path]]
-group = "protected"
-path = "/v1/admin/users/files"
-secretName = "picoclaw-alpha-authorization-header"
-acceptInsecureRouting = true
-methods = ["GET", "DELETE"]
-
-[[picoclaw-beta]]
+[[beta]]
 host = "crab-shell-proxy:8080"
 protocol = "http"
 healthCheckPath = "/healthz"
+discoverable = true
+serviceType = "rest-api"
+isContextApi = false
+openapiPath = "/doc/openapi.json"
+capabilities = ["chat"]
+description = "PicoClaw agent 'beta' - an OpenAI-compatible personal chat agent. Each user gets an isolated container; send chat via POST /v1/chat/completions."
 
-[[picoclaw-beta.secret]]
-name = "picoclaw-beta-authorization-header"
+[[beta.secret]]
+name = "beta-authorization-header"
 authorizationHeader = { headerName = "Authorization", prefix = "Bearer", token = { env = "MYC_PICOCLAW_BETA_TOKEN" } }
 
-[[picoclaw-beta.path]]
+[[beta.path]]
 group = { protectedByRoles = [{ name = "beta", permission = "write" }] }
 path = "/v1/chat/completions"
-secretName = "picoclaw-beta-authorization-header"
+secretName = "beta-authorization-header"
 acceptInsecureRouting = true
 methods = ["POST"]
 
-[[picoclaw-beta.path]]
+[[beta.path]]
 group = { protectedByRoles = [{ name = "beta" }] }
 path = "/v1/models"
-secretName = "picoclaw-beta-authorization-header"
+secretName = "beta-authorization-header"
 acceptInsecureRouting = true
 methods = ["GET"]
 
-[[picoclaw-beta.path]]
+[[beta.path]]
 group = { protectedByRoles = [{ name = "beta" }] }
 path = "/v1/sessions/history"
-secretName = "picoclaw-beta-authorization-header"
+secretName = "beta-authorization-header"
 acceptInsecureRouting = true
 methods = ["GET"]
 
-[[picoclaw-beta.path]]
+[[beta.path]]
 group = { protectedByRoles = [{ name = "beta" }] }
 path = "/v1/sessions/resolve"
-secretName = "picoclaw-beta-authorization-header"
+secretName = "beta-authorization-header"
 acceptInsecureRouting = true
 methods = ["GET"]
 
-[[picoclaw-beta.path]]
+[[beta.path]]
 group = "protected"
 path = "/v1/subscriptions"
-secretName = "picoclaw-beta-authorization-header"
+secretName = "beta-authorization-header"
 acceptInsecureRouting = true
 methods = ["GET"]
 
-[[picoclaw-beta.path]]
+[[beta.path]]
 group = { protectedByRoles = [{ name = "beta", permission = "write" }] }
 path = "/v1/secrets"
-secretName = "picoclaw-beta-authorization-header"
+secretName = "beta-authorization-header"
 acceptInsecureRouting = true
 methods = ["GET", "POST", "DELETE"]
 
-[[picoclaw-beta.path]]
+[[beta.path]]
 group = { protectedByRoles = [{ name = "beta", permission = "write" }] }
 path = "/v1/media"
-secretName = "picoclaw-beta-authorization-header"
+secretName = "beta-authorization-header"
 acceptInsecureRouting = true
 methods = ["GET", "POST", "DELETE"]
 
-[[picoclaw-beta.path]]
+[[beta.path]]
 group = { protectedByRoles = [{ name = "beta", permission = "write" }] }
 path = "/v1/memory"
-secretName = "picoclaw-beta-authorization-header"
+secretName = "beta-authorization-header"
 acceptInsecureRouting = true
 methods = ["GET", "PUT"]
 
-[[picoclaw-beta.path]]
+[[beta.path]]
+# All /v1/admin/* endpoints share group=protected + this secret; the
+# proxy enforces the exact path+method per route. Collapsed to one
+# wildcard (mycelium matches via the wildmatch crate).
 group = "protected"
-path = "/v1/admin/scopes"
-secretName = "picoclaw-beta-authorization-header"
+path = "/v1/admin/*"
+secretName = "beta-authorization-header"
 acceptInsecureRouting = true
-methods = ["GET"]
+methods = ["GET", "POST", "PUT", "DELETE"]
 
-[[picoclaw-beta.path]]
-group = "protected"
-path = "/v1/admin/shared"
-secretName = "picoclaw-beta-authorization-header"
-acceptInsecureRouting = true
-methods = ["GET", "POST", "DELETE"]
+# ------------------------------------------------------------------------------
+# hermes-glm: a Nous Research hermes-agent instance (harness = "hermes" in
+# crab-shell-proxy/config.yaml), routed to the same crab-shell-proxy downstream.
+# crab-shell-proxy tells it apart via x-mycelium-service-name = "hermes-glm" and
+# drives the container over its OpenAI-compatible API server (:8642) instead of
+# the Pico Protocol. Same auth/role contract as the picoclaw services above: the
+# "hermes-glm" guest-role is auto-declared here; granting it to an account still
+# needs the Staff -> tenant -> subscription -> guest-invite chain (M3).
+# ------------------------------------------------------------------------------
 
-[[picoclaw-beta.path]]
-group = "protected"
-path = "/v1/admin/shared/content"
-secretName = "picoclaw-beta-authorization-header"
-acceptInsecureRouting = true
-methods = ["GET"]
+[[hermes-glm]]
+host = "crab-shell-proxy:8080"
+protocol = "http"
+healthCheckPath = "/healthz"
+discoverable = true
+serviceType = "rest-api"
+isContextApi = false
+openapiPath = "/doc/openapi.json"
+capabilities = ["chat"]
+description = "Hermes-agent (Nous Research, GLM via z.ai) - an OpenAI-compatible personal chat agent. Each user gets an isolated container; send chat via POST /v1/chat/completions."
 
-[[picoclaw-beta.path]]
-group = "protected"
-path = "/v1/admin/skills"
-secretName = "picoclaw-beta-authorization-header"
-acceptInsecureRouting = true
-methods = ["GET", "POST", "DELETE"]
+[[hermes-glm.secret]]
+name = "hermes-glm-authorization-header"
+authorizationHeader = { headerName = "Authorization", prefix = "Bearer", token = { env = "MYC_HERMES_GLM_TOKEN" } }
 
-[[picoclaw-beta.path]]
-group = "protected"
-path = "/v1/admin/skills/doc"
-secretName = "picoclaw-beta-authorization-header"
-acceptInsecureRouting = true
-methods = ["GET"]
-
-[[picoclaw-beta.path]]
-group = "protected"
-path = "/v1/admin/skills/archive"
-secretName = "picoclaw-beta-authorization-header"
-acceptInsecureRouting = true
-methods = ["GET"]
-
-[[picoclaw-beta.path]]
-group = "protected"
-path = "/v1/admin/models"
-secretName = "picoclaw-beta-authorization-header"
-acceptInsecureRouting = true
-methods = ["GET"]
-
-[[picoclaw-beta.path]]
-group = "protected"
-path = "/v1/admin/model"
-secretName = "picoclaw-beta-authorization-header"
-acceptInsecureRouting = true
-methods = ["GET", "PUT", "DELETE"]
-
-[[picoclaw-beta.path]]
-group = "protected"
-path = "/v1/admin/model/users"
-secretName = "picoclaw-beta-authorization-header"
-acceptInsecureRouting = true
-methods = ["GET"]
-
-[[picoclaw-beta.path]]
-group = "protected"
-path = "/v1/admin/registered-models"
-secretName = "picoclaw-beta-authorization-header"
-acceptInsecureRouting = true
-methods = ["GET", "POST", "DELETE"]
-
-[[picoclaw-beta.path]]
-group = "protected"
-path = "/v1/admin/registered-models/apply"
-secretName = "picoclaw-beta-authorization-header"
+[[hermes-glm.path]]
+group = { protectedByRoles = [{ name = "hermes-glm", permission = "write" }] }
+path = "/v1/chat/completions"
+secretName = "hermes-glm-authorization-header"
 acceptInsecureRouting = true
 methods = ["POST"]
 
-[[picoclaw-beta.path]]
-group = "protected"
-path = "/v1/admin/shared-secrets"
-secretName = "picoclaw-beta-authorization-header"
-acceptInsecureRouting = true
-methods = ["GET", "POST", "DELETE"]
-
-[[picoclaw-beta.path]]
-group = "protected"
-path = "/v1/admin/users"
-secretName = "picoclaw-beta-authorization-header"
+[[hermes-glm.path]]
+group = { protectedByRoles = [{ name = "hermes-glm" }] }
+path = "/v1/models"
+secretName = "hermes-glm-authorization-header"
 acceptInsecureRouting = true
 methods = ["GET"]
 
-[[picoclaw-beta.path]]
-group = "protected"
-path = "/v1/admin/users/files"
-secretName = "picoclaw-beta-authorization-header"
+[[hermes-glm.path]]
+group = { protectedByRoles = [{ name = "hermes-glm" }] }
+path = "/v1/sessions/history"
+secretName = "hermes-glm-authorization-header"
 acceptInsecureRouting = true
-methods = ["GET", "DELETE"]
+methods = ["GET"]
+
+[[hermes-glm.path]]
+group = { protectedByRoles = [{ name = "hermes-glm" }] }
+path = "/v1/sessions/resolve"
+secretName = "hermes-glm-authorization-header"
+acceptInsecureRouting = true
+methods = ["GET"]
+
+[[hermes-glm.path]]
+group = "protected"
+path = "/v1/subscriptions"
+secretName = "hermes-glm-authorization-header"
+acceptInsecureRouting = true
+methods = ["GET"]
+
+[[hermes-glm.path]]
+group = { protectedByRoles = [{ name = "hermes-glm", permission = "write" }] }
+path = "/v1/secrets"
+secretName = "hermes-glm-authorization-header"
+acceptInsecureRouting = true
+methods = ["GET", "POST", "DELETE"]
+
+[[hermes-glm.path]]
+group = { protectedByRoles = [{ name = "hermes-glm", permission = "write" }] }
+path = "/v1/media"
+secretName = "hermes-glm-authorization-header"
+acceptInsecureRouting = true
+methods = ["GET", "POST", "DELETE"]
+
+[[hermes-glm.path]]
+group = { protectedByRoles = [{ name = "hermes-glm", permission = "write" }] }
+path = "/v1/memory"
+secretName = "hermes-glm-authorization-header"
+acceptInsecureRouting = true
+methods = ["GET", "PUT"]
+
+[[hermes-glm.path]]
+# All /v1/admin/* endpoints share group=protected + this secret; the
+# proxy enforces the exact path+method per route. Collapsed to one
+# wildcard (mycelium matches via the wildmatch crate).
+group = "protected"
+path = "/v1/admin/*"
+secretName = "hermes-glm-authorization-header"
+acceptInsecureRouting = true
+methods = ["GET", "POST", "PUT", "DELETE"]

--- a/fungi/mycelium/config.base.toml
+++ b/fungi/mycelium/config.base.toml
@@ -240,6 +240,27 @@ methods = ["GET"]
 
 [[picoclaw-alpha.path]]
 group = "protected"
+path = "/v1/admin/skills"
+secretName = "picoclaw-alpha-authorization-header"
+acceptInsecureRouting = true
+methods = ["GET", "POST", "DELETE"]
+
+[[picoclaw-alpha.path]]
+group = "protected"
+path = "/v1/admin/skills/doc"
+secretName = "picoclaw-alpha-authorization-header"
+acceptInsecureRouting = true
+methods = ["GET"]
+
+[[picoclaw-alpha.path]]
+group = "protected"
+path = "/v1/admin/skills/archive"
+secretName = "picoclaw-alpha-authorization-header"
+acceptInsecureRouting = true
+methods = ["GET"]
+
+[[picoclaw-alpha.path]]
+group = "protected"
 path = "/v1/admin/shared-secrets"
 secretName = "picoclaw-alpha-authorization-header"
 acceptInsecureRouting = true
@@ -341,6 +362,27 @@ methods = ["GET", "POST", "DELETE"]
 [[picoclaw-beta.path]]
 group = "protected"
 path = "/v1/admin/shared/content"
+secretName = "picoclaw-beta-authorization-header"
+acceptInsecureRouting = true
+methods = ["GET"]
+
+[[picoclaw-beta.path]]
+group = "protected"
+path = "/v1/admin/skills"
+secretName = "picoclaw-beta-authorization-header"
+acceptInsecureRouting = true
+methods = ["GET", "POST", "DELETE"]
+
+[[picoclaw-beta.path]]
+group = "protected"
+path = "/v1/admin/skills/doc"
+secretName = "picoclaw-beta-authorization-header"
+acceptInsecureRouting = true
+methods = ["GET"]
+
+[[picoclaw-beta.path]]
+group = "protected"
+path = "/v1/admin/skills/archive"
 secretName = "picoclaw-beta-authorization-header"
 acceptInsecureRouting = true
 methods = ["GET"]

--- a/fungi/mycelium/config.base.toml
+++ b/fungi/mycelium/config.base.toml
@@ -282,6 +282,20 @@ methods = ["GET"]
 
 [[picoclaw-alpha.path]]
 group = "protected"
+path = "/v1/admin/registered-models"
+secretName = "picoclaw-alpha-authorization-header"
+acceptInsecureRouting = true
+methods = ["GET", "POST", "DELETE"]
+
+[[picoclaw-alpha.path]]
+group = "protected"
+path = "/v1/admin/registered-models/apply"
+secretName = "picoclaw-alpha-authorization-header"
+acceptInsecureRouting = true
+methods = ["POST"]
+
+[[picoclaw-alpha.path]]
+group = "protected"
 path = "/v1/admin/shared-secrets"
 secretName = "picoclaw-alpha-authorization-header"
 acceptInsecureRouting = true
@@ -428,6 +442,20 @@ path = "/v1/admin/model/users"
 secretName = "picoclaw-beta-authorization-header"
 acceptInsecureRouting = true
 methods = ["GET"]
+
+[[picoclaw-beta.path]]
+group = "protected"
+path = "/v1/admin/registered-models"
+secretName = "picoclaw-beta-authorization-header"
+acceptInsecureRouting = true
+methods = ["GET", "POST", "DELETE"]
+
+[[picoclaw-beta.path]]
+group = "protected"
+path = "/v1/admin/registered-models/apply"
+secretName = "picoclaw-beta-authorization-header"
+acceptInsecureRouting = true
+methods = ["POST"]
 
 [[picoclaw-beta.path]]
 group = "protected"

--- a/fungi/mycelium/config.standalone.toml
+++ b/fungi/mycelium/config.standalone.toml
@@ -318,6 +318,27 @@ methods = ["GET"]
 
 [[picoclaw-alpha.path]]
 group = "protected"
+path = "/v1/admin/models"
+secretName = "picoclaw-alpha-authorization-header"
+acceptInsecureRouting = true
+methods = ["GET"]
+
+[[picoclaw-alpha.path]]
+group = "protected"
+path = "/v1/admin/model"
+secretName = "picoclaw-alpha-authorization-header"
+acceptInsecureRouting = true
+methods = ["GET", "PUT", "DELETE"]
+
+[[picoclaw-alpha.path]]
+group = "protected"
+path = "/v1/admin/model/users"
+secretName = "picoclaw-alpha-authorization-header"
+acceptInsecureRouting = true
+methods = ["GET"]
+
+[[picoclaw-alpha.path]]
+group = "protected"
 path = "/v1/admin/shared-secrets"
 secretName = "picoclaw-alpha-authorization-header"
 acceptInsecureRouting = true
@@ -447,6 +468,27 @@ methods = ["GET"]
 [[picoclaw-beta.path]]
 group = "protected"
 path = "/v1/admin/skills/archive"
+secretName = "picoclaw-beta-authorization-header"
+acceptInsecureRouting = true
+methods = ["GET"]
+
+[[picoclaw-beta.path]]
+group = "protected"
+path = "/v1/admin/models"
+secretName = "picoclaw-beta-authorization-header"
+acceptInsecureRouting = true
+methods = ["GET"]
+
+[[picoclaw-beta.path]]
+group = "protected"
+path = "/v1/admin/model"
+secretName = "picoclaw-beta-authorization-header"
+acceptInsecureRouting = true
+methods = ["GET", "PUT", "DELETE"]
+
+[[picoclaw-beta.path]]
+group = "protected"
+path = "/v1/admin/model/users"
 secretName = "picoclaw-beta-authorization-header"
 acceptInsecureRouting = true
 methods = ["GET"]

--- a/fungi/mycelium/config.standalone.toml
+++ b/fungi/mycelium/config.standalone.toml
@@ -121,7 +121,7 @@ target = "stdout"
 # downstream, crab-shell-proxy:8080, over the compose-internal `zombie_net`
 # network. crab-shell-proxy tells the agents apart via the
 # x-mycelium-service-name header mycelium injects (the service key below,
-# e.g. "picoclaw-alpha"), since the first path segment is stripped before
+# e.g. "alpha"), since the first path segment is stripped before
 # forwarding. It then spawns/reuses one bare picoclaw container per
 # (agent, user) and speaks the Pico Protocol to it. crab-shell-proxy also
 # validates the `Authorization: Bearer <token>` mycelium injects here against
@@ -131,7 +131,7 @@ target = "stdout"
 # mycelium's router takes the *first path segment* of the request as the
 # service name (adapters/mem_db/src/repositories/shared.rs::extract_path_parts)
 # and matches everything after it against `path` below -- so callers must hit
-# /picoclaw-alpha/... and /picoclaw-beta/... (the literal TOML service keys),
+# /alpha/... and /beta/... (the literal TOML service keys),
 # NOT /alpha/... or /beta/....
 #
 # `token = { env = "VAR_NAME" }` is the field-level env resolver fixed in
@@ -177,7 +177,7 @@ target = "stdout"
 
 [api.services]
 
-[[picoclaw-alpha]]
+[[alpha]]
 # NOT `proxyAddress`: that field means "route through this generic
 # forward-proxy" (mycelium embeds the real target URL as a path suffix on
 # it -- see Service::proxy_address's own doc comment and
@@ -190,43 +190,49 @@ target = "stdout"
 host = "crab-shell-proxy:8080"
 protocol = "http"
 healthCheckPath = "/healthz"
+discoverable = true
+serviceType = "rest-api"
+isContextApi = false
+openapiPath = "/doc/openapi.json"
+capabilities = ["chat"]
+description = "PicoClaw agent 'alpha' - an OpenAI-compatible personal chat agent. Each user gets an isolated container; send chat via POST /v1/chat/completions."
 
-[[picoclaw-alpha.secret]]
-name = "picoclaw-alpha-authorization-header"
+[[alpha.secret]]
+name = "alpha-authorization-header"
 authorizationHeader = { headerName = "Authorization", prefix = "Bearer", token = { env = "MYC_PICOCLAW_ALPHA_TOKEN" } }
 
-[[picoclaw-alpha.path]]
+[[alpha.path]]
 group = { protectedByRoles = [{ name = "alpha", permission = "write" }] }
 path = "/v1/chat/completions"
-secretName = "picoclaw-alpha-authorization-header"
+secretName = "alpha-authorization-header"
 acceptInsecureRouting = true
 methods = ["POST"]
 
-[[picoclaw-alpha.path]]
+[[alpha.path]]
 group = { protectedByRoles = [{ name = "alpha" }] }
 path = "/v1/models"
-secretName = "picoclaw-alpha-authorization-header"
+secretName = "alpha-authorization-header"
 acceptInsecureRouting = true
 methods = ["GET"]
 
-[[picoclaw-alpha.path]]
+[[alpha.path]]
 group = { protectedByRoles = [{ name = "alpha" }] }
 path = "/v1/sessions/history"
-secretName = "picoclaw-alpha-authorization-header"
+secretName = "alpha-authorization-header"
 acceptInsecureRouting = true
 methods = ["GET"]
 
-[[picoclaw-alpha.path]]
+[[alpha.path]]
 # Session linkage (conversation-enrichment feature): resolves the sessionKey +
 # picoclaw on-disk file basename for a conversation. Read-only metadata, gated
 # like /v1/sessions/history (role name, no write permission).
 group = { protectedByRoles = [{ name = "alpha" }] }
 path = "/v1/sessions/resolve"
-secretName = "picoclaw-alpha-authorization-header"
+secretName = "alpha-authorization-header"
 acceptInsecureRouting = true
 methods = ["GET"]
 
-[[picoclaw-alpha.path]]
+[[alpha.path]]
 # Discovery (workspace-selection feature) is agent-agnostic: it returns ALL of
 # the caller's licensed subscriptions (across roles), and the client must reach
 # it BEFORE it knows which role it holds -- so it is `protected` (any resolvable
@@ -235,35 +241,35 @@ methods = ["GET"]
 # for symmetry; either works for any member.
 group = "protected"
 path = "/v1/subscriptions"
-secretName = "picoclaw-alpha-authorization-header"
+secretName = "alpha-authorization-header"
 acceptInsecureRouting = true
 methods = ["GET"]
 
-[[picoclaw-alpha.path]]
+[[alpha.path]]
 # Secret injection (agent-customization feature): per-(user, agent), role-gated
 # with write (injecting is a write; GET/DELETE also gated the same, a member only
 # ever touches their own store). Values are write-only over the API.
 group = { protectedByRoles = [{ name = "alpha", permission = "write" }] }
 path = "/v1/secrets"
-secretName = "picoclaw-alpha-authorization-header"
+secretName = "alpha-authorization-header"
 acceptInsecureRouting = true
 methods = ["GET", "POST", "DELETE"]
 
-[[picoclaw-alpha.path]]
+[[alpha.path]]
 # Media upload (media-upload feature): stores a file in the caller's workspace,
 # role-gated with write (same chain as chat). POST multipart only.
 group = { protectedByRoles = [{ name = "alpha", permission = "write" }] }
 path = "/v1/media"
-secretName = "picoclaw-alpha-authorization-header"
+secretName = "alpha-authorization-header"
 acceptInsecureRouting = true
 methods = ["GET", "POST", "DELETE"]
 
-[[picoclaw-alpha.path]]
+[[alpha.path]]
 # Workspace memory (conversation-enrichment): the user edits MEMORY_CUSTOM.md at
 # the workspace root, write-gated like /v1/media. GET reads it, PUT replaces it.
 group = { protectedByRoles = [{ name = "alpha", permission = "write" }] }
 path = "/v1/memory"
-secretName = "picoclaw-alpha-authorization-header"
+secretName = "alpha-authorization-header"
 acceptInsecureRouting = true
 methods = ["GET", "PUT"]
 
@@ -274,270 +280,191 @@ methods = ["GET", "PUT"]
 # secretName injects the bearer token so the proxy's resolveAgent anti-bypass
 # still applies. There is deliberately NO /v1/admin/users/files/content route and
 # no user-file write route (FR-7 privacy invariant).
-[[picoclaw-alpha.path]]
+[[alpha.path]]
+# All /v1/admin/* endpoints share group=protected + this secret; the
+# proxy enforces the exact path+method per route. Collapsed to one
+# wildcard (mycelium matches via the wildmatch crate).
 group = "protected"
-path = "/v1/admin/scopes"
-secretName = "picoclaw-alpha-authorization-header"
+path = "/v1/admin/*"
+secretName = "alpha-authorization-header"
 acceptInsecureRouting = true
-methods = ["GET"]
+methods = ["GET", "POST", "PUT", "DELETE"]
 
-[[picoclaw-alpha.path]]
-group = "protected"
-path = "/v1/admin/shared"
-secretName = "picoclaw-alpha-authorization-header"
-acceptInsecureRouting = true
-methods = ["GET", "POST", "DELETE"]
-
-[[picoclaw-alpha.path]]
-group = "protected"
-path = "/v1/admin/shared/content"
-secretName = "picoclaw-alpha-authorization-header"
-acceptInsecureRouting = true
-methods = ["GET"]
-
-[[picoclaw-alpha.path]]
-group = "protected"
-path = "/v1/admin/skills"
-secretName = "picoclaw-alpha-authorization-header"
-acceptInsecureRouting = true
-methods = ["GET", "POST", "DELETE"]
-
-[[picoclaw-alpha.path]]
-group = "protected"
-path = "/v1/admin/skills/doc"
-secretName = "picoclaw-alpha-authorization-header"
-acceptInsecureRouting = true
-methods = ["GET"]
-
-[[picoclaw-alpha.path]]
-group = "protected"
-path = "/v1/admin/skills/archive"
-secretName = "picoclaw-alpha-authorization-header"
-acceptInsecureRouting = true
-methods = ["GET"]
-
-[[picoclaw-alpha.path]]
-group = "protected"
-path = "/v1/admin/models"
-secretName = "picoclaw-alpha-authorization-header"
-acceptInsecureRouting = true
-methods = ["GET"]
-
-[[picoclaw-alpha.path]]
-group = "protected"
-path = "/v1/admin/model"
-secretName = "picoclaw-alpha-authorization-header"
-acceptInsecureRouting = true
-methods = ["GET", "PUT", "DELETE"]
-
-[[picoclaw-alpha.path]]
-group = "protected"
-path = "/v1/admin/model/users"
-secretName = "picoclaw-alpha-authorization-header"
-acceptInsecureRouting = true
-methods = ["GET"]
-
-[[picoclaw-alpha.path]]
-group = "protected"
-path = "/v1/admin/registered-models"
-secretName = "picoclaw-alpha-authorization-header"
-acceptInsecureRouting = true
-methods = ["GET", "POST", "DELETE"]
-
-[[picoclaw-alpha.path]]
-group = "protected"
-path = "/v1/admin/registered-models/apply"
-secretName = "picoclaw-alpha-authorization-header"
-acceptInsecureRouting = true
-methods = ["POST"]
-
-[[picoclaw-alpha.path]]
-group = "protected"
-path = "/v1/admin/shared-secrets"
-secretName = "picoclaw-alpha-authorization-header"
-acceptInsecureRouting = true
-methods = ["GET", "POST", "DELETE"]
-
-[[picoclaw-alpha.path]]
-group = "protected"
-path = "/v1/admin/users"
-secretName = "picoclaw-alpha-authorization-header"
-acceptInsecureRouting = true
-methods = ["GET"]
-
-[[picoclaw-alpha.path]]
-group = "protected"
-path = "/v1/admin/users/files"
-secretName = "picoclaw-alpha-authorization-header"
-acceptInsecureRouting = true
-methods = ["GET", "DELETE"]
-
-[[picoclaw-beta]]
+[[beta]]
 host = "crab-shell-proxy:8080"
 protocol = "http"
 healthCheckPath = "/healthz"
+discoverable = true
+serviceType = "rest-api"
+isContextApi = false
+openapiPath = "/doc/openapi.json"
+capabilities = ["chat"]
+description = "PicoClaw agent 'beta' - an OpenAI-compatible personal chat agent. Each user gets an isolated container; send chat via POST /v1/chat/completions."
 
-[[picoclaw-beta.secret]]
-name = "picoclaw-beta-authorization-header"
+[[beta.secret]]
+name = "beta-authorization-header"
 authorizationHeader = { headerName = "Authorization", prefix = "Bearer", token = { env = "MYC_PICOCLAW_BETA_TOKEN" } }
 
-[[picoclaw-beta.path]]
+[[beta.path]]
 group = { protectedByRoles = [{ name = "beta", permission = "write" }] }
 path = "/v1/chat/completions"
-secretName = "picoclaw-beta-authorization-header"
+secretName = "beta-authorization-header"
 acceptInsecureRouting = true
 methods = ["POST"]
 
-[[picoclaw-beta.path]]
+[[beta.path]]
 group = { protectedByRoles = [{ name = "beta" }] }
 path = "/v1/models"
-secretName = "picoclaw-beta-authorization-header"
+secretName = "beta-authorization-header"
 acceptInsecureRouting = true
 methods = ["GET"]
 
-[[picoclaw-beta.path]]
+[[beta.path]]
 group = { protectedByRoles = [{ name = "beta" }] }
 path = "/v1/sessions/history"
-secretName = "picoclaw-beta-authorization-header"
+secretName = "beta-authorization-header"
 acceptInsecureRouting = true
 methods = ["GET"]
 
-[[picoclaw-beta.path]]
-# Session linkage (see the picoclaw-alpha /v1/sessions/resolve comment).
+[[beta.path]]
+# Session linkage (see the alpha /v1/sessions/resolve comment).
 group = { protectedByRoles = [{ name = "beta" }] }
 path = "/v1/sessions/resolve"
-secretName = "picoclaw-beta-authorization-header"
+secretName = "beta-authorization-header"
 acceptInsecureRouting = true
 methods = ["GET"]
 
-[[picoclaw-beta.path]]
-# Agent-agnostic discovery (see the picoclaw-alpha /v1/subscriptions comment).
+[[beta.path]]
+# Agent-agnostic discovery (see the alpha /v1/subscriptions comment).
 group = "protected"
 path = "/v1/subscriptions"
-secretName = "picoclaw-beta-authorization-header"
+secretName = "beta-authorization-header"
 acceptInsecureRouting = true
 methods = ["GET"]
 
-[[picoclaw-beta.path]]
-# Secret injection (see the picoclaw-alpha /v1/secrets comment).
+[[beta.path]]
+# Secret injection (see the alpha /v1/secrets comment).
 group = { protectedByRoles = [{ name = "beta", permission = "write" }] }
 path = "/v1/secrets"
-secretName = "picoclaw-beta-authorization-header"
+secretName = "beta-authorization-header"
 acceptInsecureRouting = true
 methods = ["GET", "POST", "DELETE"]
 
-[[picoclaw-beta.path]]
-# Media upload (see the picoclaw-alpha /v1/media comment).
+[[beta.path]]
+# Media upload (see the alpha /v1/media comment).
 group = { protectedByRoles = [{ name = "beta", permission = "write" }] }
 path = "/v1/media"
-secretName = "picoclaw-beta-authorization-header"
+secretName = "beta-authorization-header"
 acceptInsecureRouting = true
 methods = ["GET", "POST", "DELETE"]
 
-[[picoclaw-beta.path]]
-# Workspace memory (see the picoclaw-alpha /v1/memory comment).
+[[beta.path]]
+# Workspace memory (see the alpha /v1/memory comment).
 group = { protectedByRoles = [{ name = "beta", permission = "write" }] }
 path = "/v1/memory"
-secretName = "picoclaw-beta-authorization-header"
+secretName = "beta-authorization-header"
 acceptInsecureRouting = true
 methods = ["GET", "PUT"]
 
-# admin-shared-content (see the picoclaw-alpha /v1/admin comment). `protected`,
+# admin-shared-content (see the alpha /v1/admin comment). `protected`,
 # tier resolved in-proxy; no user-file content/write route (FR-7).
-[[picoclaw-beta.path]]
+[[beta.path]]
+# All /v1/admin/* endpoints share group=protected + this secret; the
+# proxy enforces the exact path+method per route. Collapsed to one
+# wildcard (mycelium matches via the wildmatch crate).
 group = "protected"
-path = "/v1/admin/scopes"
-secretName = "picoclaw-beta-authorization-header"
+path = "/v1/admin/*"
+secretName = "beta-authorization-header"
 acceptInsecureRouting = true
-methods = ["GET"]
+methods = ["GET", "POST", "PUT", "DELETE"]
 
-[[picoclaw-beta.path]]
-group = "protected"
-path = "/v1/admin/shared"
-secretName = "picoclaw-beta-authorization-header"
-acceptInsecureRouting = true
-methods = ["GET", "POST", "DELETE"]
+# ------------------------------------------------------------------------------
+# hermes-glm: a Nous Research hermes-agent instance (harness = "hermes" in
+# crab-shell-proxy/config.yaml), routed to the same crab-shell-proxy downstream.
+# crab-shell-proxy tells it apart via x-mycelium-service-name = "hermes-glm" and
+# drives the container over its OpenAI-compatible API server (:8642) instead of
+# the Pico Protocol. Same auth/role contract as the picoclaw services above: the
+# "hermes-glm" guest-role is auto-declared here; granting it to an account still
+# needs the Staff -> tenant -> subscription -> guest-invite chain (M3).
+# ------------------------------------------------------------------------------
 
-[[picoclaw-beta.path]]
-group = "protected"
-path = "/v1/admin/shared/content"
-secretName = "picoclaw-beta-authorization-header"
-acceptInsecureRouting = true
-methods = ["GET"]
+[[hermes-glm]]
+host = "crab-shell-proxy:8080"
+protocol = "http"
+healthCheckPath = "/healthz"
+discoverable = true
+serviceType = "rest-api"
+isContextApi = false
+openapiPath = "/doc/openapi.json"
+capabilities = ["chat"]
+description = "Hermes-agent (Nous Research, GLM via z.ai) - an OpenAI-compatible personal chat agent. Each user gets an isolated container; send chat via POST /v1/chat/completions."
 
-[[picoclaw-beta.path]]
-group = "protected"
-path = "/v1/admin/skills"
-secretName = "picoclaw-beta-authorization-header"
-acceptInsecureRouting = true
-methods = ["GET", "POST", "DELETE"]
+[[hermes-glm.secret]]
+name = "hermes-glm-authorization-header"
+authorizationHeader = { headerName = "Authorization", prefix = "Bearer", token = { env = "MYC_HERMES_GLM_TOKEN" } }
 
-[[picoclaw-beta.path]]
-group = "protected"
-path = "/v1/admin/skills/doc"
-secretName = "picoclaw-beta-authorization-header"
-acceptInsecureRouting = true
-methods = ["GET"]
-
-[[picoclaw-beta.path]]
-group = "protected"
-path = "/v1/admin/skills/archive"
-secretName = "picoclaw-beta-authorization-header"
-acceptInsecureRouting = true
-methods = ["GET"]
-
-[[picoclaw-beta.path]]
-group = "protected"
-path = "/v1/admin/models"
-secretName = "picoclaw-beta-authorization-header"
-acceptInsecureRouting = true
-methods = ["GET"]
-
-[[picoclaw-beta.path]]
-group = "protected"
-path = "/v1/admin/model"
-secretName = "picoclaw-beta-authorization-header"
-acceptInsecureRouting = true
-methods = ["GET", "PUT", "DELETE"]
-
-[[picoclaw-beta.path]]
-group = "protected"
-path = "/v1/admin/model/users"
-secretName = "picoclaw-beta-authorization-header"
-acceptInsecureRouting = true
-methods = ["GET"]
-
-[[picoclaw-beta.path]]
-group = "protected"
-path = "/v1/admin/registered-models"
-secretName = "picoclaw-beta-authorization-header"
-acceptInsecureRouting = true
-methods = ["GET", "POST", "DELETE"]
-
-[[picoclaw-beta.path]]
-group = "protected"
-path = "/v1/admin/registered-models/apply"
-secretName = "picoclaw-beta-authorization-header"
+[[hermes-glm.path]]
+group = { protectedByRoles = [{ name = "hermes-glm", permission = "write" }] }
+path = "/v1/chat/completions"
+secretName = "hermes-glm-authorization-header"
 acceptInsecureRouting = true
 methods = ["POST"]
 
-[[picoclaw-beta.path]]
-group = "protected"
-path = "/v1/admin/shared-secrets"
-secretName = "picoclaw-beta-authorization-header"
-acceptInsecureRouting = true
-methods = ["GET", "POST", "DELETE"]
-
-[[picoclaw-beta.path]]
-group = "protected"
-path = "/v1/admin/users"
-secretName = "picoclaw-beta-authorization-header"
+[[hermes-glm.path]]
+group = { protectedByRoles = [{ name = "hermes-glm" }] }
+path = "/v1/models"
+secretName = "hermes-glm-authorization-header"
 acceptInsecureRouting = true
 methods = ["GET"]
 
-[[picoclaw-beta.path]]
-group = "protected"
-path = "/v1/admin/users/files"
-secretName = "picoclaw-beta-authorization-header"
+[[hermes-glm.path]]
+group = { protectedByRoles = [{ name = "hermes-glm" }] }
+path = "/v1/sessions/history"
+secretName = "hermes-glm-authorization-header"
 acceptInsecureRouting = true
-methods = ["GET", "DELETE"]
+methods = ["GET"]
+
+[[hermes-glm.path]]
+group = { protectedByRoles = [{ name = "hermes-glm" }] }
+path = "/v1/sessions/resolve"
+secretName = "hermes-glm-authorization-header"
+acceptInsecureRouting = true
+methods = ["GET"]
+
+[[hermes-glm.path]]
+group = "protected"
+path = "/v1/subscriptions"
+secretName = "hermes-glm-authorization-header"
+acceptInsecureRouting = true
+methods = ["GET"]
+
+[[hermes-glm.path]]
+group = { protectedByRoles = [{ name = "hermes-glm", permission = "write" }] }
+path = "/v1/secrets"
+secretName = "hermes-glm-authorization-header"
+acceptInsecureRouting = true
+methods = ["GET", "POST", "DELETE"]
+
+[[hermes-glm.path]]
+group = { protectedByRoles = [{ name = "hermes-glm", permission = "write" }] }
+path = "/v1/media"
+secretName = "hermes-glm-authorization-header"
+acceptInsecureRouting = true
+methods = ["GET", "POST", "DELETE"]
+
+[[hermes-glm.path]]
+group = { protectedByRoles = [{ name = "hermes-glm", permission = "write" }] }
+path = "/v1/memory"
+secretName = "hermes-glm-authorization-header"
+acceptInsecureRouting = true
+methods = ["GET", "PUT"]
+
+[[hermes-glm.path]]
+# All /v1/admin/* endpoints share group=protected + this secret; the
+# proxy enforces the exact path+method per route. Collapsed to one
+# wildcard (mycelium matches via the wildmatch crate).
+group = "protected"
+path = "/v1/admin/*"
+secretName = "hermes-glm-authorization-header"
+acceptInsecureRouting = true
+methods = ["GET", "POST", "PUT", "DELETE"]

--- a/fungi/mycelium/config.standalone.toml
+++ b/fungi/mycelium/config.standalone.toml
@@ -339,6 +339,20 @@ methods = ["GET"]
 
 [[picoclaw-alpha.path]]
 group = "protected"
+path = "/v1/admin/registered-models"
+secretName = "picoclaw-alpha-authorization-header"
+acceptInsecureRouting = true
+methods = ["GET", "POST", "DELETE"]
+
+[[picoclaw-alpha.path]]
+group = "protected"
+path = "/v1/admin/registered-models/apply"
+secretName = "picoclaw-alpha-authorization-header"
+acceptInsecureRouting = true
+methods = ["POST"]
+
+[[picoclaw-alpha.path]]
+group = "protected"
 path = "/v1/admin/shared-secrets"
 secretName = "picoclaw-alpha-authorization-header"
 acceptInsecureRouting = true
@@ -492,6 +506,20 @@ path = "/v1/admin/model/users"
 secretName = "picoclaw-beta-authorization-header"
 acceptInsecureRouting = true
 methods = ["GET"]
+
+[[picoclaw-beta.path]]
+group = "protected"
+path = "/v1/admin/registered-models"
+secretName = "picoclaw-beta-authorization-header"
+acceptInsecureRouting = true
+methods = ["GET", "POST", "DELETE"]
+
+[[picoclaw-beta.path]]
+group = "protected"
+path = "/v1/admin/registered-models/apply"
+secretName = "picoclaw-beta-authorization-header"
+acceptInsecureRouting = true
+methods = ["POST"]
 
 [[picoclaw-beta.path]]
 group = "protected"

--- a/fungi/mycelium/config.standalone.toml
+++ b/fungi/mycelium/config.standalone.toml
@@ -297,6 +297,27 @@ methods = ["GET"]
 
 [[picoclaw-alpha.path]]
 group = "protected"
+path = "/v1/admin/skills"
+secretName = "picoclaw-alpha-authorization-header"
+acceptInsecureRouting = true
+methods = ["GET", "POST", "DELETE"]
+
+[[picoclaw-alpha.path]]
+group = "protected"
+path = "/v1/admin/skills/doc"
+secretName = "picoclaw-alpha-authorization-header"
+acceptInsecureRouting = true
+methods = ["GET"]
+
+[[picoclaw-alpha.path]]
+group = "protected"
+path = "/v1/admin/skills/archive"
+secretName = "picoclaw-alpha-authorization-header"
+acceptInsecureRouting = true
+methods = ["GET"]
+
+[[picoclaw-alpha.path]]
+group = "protected"
 path = "/v1/admin/shared-secrets"
 secretName = "picoclaw-alpha-authorization-header"
 acceptInsecureRouting = true
@@ -405,6 +426,27 @@ methods = ["GET", "POST", "DELETE"]
 [[picoclaw-beta.path]]
 group = "protected"
 path = "/v1/admin/shared/content"
+secretName = "picoclaw-beta-authorization-header"
+acceptInsecureRouting = true
+methods = ["GET"]
+
+[[picoclaw-beta.path]]
+group = "protected"
+path = "/v1/admin/skills"
+secretName = "picoclaw-beta-authorization-header"
+acceptInsecureRouting = true
+methods = ["GET", "POST", "DELETE"]
+
+[[picoclaw-beta.path]]
+group = "protected"
+path = "/v1/admin/skills/doc"
+secretName = "picoclaw-beta-authorization-header"
+acceptInsecureRouting = true
+methods = ["GET"]
+
+[[picoclaw-beta.path]]
+group = "protected"
+path = "/v1/admin/skills/archive"
 secretName = "picoclaw-beta-authorization-header"
 acceptInsecureRouting = true
 methods = ["GET"]


### PR DESCRIPTION
Project-level wiring for multi-harness support (Nous Research **Hermes Agent** as the first non-picoclaw target). Companion PRs: `crab-shell-proxy` #4 and `crab-exoskeleton-webapp` #5 (submodules bumped here).

## Changes
- **mycelium** `config.standalone.toml` + `config.base.toml`: services renamed so the service key equals the guest-role (`picoclaw-alpha`→`alpha`, `picoclaw-beta`→`beta`), added the `hermes-glm` service. All services marked `discoverable` with `openapiPath=/doc/openapi.json` so they surface in `/tools`. Each service's ~14 per-path `/v1/admin/*` routes collapsed to a single wildcard entry (mycelium matches via the `wildmatch` crate; verified no route overlap).
- **docker-compose.yaml**: hermes env passthrough — `MYC_HERMES_GLM_TOKEN` (proxy + gateway), `PROXY_GLM_API_KEY` (proxy).
- **.env.example**: documents the new hermes token + GLM key.
- **submodules**: bump `crab-shell-proxy` (multi-harness + OpenAPI) and `crab-exoskeleton-webapp` (route-by-role + /tools).
- **.specs/features/multi-harness-support/spec.md** updates.

## Status
Hermes chat verified working end-to-end against a live GLM/z.ai container. Deferred (tracked in spec): hermes latency tuning (lean profile), /tools health-detection refinement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)