### PR TITLE
chore: rule — always call mycelium over JSON-RPC

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,61 @@
+# zombie-crab-project — Claude Code instructions
+
+Monorepo-wide rules. Each submodule has its own `.claude/CLAUDE.md` for rules that
+only apply inside it; this file holds what applies across the stack.
+
+## Calling mycelium
+
+**Always call mycelium over JSON-RPC. Never add a new call to its REST surface.**
+
+Mycelium's gateway exposes both a REST API and a JSON-RPC 2.0 endpoint at
+`POST /_adm/rpc`. The two are not interchangeable, and REST is the wrong default:
+
+- The REST `beginners` endpoints are **external-identity-provider only**. For a
+  magic-link user they answer `400 "Invalid provider"`. The RPC dispatcher resolves
+  the internal issuer instead, so it is the only transport that works for this
+  deployment's own users. This was established empirically, not assumed — see
+  `crab/crab-exoskeleton-webapp/.specs/features/onboarding/context.md`.
+- The RPC surface is broader and named consistently. Whole operations (guest
+  invite/uninvite, account get) have no equivalent this stack can reach over REST.
+
+### How
+
+Envelope: `{"jsonrpc": "2.0", "method": "<name>", "params": {...}, "id": 1}` with
+`Authorization: Bearer <session token>`. Params are **camelCase**.
+
+In `crab-exoskeleton-webapp`, this means `myceliumRpc()` from `lib/mycelium.ts` —
+never a new `fetchMycelium()` path. Its one legitimate REST use is the pre-session
+magic-link request/verify pair, which has no token to authenticate RPC with.
+
+### Finding method names — never guess one
+
+The authoritative registry is `ports/api/src/rpc/method_names.rs` in the mycelium
+checkout, and `rpc.discover` returns an OpenRPC self-description at runtime. An
+invented method name fails at runtime only, and the failure looks like a
+permissions problem. Look it up.
+
+Note that RPC names do not always match REST vocabulary: REST's `uninvite_guest`
+is `subscriptionsManager.guests.revokeUserGuestToSubscriptionAccount` over RPC.
+
+### Wire shapes that have already caused bugs
+
+Check the Rust DTO before trusting a field's shape — the reference
+`mycelium-webapp` TypeScript types have been wrong about several of these:
+
+- **`Parent<T, Id>` is an externally tagged enum**: `{"record": {...}}` or
+  `{"id": "<uuid>"}` — *not* a flat object. Reading it flat silently produced
+  unlabelled roles and hid a whole UI affordance.
+- **`Email` is `{username, domain}`**, not a string.
+- **A permission** arrives as either its `0`/`1` discriminant or its string form
+  (`"read"`/`"write"`), depending on the serializer. Normalize both, and match
+  exactly — `"overwrite"` contains `"write"`.
+- **List results** may be a bare array or a paginated envelope
+  `{count, skip, size, records}`. Unwrap both.
+- **Page sizes default small** (10 for guest roles). Pass `pageSize` explicitly;
+  a truncated list looks like missing data, not like an error.
+
+### Where this rule does not apply
+
+Requests routed through **crab-shell-proxy** — `/{agent}/v1/...` and
+`/alpha/v1/admin/...` — are the proxy's own HTTP API, not mycelium's. Those stay
+REST. "Talk to mycelium over JSON-RPC" is not "convert the proxy to JSON-RPC".

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ data/
 
 # Real deploy env files with secrets (deploy/<mode>/.env) — never commit
 deploy/**/.env
+
+# Git worktrees created by tooling under .claude/ — never part of the tree
+.claude/worktrees/


### PR DESCRIPTION
## What

Adds `.claude/CLAUDE.md` at the monorepo root (the directory did not exist; both
submodules already have their own) with one rule: **always call mycelium over JSON-RPC,
never add a new call to its REST surface.**

## Why

Mycelium's gateway exposes both, and they are not interchangeable:

- The REST `beginners` endpoints are **external-identity-provider only** — for a
  magic-link user they answer `400 "Invalid provider"`. The RPC dispatcher resolves the
  internal issuer, so it is the only transport that works for this deployment's own
  users. Established empirically; see `.specs/features/onboarding/context.md` in the
  webapp.
- Whole operations (guest invite/uninvite, account get) have no equivalent this stack can
  reach over REST.

## Also recorded

- **How to find a method name instead of guessing one** — `method_names.rs` in the
  mycelium checkout, or `rpc.discover` at runtime. RPC names don't mirror REST
  vocabulary: REST's `uninvite_guest` is
  `subscriptionsManager.guests.revokeUserGuestToSubscriptionAccount`.
- **Wire shapes that have already caused bugs** — externally tagged `Parent<T, Id>`
  (`{"record": {...}}`, which just cost a hidden UI affordance), `Email` as
  `{username, domain}`, permission as either `0`/`1` or a string, list results as either
  a bare array or a paginated envelope, and small default page sizes.
- **Where the rule does not apply** — requests routed through crab-shell-proxy
  (`/{agent}/v1/...`, `/alpha/v1/admin/...`) are the *proxy's* API, not mycelium's, and
  stay REST. Stated explicitly so the rule doesn't get over-applied.

Also ignores `.claude/worktrees/`, matching the submodules' convention, so tooling
worktrees cannot be committed alongside this directory.

Companion PR (the change that surfaced all of this):
LepistaBioinformatics/crab-exoskeleton-webapp#24

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added project-wide development guidance to promote consistent behavior and integration practices.
  * Updated version-control settings to prevent temporary tooling files from being included in the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->