### PR TITLE
chore(deploy): bring prod/dokploy back in line with standalone, on rc.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,13 +146,20 @@ scaffold. See [Creating a Custom Agent](./docs/CREATE_CUSTOM_AGENT.md) to shape
 a template, and [Running and resetting from scratch](#running-and-resetting-from-scratch)
 for the self-heal behavior.
 
-**3. Configure `.env`.** Copy the matching `deploy/<mode>/.env.example` (standalone / prod / dokploy) to `.env` and set:
+**3. Configure `.env`.** Copy the matching `deploy/<mode>/.env.example` (standalone / prod / dokploy — see [Deploy modes](#deploy-modes)) to `.env` at the repo root and set:
 
-- `MYC_PICOCLAW_ALPHA_TOKEN` / `MYC_PICOCLAW_BETA_TOKEN` — bearer tokens Mycelium
-  injects and crab-shell-proxy validates per agent.
-- `PICOCLAW_ALPHA_API_KEY` / `PICOCLAW_BETA_API_KEY` — each agent's **own** LLM
-  key, read from the environment (never stored in config or images).
+- `MYC_PICOCLAW_ALPHA_TOKEN` / `MYC_PICOCLAW_BETA_TOKEN` / `MYC_HERMES_GLM_TOKEN`
+  — bearer tokens Mycelium injects and crab-shell-proxy validates per agent.
+- `PICOCLAW_ALPHA_API_KEY` / `PICOCLAW_BETA_API_KEY` / `PROXY_GLM_API_KEY` — each
+  agent's **own** LLM key, read from the environment (never stored in config or
+  images).
 - `MYC_STANDALONE_BOOTSTRAP_SECRET` — gates the one-time Staff bootstrap.
+
+The stack ships three agents: `alpha` and `beta` (picoclaw) and `hermes-glm` (a
+hermes-agent instance from Nous Research, driven over its OpenAI-compatible
+server instead of the Pico Protocol). An agent whose
+token or provider key is unset is auto-disabled by the proxy at startup, so you
+can run only the ones you have keys for.
 
 Which provider/model each agent uses is declared in
 [`crab/crab-shell-proxy/config.yaml`](./crab/crab-shell-proxy/config.yaml) (e.g.
@@ -177,11 +184,14 @@ docker compose logs mycelium-gateway | grep -i bootstrap
 (`http://localhost:${CHAT_WEBAPP_PORT:-3000}`), sign in with your email
 (magic-link, no password), pick an agent, and chat. Your first message
 cold-starts *your own* container; `docker ps` will show
-`picoclaw-alpha-<your-accId>` running as a non-root user.
+`crabshell-alpha-<hash>` running as a non-root user (the hash is the
+tenant + subscription + account triple — a container name has a 63-char limit,
+so the identity lives in the container's labels, not in its name).
 
-> The gateway routes are `protectedByRoles` (roles `alpha` / `beta`), so an
-> account must hold the matching guest-role to reach an instance. Assigning
-> roles is done from **`mycelium-webapp`**
+> The gateway routes are `protectedByRoles` (roles `alpha` / `beta` /
+> `hermes-glm`), so an account must hold the matching guest-role to reach an
+> instance. Roles can be granted from the **chat-webapp admin area**
+> (Members → invite) or from **`mycelium-webapp`**
 > (`http://localhost:${MYCELIUM_WEBAPP_PORT:-8081}`) — Mycelium's own admin UI —
 > via the Staff → tenant → subscription → guest-invite flow.
 
@@ -194,7 +204,7 @@ the on-disk state, and rebuild:
 
 ```bash
 docker compose down
-docker rm -f $(docker ps -aq --filter 'name=picoclaw') 2>/dev/null   # agents spawned outside compose
+docker rm -f $(docker ps -aq --filter 'name=crabshell') 2>/dev/null   # agents spawned outside compose
 
 # on-disk state is owned by the spawned (non-root) agents -> sudo
 sudo rm -rf data/templates data/tenants data/effective-secrets \
@@ -204,9 +214,11 @@ docker compose up -d --build   # --build is REQUIRED: the fallback template is b
 ```
 
 Then sign in and send a message — the proxy re-provisions your user from
-scratch. The Postgres volume (Mycelium accounts/roles) is **separate** and is
-not wiped, so your login survives; add `-v` to `docker compose down` only if you
-also want to reset accounts (you'd then re-run the Staff bootstrap).
+scratch. Accounts and roles live in the named volumes, **not** in `data/`, so
+they are not wiped: in standalone that is `mycelium-data` (Mycelium's SQLite
+database), plus `chat-webapp-postgres-data` for the conversation list. Your
+login survives; add `-v` to `docker compose down` only if you also want to reset
+accounts (you'd then re-run the Staff bootstrap).
 
 **Why no manual recovery is needed:** the proxy **auto-bootstraps** a missing
 `data/templates/<agent>/` from a default template **embedded in its binary**, so
@@ -217,16 +229,106 @@ embedded default, edit
 `crab/crab-shell-proxy/internal/docker/defaulttemplate/<harness>/` (today:
 `picoclaw`) and rebuild.
 
+## Deploy modes
+
+Three profiles live side by side. Each has a directory under `deploy/` holding
+its `.env.example` and the gateway config that mode mounts — copy the matching
+`.env.example` to `.env` at the repo root and use that mode's compose command.
+
+| | **standalone** (default) | **prod** | **dokploy** |
+|---|---|---|---|
+| Compose | `docker compose up -d` | `docker compose -f docker-compose.yaml -f docker-compose.prod.yaml up -d` | `docker compose -f docker-compose.dokploy.yaml up -d` (or point Dokploy at this repo + file) |
+| Mycelium | built from source (`MYCELIUM_GIT_REF`) | published image (`MYCELIUM_IMAGE_TAG`) | published image (`MYCELIUM_IMAGE_TAG`) |
+| Storage | SQLite in `mycelium-data` | `mycelium-postgres` | `mycelium-postgres` |
+| E-mail | stub — magic links land in the log | real SMTP | real SMTP |
+| Ingress | published host ports | published host ports | Traefik, one domain per service |
+| Agents | alpha · beta · hermes-glm | alpha · beta · hermes-glm | alpha · beta |
+| Gateway config | `deploy/standalone/config.standalone.toml` | `deploy/prod/config.base.toml` | `deploy/dokploy/config.base.toml` |
+| Agent catalog | baked in the proxy image | baked in the proxy image | mounted: `deploy/dokploy/crab-shell-proxy.config.yaml` |
+
+All three pin the **same Mycelium release**: standalone builds the commit tagged
+`9.0.0-rc.13`, prod and dokploy pull `MYCELIUM_IMAGE_TAG=9.0.0-rc.13`. Move them
+together — the gateway config is shared vocabulary, and a version skew between
+what you test and what you deploy is exactly where it breaks.
+
+### One-time database schema (prod and dokploy only)
+
+The Postgres backend has **no embedded migrations** (SQLite does), so the schema
+has to be applied once, after the first `up`. It takes **two steps**: upstream's
+`up.sql`, then the migration scripts `up.sql` does *not* fold in. Get both from
+the mycelium repo at the tag this deploy pins:
+
+```bash
+git clone --depth 1 --branch 9.0.0-rc.13 \
+  https://github.com/LepistaBioinformatics/mycelium.git /tmp/myc
+cd /path/to/zombie-crab-project && set -a; . ./.env; set +a
+
+# 1) base schema
+docker compose -f docker-compose.yaml -f docker-compose.prod.yaml exec -T mycelium-postgres \
+  psql -U "$MYC_DB_USER" -d postgres \
+       -v db_name="$MYC_DB_NAME" -v db_user="$MYC_DB_USER" \
+       -v db_password="$MYC_DB_PASSWORD" -v db_role=service-role-mycelium \
+  < /tmp/myc/adapters/diesel_postgres/sql/up.sql
+
+# 2) the migrations, in filename order
+for m in /tmp/myc/adapters/diesel_postgres/sql/migrations/*.sql; do
+  docker compose -f docker-compose.yaml -f docker-compose.prod.yaml exec -T mycelium-postgres \
+    psql -U "$MYC_DB_USER" -d "$MYC_DB_NAME" < "$m"
+done
+```
+
+Step 1 creates the database if missing, `\c`s into it, then creates the roles and
+tables; it **requires** `-v db_password`. Compose already created the database
+**and** the login role, so `CREATE USER … already exists` is expected and
+harmless — psql keeps going.
+
+Step 2 is not optional at `9.0.0-rc.13`: `up.sql` at this tag ships `kv_artifact`
+and the `message_queue` claim index, but **not** `instance_settings`,
+`resource_audit_log`, or the `tenant.encrypted_dek` / `kek_version` columns
+(envelope encryption) — those exist only as migrations. Verify with `\dt` (you
+should see `instance_settings` and `resource_audit_log`) and
+`\d tenant` (`encrypted_dek`, `kek_version`). For Dokploy, run the same two steps
+via `docker exec` on the `mycelium-postgres` container.
+
+### Before a prod or dokploy deploy
+
+- **`CRAB_HOST_DATA_ROOT`** — must be an absolute **host** path. crab-shell-proxy
+  hands it to the host Docker daemon as the bind-mount source for the agent
+  containers it spawns, so a path inside the proxy won't resolve.
+- **prod / `deploy/prod/config.base.toml`** — set `noreplyEmail` and
+  `supportEmail` to `MYC_SMTP_USERNAME` (Gmail rejects a mismatched `From`).
+  `domainUrl` / `allowedOrigins` ship pointing at the localhost origins this mode
+  actually serves; if you front it with a hostname, change them **together with**
+  `mycelium-webapp`'s `VITE_MYCELIUM_API_URL` build arg — the admin UI is a
+  browser-side SPA that calls the gateway directly, so a mismatch is a CORS wall.
+- **dokploy / `deploy/dokploy/config.base.toml`** — replace the `►►► REPLACE`
+  lines with your real `https://` origins (they must match `MYCELIUM_DOMAIN` and
+  `MYCELIUM_WEBAPP_DOMAIN`), and remember `dokploy-network` must already exist.
+- **Agent catalog** — dokploy mounts `deploy/dokploy/crab-shell-proxy.config.yaml`,
+  so agents can be added or dropped there without rebuilding the proxy image.
+  standalone and prod use the catalog baked into the image
+  (`crab/crab-shell-proxy/config.yaml`).
+- **Account webhook (optional)** — registering mycelium's
+  `subscriptionAccount.created` webhook makes the proxy scaffold a subscription's
+  workspace root up front instead of on the member's first chat. Over JSON-RPC
+  (`POST /_adm/rpc`, Staff token), method `systemManager.webhooks.create`:
+  `{"name": "crab-shell-proxy", "url": "http://crab-shell-proxy:8080/v1/accounts",
+  "trigger": "subscriptionAccount.created", "method": "POST", "secret":
+  {"authorizationHeader": {"headerName": "Authorization", "prefix": "Bearer",
+  "token": "<CRAB_WEBHOOK_SECRET>"}}}`.
+
 ## Day-2 administration
 
-Managing models, shared skills, shared secrets, files, members, and branding is
-done from the **chat-webapp admin area** — see the
+Managing models, shared skills, shared secrets, files, personas, members, and
+branding is done from the **chat-webapp admin area** — see the
 [Admin Guide](./docs/ADMIN_GUIDE.md).
 
 ## What's in this repo
 
 ```
-docker-compose.yaml        # the whole stack (gateway + crab-shell-proxy + webapps + db)
+docker-compose.yaml        # the whole stack, standalone/default (gateway + crab-shell-proxy + webapps + db)
+docker-compose.prod.yaml   # prod overlay: published images + mycelium in Postgres mode (-f with the above)
+docker-compose.dokploy.yaml# self-contained Traefik/Dokploy file (base + prod + ingress already merged)
 deploy/                    # per-mode configs: .env examples + mycelium/proxy configs (standalone / prod / dokploy)
 crab/                      # the crab side (per-user isolation + its chat client)
   crab-shell-proxy/        # git submodule — the Go per-user isolation orchestrator

--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -148,13 +148,20 @@ segredos. Veja [Criando um Agente Customizado](./docs/CREATE_CUSTOM_AGENT.pt-br.
 para moldar um template, e [Rodando e resetando do zero](#rodando-e-resetando-do-zero)
 para o comportamento de auto-recuperação.
 
-**3. Configure o `.env`.** Copie o `deploy/<modo>/.env.example` correspondente (standalone / prod / dokploy) para `.env` e defina:
+**3. Configure o `.env`.** Copie o `deploy/<modo>/.env.example` correspondente (standalone / prod / dokploy — veja [Modos de deploy](#modos-de-deploy)) para `.env` na raiz do repositório e defina:
 
-- `MYC_PICOCLAW_ALPHA_TOKEN` / `MYC_PICOCLAW_BETA_TOKEN` — bearer tokens que o
-  Mycelium injeta e o crab-shell-proxy valida por agente.
-- `PICOCLAW_ALPHA_API_KEY` / `PICOCLAW_BETA_API_KEY` — a chave LLM **própria** de
-  cada agente, lida do ambiente (nunca guardada em config ou imagem).
+- `MYC_PICOCLAW_ALPHA_TOKEN` / `MYC_PICOCLAW_BETA_TOKEN` / `MYC_HERMES_GLM_TOKEN`
+  — bearer tokens que o Mycelium injeta e o crab-shell-proxy valida por agente.
+- `PICOCLAW_ALPHA_API_KEY` / `PICOCLAW_BETA_API_KEY` / `PROXY_GLM_API_KEY` — a
+  chave LLM **própria** de cada agente, lida do ambiente (nunca guardada em
+  config ou imagem).
 - `MYC_STANDALONE_BOOTSTRAP_SECRET` — libera o bootstrap único de Staff.
+
+A stack traz três agentes: `alpha` e `beta` (picoclaw) e `hermes-glm` (uma
+instância do hermes-agent, da Nous Research, conduzida pelo servidor
+OpenAI-compatível dele em vez do Pico Protocol). Um agente cujo token ou chave de
+provider esteja vazio é auto-desabilitado pelo proxy no startup, então dá para
+rodar só os que você tem chave.
 
 Qual provider/model cada agente usa é declarado em
 [`crab/crab-shell-proxy/config.yaml`](./crab/crab-shell-proxy/config.yaml) (ex.:
@@ -179,11 +186,14 @@ docker compose logs mycelium-gateway | grep -i bootstrap
 (`http://localhost:${CHAT_WEBAPP_PORT:-3000}`), entre com seu e-mail
 (magic-link, sem senha), escolha um agente e converse. Sua primeira mensagem faz
 o cold-start do *seu próprio* container; o `docker ps` mostrará
-`picoclaw-alpha-<seu-accId>` rodando como usuário não-root.
+`crabshell-alpha-<hash>` rodando como usuário não-root (o hash é a tripla
+tenant + subscription + conta — nome de container tem limite de 63 caracteres,
+então a identidade fica nas labels, não no nome).
 
-> As rotas do gateway são `protectedByRoles` (papéis `alpha` / `beta`), então uma
-> conta precisa ter o guest-role correspondente para alcançar uma instância. A
-> atribuição de papéis é feita pelo **`mycelium-webapp`**
+> As rotas do gateway são `protectedByRoles` (papéis `alpha` / `beta` /
+> `hermes-glm`), então uma conta precisa ter o guest-role correspondente para
+> alcançar uma instância. Os papéis podem ser concedidos pela **área de admin do
+> chat-webapp** (Membros → convidar) ou pelo **`mycelium-webapp`**
 > (`http://localhost:${MYCELIUM_WEBAPP_PORT:-8081}`) — a UI de admin do próprio
 > Mycelium — via o fluxo Staff → tenant → subscription → guest-invite.
 
@@ -196,7 +206,7 @@ proxy criou, apague o estado em disco e rebuilde:
 
 ```bash
 docker compose down
-docker rm -f $(docker ps -aq --filter 'name=picoclaw') 2>/dev/null   # agentes criados fora do compose
+docker rm -f $(docker ps -aq --filter 'name=crabshell') 2>/dev/null   # agentes criados fora do compose
 
 # o estado em disco pertence aos agentes (não-root) spawnados -> sudo
 sudo rm -rf data/templates data/tenants data/effective-secrets \
@@ -205,10 +215,12 @@ sudo rm -rf data/templates data/tenants data/effective-secrets \
 docker compose up -d --build   # --build é OBRIGATÓRIO: o template de fallback é embutido no binário do proxy
 ```
 
-Depois logue e mande uma mensagem — o proxy re-provisiona seu usuário do zero. O
-volume do Postgres (contas/roles do Mycelium) é **separado** e não é apagado,
-então seu login sobrevive; adicione `-v` ao `docker compose down` só se quiser
-resetar contas também (aí você refaz o bootstrap de Staff).
+Depois logue e mande uma mensagem — o proxy re-provisiona seu usuário do zero.
+Contas e papéis ficam nos volumes nomeados, **não** em `data/`, então não são
+apagados: no standalone isso é o `mycelium-data` (o banco SQLite do Mycelium),
+mais o `chat-webapp-postgres-data` da lista de conversas. Seu login sobrevive;
+adicione `-v` ao `docker compose down` só se quiser resetar contas também (aí
+você refaz o bootstrap de Staff).
 
 **Por que não é preciso recuperação manual:** o proxy faz **auto-bootstrap** de
 um `data/templates/<agente>/` ausente a partir de um template default **embutido
@@ -219,16 +231,112 @@ responder na hora. Para customizar o default embutido, edite
 `crab/crab-shell-proxy/internal/docker/defaulttemplate/<harness>/` (hoje:
 `picoclaw`) e rebuilde.
 
+## Modos de deploy
+
+Três perfis convivem lado a lado. Cada um tem um diretório em `deploy/` com o seu
+`.env.example` e a config do gateway que aquele modo monta — copie o
+`.env.example` correspondente para `.env` na raiz e use o comando de compose do
+modo.
+
+| | **standalone** (padrão) | **prod** | **dokploy** |
+|---|---|---|---|
+| Compose | `docker compose up -d` | `docker compose -f docker-compose.yaml -f docker-compose.prod.yaml up -d` | `docker compose -f docker-compose.dokploy.yaml up -d` (ou aponte o Dokploy para este repo + arquivo) |
+| Mycelium | buildado do fonte (`MYCELIUM_GIT_REF`) | imagem publicada (`MYCELIUM_IMAGE_TAG`) | imagem publicada (`MYCELIUM_IMAGE_TAG`) |
+| Armazenamento | SQLite no `mycelium-data` | `mycelium-postgres` | `mycelium-postgres` |
+| E-mail | stub — os magic-links caem no log | SMTP real | SMTP real |
+| Entrada | portas publicadas no host | portas publicadas no host | Traefik, um domínio por serviço |
+| Agentes | alpha · beta · hermes-glm | alpha · beta · hermes-glm | alpha · beta |
+| Config do gateway | `deploy/standalone/config.standalone.toml` | `deploy/prod/config.base.toml` | `deploy/dokploy/config.base.toml` |
+| Catálogo de agentes | embutido na imagem do proxy | embutido na imagem do proxy | montado: `deploy/dokploy/crab-shell-proxy.config.yaml` |
+
+Os três fixam a **mesma release do Mycelium**: o standalone builda o commit da
+tag `9.0.0-rc.13`, prod e dokploy puxam `MYCELIUM_IMAGE_TAG=9.0.0-rc.13`. Mova
+todos juntos — a config do gateway é vocabulário compartilhado, e uma diferença
+de versão entre o que você testa e o que sobe é exatamente onde quebra.
+
+### Schema do banco, uma vez só (prod e dokploy)
+
+O backend Postgres **não tem migrations embutidas** (o SQLite tem), então o
+schema precisa ser aplicado uma vez, depois do primeiro `up`. São **dois
+passos**: o `up.sql` do upstream e, depois, os scripts de migration que o
+`up.sql` *não* incorpora. Pegue os dois do repo do mycelium na tag que este
+deploy fixa:
+
+```bash
+git clone --depth 1 --branch 9.0.0-rc.13 \
+  https://github.com/LepistaBioinformatics/mycelium.git /tmp/myc
+cd /caminho/para/zombie-crab-project && set -a; . ./.env; set +a
+
+# 1) schema base
+docker compose -f docker-compose.yaml -f docker-compose.prod.yaml exec -T mycelium-postgres \
+  psql -U "$MYC_DB_USER" -d postgres \
+       -v db_name="$MYC_DB_NAME" -v db_user="$MYC_DB_USER" \
+       -v db_password="$MYC_DB_PASSWORD" -v db_role=service-role-mycelium \
+  < /tmp/myc/adapters/diesel_postgres/sql/up.sql
+
+# 2) as migrations, na ordem dos nomes
+for m in /tmp/myc/adapters/diesel_postgres/sql/migrations/*.sql; do
+  docker compose -f docker-compose.yaml -f docker-compose.prod.yaml exec -T mycelium-postgres \
+    psql -U "$MYC_DB_USER" -d "$MYC_DB_NAME" < "$m"
+done
+```
+
+O passo 1 cria o banco se não existir, dá `\c` nele e então cria os roles e as
+tabelas; ele **exige** o `-v db_password`. O compose já criou o banco **e** o
+role de login, então `CREATE USER … already exists` é esperado e inofensivo — o
+psql segue adiante.
+
+O passo 2 não é opcional na `9.0.0-rc.13`: o `up.sql` dessa tag traz o
+`kv_artifact` e o índice de claim do `message_queue`, mas **não** o
+`instance_settings`, o `resource_audit_log` nem as colunas
+`tenant.encrypted_dek` / `kek_version` (envelope encryption) — essas só existem
+como migration. Confira com `\dt` (devem aparecer `instance_settings` e
+`resource_audit_log`) e `\d tenant` (`encrypted_dek`, `kek_version`). No Dokploy,
+rode os mesmos dois passos via `docker exec` no container `mycelium-postgres`.
+
+### Antes de um deploy prod ou dokploy
+
+- **`CRAB_HOST_DATA_ROOT`** — precisa ser um caminho absoluto **do host**. O
+  crab-shell-proxy entrega esse caminho ao daemon Docker do host como origem do
+  bind-mount dos containers de agente que ele cria, então um caminho de dentro do
+  proxy não resolve.
+- **prod / `deploy/prod/config.base.toml`** — ajuste `noreplyEmail` e
+  `supportEmail` para o `MYC_SMTP_USERNAME` (o Gmail recusa um `From`
+  divergente). `domainUrl` / `allowedOrigins` já vêm apontando para as origens
+  localhost que esse modo realmente serve; se você colocar um hostname na frente,
+  mude os dois **junto com** o build arg `VITE_MYCELIUM_API_URL` do
+  `mycelium-webapp` — a UI de admin é uma SPA que chama o gateway direto do
+  browser, então divergir é um muro de CORS.
+- **dokploy / `deploy/dokploy/config.base.toml`** — troque as linhas
+  `►►► REPLACE` pelas suas origens `https://` reais (têm que bater com
+  `MYCELIUM_DOMAIN` e `MYCELIUM_WEBAPP_DOMAIN`), e lembre que a rede
+  `dokploy-network` precisa já existir.
+- **Catálogo de agentes** — o dokploy monta
+  `deploy/dokploy/crab-shell-proxy.config.yaml`, então dá para adicionar ou
+  remover agentes ali sem rebuildar a imagem do proxy. standalone e prod usam o
+  catálogo embutido na imagem (`crab/crab-shell-proxy/config.yaml`).
+- **Webhook de conta (opcional)** — registrar o webhook
+  `subscriptionAccount.created` do mycelium faz o proxy montar a raiz de
+  workspace da subscription na hora, em vez de no primeiro chat do membro. Via
+  JSON-RPC (`POST /_adm/rpc`, token de Staff), método
+  `systemManager.webhooks.create`: `{"name": "crab-shell-proxy", "url":
+  "http://crab-shell-proxy:8080/v1/accounts", "trigger":
+  "subscriptionAccount.created", "method": "POST", "secret":
+  {"authorizationHeader": {"headerName": "Authorization", "prefix": "Bearer",
+  "token": "<CRAB_WEBHOOK_SECRET>"}}}`.
+
 ## Administração dia-a-dia
 
 Gerenciar modelos, skills compartilhadas, secrets compartilhados, arquivos,
-membros e branding é feito pela **área de admin do chat-webapp** — veja o
-[Guia do Administrador](./docs/ADMIN_GUIDE.pt-br.md).
+personas, membros e branding é feito pela **área de admin do chat-webapp** —
+veja o [Guia do Administrador](./docs/ADMIN_GUIDE.pt-br.md).
 
 ## O que há neste repositório
 
 ```
-docker-compose.yaml        # a stack inteira (gateway + crab-shell-proxy + webapps + db)
+docker-compose.yaml        # a stack inteira, standalone/padrão (gateway + crab-shell-proxy + webapps + db)
+docker-compose.prod.yaml   # overlay de prod: imagens publicadas + mycelium em modo Postgres (-f com o de cima)
+docker-compose.dokploy.yaml# arquivo autocontido Traefik/Dokploy (base + prod + ingress já mesclados)
 deploy/                    # configs por modo: exemplos de .env + configs do mycelium/proxy (standalone / prod / dokploy)
 crab/                      # o lado crab (isolamento por-usuário + seu cliente de chat)
   crab-shell-proxy/        # submódulo git — o orquestrador Go de isolamento por-usuário

--- a/deploy/dokploy/.env.example
+++ b/deploy/dokploy/.env.example
@@ -15,15 +15,11 @@
 #                                                    Traefik-only ingress by domain)
 #
 # After the FIRST up (base/Postgres has NO auto-migration): apply mycelium's
-# postgres/sql/up.sql once -- see docker-compose.dokploy.yaml header + README.
+# adapters/diesel_postgres/sql/up.sql AND its sibling migrations/ scripts, at the
+# tag MYCELIUM_IMAGE_TAG pins -- exact commands in the README's "Deploy modes".
 # Also point deploy/dokploy/config.base.toml (domainUrl / allowedOrigins /
 # ►►► REPLACE lines) at your https://${*_DOMAIN} origins.
 # =============================================================================
-
-# ─── PicoClaw runtime (containers crab-shell-proxy spawns per user) ───────────
-PICOCLAW_IMAGE=docker.io/sipeed/picoclaw:latest
-PICOCLAW_TZ=America/Sao_Paulo
-PICOCLAW_LOG_LEVEL=
 
 # ─── crab-shell-proxy ─────────────────────────────────────────────────────────
 # ABSOLUTE host path to the data root (bind-mount SOURCE for the sibling picoclaw
@@ -36,6 +32,10 @@ CRAB_WEBHOOK_SECRET=change-me-to-a-long-random-secret
 
 # ─── Per-agent bearer tokens (mycelium injects, the proxy validates) ──────────
 # Distinct random values per agent, e.g. openssl rand -hex 32
+# This mode runs picoclaw ONLY: neither deploy/dokploy/config.base.toml nor
+# deploy/dokploy/crab-shell-proxy.config.yaml declares hermes-glm, so there is no
+# MYC_HERMES_GLM_TOKEN / PROXY_GLM_API_KEY here. Adding the agent back means
+# adding it to BOTH of those files plus its two variables.
 MYC_PICOCLAW_ALPHA_TOKEN=change-me-alpha
 MYC_PICOCLAW_BETA_TOKEN=change-me-beta
 
@@ -49,8 +49,10 @@ CHAT_WEBAPP_DB_PASSWORD=change-me-db
 CHAT_WEBAPP_DB_NAME=chatwebapp
 
 # ─── Production images (pulled, not built) ────────────────────────────────────
-# Pin RELEASED tags for reproducible deploys instead of :latest.
-MYCELIUM_IMAGE_TAG=9.0.0-rc.7
+# Pin RELEASED tags for reproducible deploys instead of :latest. Keep mycelium on
+# the same release standalone builds from source (MYCELIUM_GIT_REF in
+# deploy/standalone/.env.example).
+MYCELIUM_IMAGE_TAG=9.0.0-rc.13
 CRAB_SHELL_PROXY_TAG=latest
 CHAT_WEBAPP_TAG=latest
 
@@ -62,7 +64,7 @@ CHAT_WEBAPP_TAG=latest
 START_AT_SIGNIN=
 
 # ─── Mycelium's own Postgres ──────────────────────────────────────────────────
-# Schema NOT auto-created -- apply postgres/sql/up.sql once after the first up.
+# Schema NOT auto-created -- apply upstream's up.sql + migrations/ after the first up.
 MYC_DB_USER=mycelium
 MYC_DB_PASSWORD=change-me-myc-db
 MYC_DB_NAME=mycelium

--- a/deploy/dokploy/config.base.toml
+++ b/deploy/dokploy/config.base.toml
@@ -1,14 +1,21 @@
 # ------------------------------------------------------------------------------
-# BASE (POSTGRES) MODE CONFIGURATION -- zombie-crab-project / production
+# BASE (POSTGRES) MODE CONFIGURATION -- zombie-crab-project / DOKPLOY (Traefik)
 #
 # Postgres-backed (mycelium's DEFAULT `postgres-backend` feature -- i.e. the
 # plain published image `ghcr.io/LepistaBioinformatics/mycelium`, NOT the
-# `--features standalone` build). Used ONLY in production, mounted into the
-# official image at /home/config.toml via docker-compose.prod.yaml (SETTINGS_PATH).
+# `--features standalone` build). Mounted into the official image at
+# /home/config.toml by the self-contained docker-compose.dokploy.yaml
+# (SETTINGS_PATH). The no-Traefik production profile uses its own copy,
+# deploy/prod/config.base.toml -- same infra sections, different origins.
+#
 # The default local stack still uses config.standalone.toml (SQLite, no external
 # deps) -- this file changes ONLY the infrastructure sections; the API-gateway
-# routing below is IDENTICAL to config.standalone.toml (crab-shell-proxy:8080,
-# protectedByRoles, the full alpha/beta route set).
+# routing below is the same as config.standalone.toml (crab-shell-proxy:8080,
+# protectedByRoles) with ONE deliberate omission: this mode runs picoclaw only,
+# so there is no `[[hermes-glm]]` service here. That matches
+# deploy/dokploy/crab-shell-proxy.config.yaml, which drops the same agent from
+# the proxy's catalog. Re-adding hermes means editing BOTH files and supplying
+# MYC_HERMES_GLM_TOKEN + PROXY_GLM_API_KEY.
 #
 # Differences vs. standalone, all infra:
 #   - vault disabled; core/jwt/hmac/token secrets resolved from env (base mode
@@ -68,8 +75,12 @@ maxAttempts = 5
 #
 # Schema is NOT auto-provisioned (diesel_postgres has no embedded migrations,
 # unlike SQLite) -- apply it once after first `up` (STATE.md L-009):
-#   psql "$MYC_BASE_DATABASE_URL" -f postgres/sql/up.sql -v db_password=...
-# See README's production section for the exact command.
+#   psql ... -f adapters/diesel_postgres/sql/up.sql -v db_password=... -v db_name=...
+# then every script under adapters/diesel_postgres/sql/migrations/ -- up.sql at
+# rc.13 does NOT include instance_settings, resource_audit_log or the tenant
+# envelope-encryption columns. Both live in the mycelium repo at the tag this
+# deploy pins. See the README's "Deploy modes" section for the exact commands
+# (it also explains the harmless "role already exists" up.sql prints).
 # ------------------------------------------------------------------------------
 
 [diesel]
@@ -144,10 +155,11 @@ format = "ansi"
 target = "stdout"
 
 # ==============================================================================
-# API GATEWAY ROUTE CONFIGURATION -- IDENTICAL to config.standalone.toml.
-# See that file's comment block (lines ~117-176) for the full routing, header
-# contract, and protectedByRoles rationale. Kept in sync verbatim: only the
-# infrastructure sections above differ between standalone and base mode.
+# API GATEWAY ROUTE CONFIGURATION -- the same routes as config.standalone.toml
+# for alpha and beta; hermes-glm is deliberately absent (see the header). See
+# that file's `[api.services]` comment block for the full routing, header
+# contract, and protectedByRoles rationale. A route added to one of the three
+# deploy TOMLs has to be added to the others.
 # ==============================================================================
 
 [api.services]

--- a/deploy/prod/.env.example
+++ b/deploy/prod/.env.example
@@ -6,13 +6,9 @@
 # Traefik ingress instead).
 #
 # After the FIRST up (base/Postgres has NO auto-migration): apply mycelium's
-# postgres/sql/up.sql once -- see docker-compose.prod.yaml header + README.
+# adapters/diesel_postgres/sql/up.sql AND its sibling migrations/ scripts, at the
+# tag MYCELIUM_IMAGE_TAG pins -- exact commands in the README's "Deploy modes".
 # =============================================================================
-
-# --- PicoClaw runtime -------------------------------------------------------
-PICOCLAW_IMAGE=docker.io/sipeed/picoclaw:latest
-PICOCLAW_TZ=America/Sao_Paulo
-PICOCLAW_LOG_LEVEL=
 
 # --- crab-shell-proxy -------------------------------------------------------
 #CRAB_HOST_DATA_ROOT=/absolute/host/path/to/data
@@ -24,12 +20,22 @@ CHAT_WEBAPP_PORT=3000
 MYCELIUM_WEBAPP_PORT=8081
 
 # --- Per-agent bearer tokens ------------------------------------------------
+# One per agent routed in deploy/prod/config.base.toml. hermes-glm IS routed
+# there (same agent set as standalone), so its token belongs here too: leaving
+# it empty makes the gateway advertise the agent and inject an empty bearer,
+# which fails at request time instead of at boot. To run prod WITHOUT hermes,
+# drop its `[[hermes-glm]]` blocks from config.base.toml and mount a
+# crab-shell-proxy config.yaml without the agent (that is what deploy/dokploy
+# does).
 MYC_PICOCLAW_ALPHA_TOKEN=change-me-alpha
 MYC_PICOCLAW_BETA_TOKEN=change-me-beta
+MYC_HERMES_GLM_TOKEN=change-me-hermes-glm
 
 # --- Per-instance LLM API keys ----------------------------------------------
 PICOCLAW_ALPHA_API_KEY=sk-your-alpha-key
 PICOCLAW_BETA_API_KEY=sk-your-beta-key
+# z.ai/GLM key for the hermes-glm agent (unset => the proxy auto-disables it)
+PROXY_GLM_API_KEY=your-zai-glm-key
 
 # --- chat-webapp Postgres ---------------------------------------------------
 CHAT_WEBAPP_DB_USER=chatwebapp
@@ -37,7 +43,9 @@ CHAT_WEBAPP_DB_PASSWORD=change-me-db
 CHAT_WEBAPP_DB_NAME=chatwebapp
 
 # --- Production images (pulled, not built) ----------------------------------
-MYCELIUM_IMAGE_TAG=9.0.0-rc.7
+# Same mycelium release standalone builds from source (MYCELIUM_GIT_REF in
+# deploy/standalone/.env.example) -- keep them on one version.
+MYCELIUM_IMAGE_TAG=9.0.0-rc.13
 CRAB_SHELL_PROXY_TAG=latest
 CHAT_WEBAPP_TAG=latest
 

--- a/deploy/prod/config.base.toml
+++ b/deploy/prod/config.base.toml
@@ -1,14 +1,21 @@
 # ------------------------------------------------------------------------------
-# BASE (POSTGRES) MODE CONFIGURATION -- zombie-crab-project / production
+# BASE (POSTGRES) MODE CONFIGURATION -- zombie-crab-project / PROD (no Traefik)
 #
 # Postgres-backed (mycelium's DEFAULT `postgres-backend` feature -- i.e. the
 # plain published image `ghcr.io/LepistaBioinformatics/mycelium`, NOT the
-# `--features standalone` build). Used ONLY in production, mounted into the
-# official image at /home/config.toml via docker-compose.prod.yaml (SETTINGS_PATH).
+# `--features standalone` build). Used ONLY by the prod profile, mounted into the
+# official image at /home/config.toml via docker-compose.prod.yaml (SETTINGS_PATH):
+#   docker compose -f docker-compose.yaml -f docker-compose.prod.yaml up -d
 # The default local stack still uses config.standalone.toml (SQLite, no external
 # deps) -- this file changes ONLY the infrastructure sections; the API-gateway
 # routing below is IDENTICAL to config.standalone.toml (crab-shell-proxy:8080,
-# protectedByRoles, the full alpha/beta route set).
+# protectedByRoles, the full alpha/beta/hermes-glm route set).
+#
+# THIS MODE IS NOT THE TRAEFIK ONE. It keeps the base file's PUBLISHED HOST PORTS
+# (gateway :8080, chat-webapp :3000, mycelium-webapp :8081) and terminates no TLS
+# of its own. For Traefik/Dokploy ingress by domain use the self-contained
+# docker-compose.dokploy.yaml with deploy/dokploy/config.base.toml -- the two
+# files are otherwise identical, and the origins below are the difference.
 #
 # Differences vs. standalone, all infra:
 #   - vault disabled; core/jwt/hmac/token secrets resolved from env (base mode
@@ -24,10 +31,16 @@
 #     this stack; revisit if you add a Redis container.
 #
 # ►►► REPLACE BEFORE DEPLOY (plain strings -- NOT env-resolvable, and this file
-#     is mounted so no rebuild is needed): `domainUrl`, `allowedOrigins`, and
-#     `noreplyEmail`. noreplyEmail MUST equal MYC_SMTP_USERNAME (your Gmail
-#     address) -- Gmail rejects a mismatched From. domainUrl/allowedOrigins must
-#     be your real public https:// origins (mycelium + mycelium-webapp).
+#     is mounted so no rebuild is needed): `noreplyEmail` / `supportEmail`, and
+#     `domainUrl` UNLESS this really is a localhost deploy. noreplyEmail MUST
+#     equal MYC_SMTP_USERNAME (your Gmail address) -- Gmail rejects a mismatched
+#     From. domainUrl goes into REAL magic-link emails in this mode (base mode
+#     has no stub transport), so a localhost value there ships unusable links to
+#     anyone not sitting at the host.
+#
+#     `allowedOrigins` is pre-set to the origins this mode actually serves and is
+#     correct as shipped. Change it only together with the webapp build arg --
+#     see its own comment below.
 # ------------------------------------------------------------------------------
 
 vault = "disabled"
@@ -38,7 +51,12 @@ vault = "disabled"
 
 [core.accountLifeCycle]
 domainName = "Zombie Crab"
-domainUrl = "https://mycelium.example.com"                    # ►►► REPLACE
+# ►►► REPLACE unless this is genuinely a localhost deploy. Base URL mycelium
+# writes into the emails it really sends (magic-link, invitations), so it must be
+# the URL a human actually opens -- not an internal service name, and not
+# localhost if the users are anywhere else. The default matches this mode's
+# published gateway port; behind a reverse proxy, put its public https:// URL.
+domainUrl = "http://localhost:8080"
 tokenExpiration = 3600                                                # 1 hour
 noreplyName = "Mycelium"
 noreplyEmail = "your-account@gmail.com"                       # ►►► REPLACE (== MYC_SMTP_USERNAME)
@@ -68,8 +86,12 @@ maxAttempts = 5
 #
 # Schema is NOT auto-provisioned (diesel_postgres has no embedded migrations,
 # unlike SQLite) -- apply it once after first `up` (STATE.md L-009):
-#   psql "$MYC_BASE_DATABASE_URL" -f postgres/sql/up.sql -v db_password=...
-# See README's production section for the exact command.
+#   psql ... -f adapters/diesel_postgres/sql/up.sql -v db_password=... -v db_name=...
+# then every script under adapters/diesel_postgres/sql/migrations/ -- up.sql at
+# rc.13 does NOT include instance_settings, resource_audit_log or the tenant
+# envelope-encryption columns. Both live in the mycelium repo at the tag this
+# deploy pins. See the README's "Deploy modes" section for the exact commands
+# (it also explains the harmless "role already exists" up.sql prints).
 # ------------------------------------------------------------------------------
 
 [diesel]
@@ -124,13 +146,21 @@ servicePort = 8080
 serviceWorkers = 1
 gatewayTimeout = 60
 
-# ►►► REPLACE with your real public origins. The mycelium-webapp SPA calls the
-# gateway directly from the browser, so its origin must be allowed. chat-webapp
-# is a server-side BFF and does NOT need to be listed.
-allowedOrigins = ["https://mycelium.example.com", "https://admin.example.com"]
+# The mycelium-webapp SPA calls the gateway DIRECTLY from the browser, so its
+# origin has to be allowed here -- and it must be the origin the SPA is actually
+# served from. This mode does not override the base file's build arg, so the SPA
+# is built with VITE_MYCELIUM_API_URL=http://localhost:${MYCELIUM_PORT:-8080} and
+# served on http://localhost:${MYCELIUM_WEBAPP_PORT:-8081}: those are the two
+# origins below. Put a public hostname here ONLY together with rebuilding
+# mycelium-webapp against the matching URL (docker-compose.yaml's
+# `mycelium-webapp.build.args.VITE_MYCELIUM_API_URL`) -- changing one and not the
+# other is a CORS failure that looks like a broken admin UI.
+# chat-webapp is a server-side BFF and does NOT need to be listed.
+allowedOrigins = ["http://localhost:8080", "http://localhost:8081"]
 
-# TLS terminates at Traefik (docker-compose.dokploy.yaml); the gateway speaks
-# plain HTTP on the internal network.
+# No TLS terminator in this mode: the gateway serves plain HTTP on its published
+# host port. Front it with a reverse proxy (or use the Dokploy/Traefik profile)
+# before it faces anything but a trusted network.
 tls = "disabled"
 
 [api.cache]
@@ -144,10 +174,12 @@ format = "ansi"
 target = "stdout"
 
 # ==============================================================================
-# API GATEWAY ROUTE CONFIGURATION -- IDENTICAL to config.standalone.toml.
-# See that file's comment block (lines ~117-176) for the full routing, header
-# contract, and protectedByRoles rationale. Kept in sync verbatim: only the
-# infrastructure sections above differ between standalone and base mode.
+# API GATEWAY ROUTE CONFIGURATION -- IDENTICAL to config.standalone.toml,
+# agent for agent (alpha, beta, hermes-glm). See that file's `[api.services]`
+# comment block for the full routing, header contract, and protectedByRoles
+# rationale. Kept in sync verbatim: only the infrastructure sections above
+# differ between standalone and base mode. A route added to one of the three
+# deploy TOMLs has to be added to the others.
 # ==============================================================================
 
 [api.services]

--- a/deploy/standalone/.env.example
+++ b/deploy/standalone/.env.example
@@ -5,12 +5,10 @@
 # every service is built locally; host ports are published.
 # =============================================================================
 
-# --- PicoClaw runtime -------------------------------------------------------
-PICOCLAW_IMAGE=docker.io/sipeed/picoclaw:latest
-PICOCLAW_TZ=America/Sao_Paulo
-PICOCLAW_LOG_LEVEL=
-
 # --- crab-shell-proxy -------------------------------------------------------
+# The picoclaw image the proxy spawns is NOT an env var: it comes from
+# `picoclawImage` in crab-shell-proxy's config.yaml. Only the variables below
+# are read from the environment (internal/config.Load).
 # Absolute HOST path of the data root; defaults to ${PWD}/data when compose runs
 # from the project root. Set explicitly if you run from elsewhere.
 #CRAB_HOST_DATA_ROOT=/absolute/path/to/zombie-crab-project/data
@@ -19,8 +17,10 @@ CRAB_WEBHOOK_SECRET=change-me-to-a-long-random-secret
 
 # --- Mycelium gateway (built from source in standalone) ---------------------
 MYCELIUM_PORT=8080
-# Pinned upstream commit built by mycelium/Dockerfile.standalone.
-MYCELIUM_GIT_REF=009c771770710ee5e42b119544bbada5953b5d56
+# Pinned upstream commit built by fungi/mycelium/Dockerfile.standalone: the
+# commit tagged 9.0.0-rc.13. Same release the prod/dokploy modes pull by tag
+# (MYCELIUM_IMAGE_TAG=9.0.0-rc.13) -- move all of them together.
+MYCELIUM_GIT_REF=9298ecb44a69ced91cb2d7d3356a716aedca858b
 
 # --- Per-agent bearer tokens (mycelium injects, the proxy validates) --------
 # openssl rand -hex 32 each

--- a/deploy/standalone/config.standalone.toml
+++ b/deploy/standalone/config.standalone.toml
@@ -3,9 +3,10 @@
 #
 # Adapted from mycelium-monorepo's settings/config.standalone.example.toml:
 # zero external runtime dependencies (SQLite instead of Postgres, in-process
-# moka cache instead of Redis, stub/file email transport). Routes two
-# picoclaw+picoclaw-openai-proxy sidecar pairs ("alpha"/"beta", see
-# ../docker-compose.yaml) instead of upstream's single example route.
+# moka cache instead of Redis, stub/file email transport). Declares one service
+# per agent ("alpha", "beta", "hermes-glm"), all routed to the single
+# crab-shell-proxy downstream (see ../../docker-compose.yaml), instead of
+# upstream's single example route.
 #
 # This is a static file, not a template: the per-instance secrets below use
 # mycelium's own field-level env-var secret resolver (`token = { env =
@@ -97,9 +98,10 @@ gatewayTimeout = 60
 # http://localhost:8080 -- mycelium-webapp's own dev-mode default, harmless
 # to leave in. http://localhost:8081 -- this stack's mycelium-webapp service
 # (browser-side SPA, calls the gateway directly -- see docker-compose.yaml).
-# This file is baked into the image at build time (not templated), so if you
-# change MYCELIUM_WEBAPP_PORT in .env you must also update this value and
-# rebuild mycelium-gateway.
+# This file is MOUNTED into the gateway (docker-compose.yaml mounts it at
+# /home/config.toml), not templated and not baked -- so if you change
+# MYCELIUM_WEBAPP_PORT in .env you must update this value too, but a
+# `docker compose restart mycelium-gateway` is enough to pick it up.
 allowedOrigins = ["http://localhost:8080", "http://localhost:8081"]
 
 tls = "disabled"
@@ -117,8 +119,8 @@ target = "stdout"
 # ------------------------------------------------------------------------------
 # API GATEWAY ROUTE CONFIGURATION
 #
-# Two named services -- one per agent (alpha/beta) -- BOTH pointing at the same
-# downstream, crab-shell-proxy:8080, over the compose-internal `zombie_net`
+# One named service per agent (alpha, beta, hermes-glm) -- ALL pointing at the
+# same downstream, crab-shell-proxy:8080, over the compose-internal `zombie_net`
 # network. crab-shell-proxy tells the agents apart via the
 # x-mycelium-service-name header mycelium injects (the service key below,
 # e.g. "alpha"), since the first path segment is stripped before
@@ -130,9 +132,9 @@ target = "stdout"
 #
 # mycelium's router takes the *first path segment* of the request as the
 # service name (adapters/mem_db/src/repositories/shared.rs::extract_path_parts)
-# and matches everything after it against `path` below -- so callers must hit
-# /alpha/... and /beta/... (the literal TOML service keys),
-# NOT /alpha/... or /beta/....
+# and matches everything after it against `path` below -- so callers hit
+# /alpha/..., /beta/... and /hermes-glm/...: the literal TOML service keys, with
+# no "picoclaw-" prefix (an earlier layout used one; the keys were renamed).
 #
 # `token = { env = "VAR_NAME" }` is the field-level env resolver fixed in
 # LepistaBioinformatics/mycelium#166 (SecretResolver<String>, released in
@@ -146,9 +148,10 @@ target = "stdout"
 # at an auth-gated route like /v1/models always fails with "Unable to
 # perform the health check" (every attempt gets a 401, which the dispatcher
 # doesn't treat as a real error, so it falls through all retries with
-# neither a response nor an error recorded). picoclaw-openai-proxy's
-# /healthz is intentionally unauthenticated and also proxies picoclaw's own
-# /health, so one check covers both.
+# neither a response nor an error recorded). crab-shell-proxy's /healthz is
+# intentionally unauthenticated (internal/httpapi/handlers.go) and reports the
+# proxy itself -- the per-user agent containers are checked by the proxy on
+# spawn, not by the gateway.
 #
 # `group = { protectedByRoles = [{ name = "<instance>" }] }`
 # (M3, role-scoped access -- see .specs/project/ROADMAP.md/STATE.md AD-008):
@@ -162,17 +165,16 @@ target = "stdout"
 # matching guest-role, every request 403s ("User does not have permission to
 # perform this action" -- fetch_and_inject_profile_from_token_to_forward.rs).
 #
-# This flips the header contract picoclaw-openai-proxy relies on:
-# "authenticated" injected the caller's verified email as a plain
-# x-mycelium-email header (check_credentials_with_multi_identity_provider).
-# "protectedByRoles" instead calls fetch_and_inject_profile_from_token_to_forward,
-# which injects the full account Profile as x-mycelium-profile -- JSON,
-# zstd-compressed, base64-encoded (compress_and_encode_profile_to_base64).
-# picoclaw-openai-proxy's server.js was updated to decode this and pull the
-# principal owner's email from `profile.owners` instead of reading a plain
-# header -- see that file's own comments. The caller still can't declare
-# "I'm someone else": mycelium builds this header server-side from the
-# verified token, same guarantee "authenticated" gave via x-mycelium-email.
+# This decides which header contract the downstream gets: "authenticated"
+# would inject the caller's verified email as a plain x-mycelium-email header
+# (check_credentials_with_multi_identity_provider), while "protectedByRoles"
+# calls fetch_and_inject_profile_from_token_to_forward, which injects the full
+# account Profile as x-mycelium-profile -- JSON, zstd-compressed,
+# base64-encoded (compress_and_encode_profile_to_base64). crab-shell-proxy
+# decodes that header and keys the user on the profile's accId (not the email,
+# which is mutable) -- see internal/identity/. The caller still can't declare
+# "I'm someone else": mycelium builds the header server-side from the verified
+# token, the same guarantee "authenticated" gave via x-mycelium-email.
 # ------------------------------------------------------------------------------
 
 [api.services]
@@ -183,9 +185,9 @@ target = "stdout"
 # it -- see Service::proxy_address's own doc comment and
 # ports/api/src/router/initialize_downstream_request.rs), a different
 # concept from "this is my sidecar, send requests to it directly".
-# picoclaw-openai-proxy is a plain HTTP service (not a path-embedding
-# forward proxy), so it must be `host`, not `proxyAddress` -- confirmed
-# empirically: `proxyAddress` produced "invalid format" 500s on every
+# crab-shell-proxy is a plain HTTP service (not a path-embedding forward
+# proxy), so it must be `host`, not `proxyAddress` -- confirmed empirically:
+# `proxyAddress` produced "invalid format" 500s on every
 # /v1/chat/completions call.
 host = "crab-shell-proxy:8080"
 protocol = "http"

--- a/docker-compose.dokploy.yaml
+++ b/docker-compose.dokploy.yaml
@@ -20,7 +20,9 @@
 #     subdirs of this root, which must be pre-seeded with data/templates/<agent>.
 #   - dokploy-network is external (Dokploy owns it) and must already exist.
 #   - After the FIRST up (base/Postgres has no auto-migration): apply mycelium's
-#     postgres/sql/up.sql once against mycelium-postgres -- see README.
+#     adapters/diesel_postgres/sql/up.sql AND its sibling migrations/ scripts
+#     against mycelium-postgres, at the tag MYCELIUM_IMAGE_TAG pins -- exact
+#     commands in the README's "Deploy modes" section.
 #
 # Local/dev and the layered workflow are unchanged: docker-compose.yaml (default)
 # and docker-compose.prod.yaml still exist and are used as before.
@@ -82,17 +84,19 @@ services:
         type: volume
         volume: {}
   crab-shell-proxy:
+    # picoclaw ONLY in this mode -- no MYC_HERMES_GLM_TOKEN / PROXY_GLM_API_KEY,
+    # matching the agent catalog mounted below and the services declared in
+    # deploy/dokploy/config.base.toml. Re-adding hermes means editing both of
+    # those files and adding the two variables back here.
     environment:
       CRAB_CONTAINER_DATA_ROOT: /data
       CRAB_HOST_DATA_ROOT: ${CRAB_HOST_DATA_ROOT:-${PWD}/data}
       CRAB_NETWORK: zombie_net
       CRAB_WEBHOOK_SECRET: ${CRAB_WEBHOOK_SECRET}
-      MYC_HERMES_GLM_TOKEN: ${MYC_HERMES_GLM_TOKEN}
       MYC_PICOCLAW_ALPHA_TOKEN: ${MYC_PICOCLAW_ALPHA_TOKEN}
       MYC_PICOCLAW_BETA_TOKEN: ${MYC_PICOCLAW_BETA_TOKEN}
       PICOCLAW_ALPHA_API_KEY: ${PICOCLAW_ALPHA_API_KEY}
       PICOCLAW_BETA_API_KEY: ${PICOCLAW_BETA_API_KEY}
-      PROXY_GLM_API_KEY: ${PROXY_GLM_API_KEY}
     healthcheck:
       interval: 15s
       retries: 10
@@ -135,7 +139,6 @@ services:
         condition: service_healthy
         required: true
     environment:
-      - MYC_HERMES_GLM_TOKEN=${MYC_HERMES_GLM_TOKEN}
       - MYC_PICOCLAW_ALPHA_TOKEN=${MYC_PICOCLAW_ALPHA_TOKEN}
       - MYC_PICOCLAW_BETA_TOKEN=${MYC_PICOCLAW_BETA_TOKEN}
       - MYC_STANDALONE_BOOTSTRAP_SECRET=${MYC_STANDALONE_BOOTSTRAP_SECRET}
@@ -160,7 +163,7 @@ services:
         - http://127.0.0.1:8080/health
       timeout: 5s
     hostname: mycelium-gateway
-    image: ghcr.io/lepistabioinformatics/mycelium:${MYCELIUM_IMAGE_TAG:-9.0.0-rc.7}
+    image: ghcr.io/lepistabioinformatics/mycelium:${MYCELIUM_IMAGE_TAG:-9.0.0-rc.13}
     labels:
       - traefik.enable=true
       - traefik.docker.network=dokploy-network

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -19,9 +19,10 @@
 # and deploy/dokploy/.env.example). It is no longer a -f override layered on this file.
 #
 # One-time after the FIRST up (base/Postgres has no auto-migration, L-009):
-#   docker compose ... exec mycelium-postgres \
-#     psql -U "$MYC_DB_USER" -d "$MYC_DB_NAME" -f -   < postgres/sql/up.sql
-#   (or run psql from the host against the DB URL) -- see README production section.
+#   apply upstream's adapters/diesel_postgres/sql/up.sql AND the scripts under
+#   adapters/diesel_postgres/sql/migrations/ (up.sql at rc.13 does not fold them
+#   all in), at the SAME tag this file pins (MYCELIUM_IMAGE_TAG). up.sql needs
+#   -v db_password -- see the README's "Deploy modes" for the exact commands.
 #
 # All values below come from .env -- see deploy/prod/.env.example. `build: !reset null` drops the base file's build so the image is
 # PULLED, never built (a plain `image:` alongside `build:` would still build if
@@ -52,7 +53,7 @@ services:
     # Official published image, base/Postgres build (mycelium's default cargo
     # features). No local build.
     build: !reset null
-    image: ghcr.io/lepistabioinformatics/mycelium:${MYCELIUM_IMAGE_TAG:-9.0.0-rc.7}
+    image: ghcr.io/lepistabioinformatics/mycelium:${MYCELIUM_IMAGE_TAG:-9.0.0-rc.13}
     environment:
       # The official image sets Entrypoint=myc-api but does NOT define
       # SETTINGS_PATH (verified from the image config), so point it at the
@@ -81,6 +82,11 @@ services:
   crab-shell-proxy:
     build: !reset null
     image: ghcr.io/lepistabioinformatics/crab-shell-proxy:${CRAB_SHELL_PROXY_TAG:-latest}
+    # Drop the base file's TEMPORARY 127.0.0.1:18080 publish (direct-to-proxy
+    # testing). `ports` CONCATENATES across -f layers, so without this reset the
+    # port stays live here -- and in production the gateway must be the only
+    # entry point, including on loopback.
+    ports: !reset []
 
   chat-webapp:
     build: !reset null

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,20 +5,21 @@
 # Protocol WS channel; crab-shell-proxy speaks that protocol directly in Go):
 #
 #   mycelium-gateway (standalone, :8080, published)
-#     |-- /picoclaw-alpha/v1/*  --\
-#     `-- /picoclaw-beta/v1/*   ----> crab-shell-proxy:8080
-#                                       |  (agent from x-mycelium-service-name,
-#                                       |   user from x-mycelium-profile email)
-#                                       `--> picoclaw-<agent>-<userhash>:18790
-#                                            (spawned on demand, one per user)
+#     |-- /alpha/v1/*       --\
+#     |-- /beta/v1/*        ----> crab-shell-proxy:8080
+#     `-- /hermes-glm/v1/*  --/     |  (agent from x-mycelium-service-name,
+#                                   |   user from the x-mycelium-profile accId)
+#                                   `--> crabshell-<agent>-<hash>:18790
+#                                        (spawned on demand, one per user;
+#                                         hermes agents answer on :8642 instead)
 #
 # mycelium routes by first path segment == the TOML service key (see
-# mycelium/config.standalone.toml), so it's /picoclaw-alpha/... and
-# /picoclaw-beta/..., NOT /alpha/... . It strips that segment before
-# forwarding, but injects x-mycelium-service-name so crab-shell-proxy still
-# knows which agent was addressed. The spawned picoclaw containers and
-# crab-shell-proxy publish no host ports -- mycelium-gateway is the single
-# entry point.
+# deploy/standalone/config.standalone.toml), so callers hit /alpha/..., /beta/...
+# and /hermes-glm/... -- the literal keys, with no "picoclaw-" prefix. It strips
+# that segment before forwarding, but injects x-mycelium-service-name so
+# crab-shell-proxy still knows which agent was addressed. The spawned agent
+# containers publish no host ports, and crab-shell-proxy publishes only the
+# TEMPORARY loopback port below -- mycelium-gateway is the entry point.
 #
 # Two more services sit alongside this for human use: chat-webapp (:3000, a BFF
 # test client -- signin + instance picker + chat) and mycelium-webapp (:8081,
@@ -139,7 +140,11 @@ services:
       context: ./fungi/mycelium
       dockerfile: Dockerfile.standalone
       args:
-        MYCELIUM_GIT_REF: ${MYCELIUM_GIT_REF:-009c771770710ee5e42b119544bbada5953b5d56}
+        # 9.0.0-rc.13. Compose's build arg OVERRIDES the Dockerfile's own ARG
+        # default, so this line -- not the Dockerfile -- decides what standalone
+        # builds. Keep it, deploy/standalone/.env.example, and the prod/dokploy
+        # MYCELIUM_IMAGE_TAG on the same release.
+        MYCELIUM_GIT_REF: ${MYCELIUM_GIT_REF:-9298ecb44a69ced91cb2d7d3356a716aedca858b}
     restart: unless-stopped
     # Fixes L-002 (STATE.md): standalone mode wraps its auto-generated
     # secrets file (/data/.secrets/token_secret.secret) with a key derived

--- a/docs/ADMIN_GUIDE.md
+++ b/docs/ADMIN_GUIDE.md
@@ -1,8 +1,9 @@
 # Admin Guide
 
 Day-2 operations from the **chat-webapp admin area**: injecting shared files,
-secrets, and skills into users' agents, registering models per agent and
-assigning them to individual users, reviewing members, and setting branding.
+secrets, and skills into users' agents, setting the agent's identity files,
+deciding which model people get, repairing instance configuration, inviting
+members, and setting branding.
 
 For *creating* a new agent, see [Creating a Custom Agent](./CREATE_CUSTOM_AGENT.md).
 For running/resetting the whole stack, see the root
@@ -10,7 +11,7 @@ For running/resetting the whole stack, see the root
 
 ---
 
-## 1. Who can administer, and scopes
+## 1. Who can administer, and what you pick first
 
 The admin area is reachable from **chat-webapp** to accounts that manage a
 **scope**. A scope is one of:
@@ -18,23 +19,31 @@ The admin area is reachable from **chat-webapp** to accounts that manage a
 - **Tenant** — everything under a tenant.
 - **Subscription** — one subscription account under a tenant.
 
-Everything in the admin area operates **on the selected scope** (the scope rail
-at the top). Changes cascade down to the picoclaw containers of the users in
-that scope. **Branding** is the exception — it's instance-wide and only staff
-can edit it.
+The screen is **agent-first**: you choose the agent (`alpha`, `beta`,
+`hermes-glm`, …) before any tenant or subscription, because agents come from the
+deployment's proxy configuration and exist before any tenant does. Then you pick
+the scope in the rail, and every section acts on that **(agent, scope)** pair.
+Changes cascade down to the agent containers of the users in that scope.
+
+Two things are not agent sections: **Members** (a member list belongs to a
+subscription, whatever agents it runs) and **Branding** (instance-wide,
+staff-only).
 
 The mental model: you edit **shared** material at a scope, the proxy syncs it
 into an **effective** view, and each user's agent container mounts that view
 read-only. One user never sees another user's private workspace — only the
 shared material you injected at their scope.
 
+The sections below are named as the tabs are: **Files · Secrets · Skills ·
+Identity · Models · Config**, plus **Members** and **Branding**.
+
 ---
 
-## 2. Shared files
+## 2. Files
 
 Inject arbitrary files into every user's agent workspace at the scope.
 
-1. Open **Shared files**.
+1. Open **Files**.
 2. Pick the scope.
 3. Upload files.
 
@@ -43,7 +52,7 @@ datasets, or any static content the agents should be able to read.
 
 ---
 
-## 3. Shared secrets
+## 3. Secrets
 
 Provide secrets (API keys, tokens, connection strings) to the agents at a
 scope **without** baking them into templates or images.
@@ -55,22 +64,22 @@ Supported formats:
 - **file** — upload a secret file as-is.
 
 > The picoclaw-**native** secret format (model API key) is intentionally **not**
-> available here. Model credentials are managed per agent from the **Model** tab
-> (section 5), not as a shared secret.
+> available here. Model credentials are managed from the **Models** tab
+> (section 6), not as a shared secret.
 
 Secrets are written to the scope's shared-secrets store and synced into the
 effective view mounted read-only into each user's agent.
 
 ---
 
-## 4. Shared skills
+## 4. Skills
 
 Push skills (a `SKILL.md` plus optional supporting files) to all users' agents
 at a scope. A skill is a folder with a `SKILL.md` (YAML frontmatter `name` +
 `description`, then a Markdown body) — the same shape used in a template's
 `workspace/skills/<name>/`.
 
-1. Open **Shared skills**, pick the scope.
+1. Open **Skills**, pick the scope.
 2. Add a skill by:
    - writing/editing its `SKILL.md` document inline, or
    - uploading a **zip** of the skill folder.
@@ -82,67 +91,130 @@ mount inode is preserved so running agents pick it up).
 
 ---
 
-## 5. Model — per-agent registry and per-user assignment
+## 5. Identity (persona)
 
-The **Model** tab lets an admin register LLM models **per agent** and then
-assign a registered model to **individual users** of that agent. This is
-admin-only: normal users cannot change their own model.
+The four files the agent reads as its identity, delivered to every workspace
+under the (agent, scope) you selected — overriding the agent template, with the
+more specific scope winning over the broader one:
 
-### 5.1 Register a model (per agent)
+| File | What it is | How it is delivered |
+|---|---|---|
+| `AGENT.md` | what the agent does and how it behaves | **read-only** |
+| `SOUL.md` | its voice / personality | **read-only** |
+| `HEARTBEAT.md` | its recurring task list | **read-only** |
+| `USER.md` | what is known about the user | **seed only** |
 
-1. Open **Model**.
-2. Choose the **Agent** (e.g. `alpha`, `beta`) at the top.
-3. Under **Register model**, fill:
-   - **provider** — e.g. `zhipu`, `deepseek`, `openai`.
-   - **model_name** — the picoclaw `model_name` (e.g. `glm-4.7`).
-   - **litellm model** — the provider-side model id (often equal to `model_name`).
-   - **api_base** — the provider base URL (e.g. `https://open.bigmodel.cn/api/paas/v4`).
-   - **api_key** — write-only; stored server-side, never echoed back.
-4. **Register.** The model joins that agent's registry.
+The set is **fixed and closed** — these endpoints write into a workspace root,
+so an arbitrary filename would be an arbitrary-file-write reaching every
+container under the scope. The proxy rejects any other name.
 
-Registered models are **per agent and global to the agent** — the same list is
-available to assign to any user of that agent.
+- **Read-only files** cannot be changed by the member in their workspace, and an
+  edit never survives a restart.
+- **`USER.md` stays writable**: the agent records what it learns about the user
+  there. Setting it here defines what a **new** workspace starts from; it never
+  overwrites an existing one.
 
-### 5.2 Assign a model to a user
-
-In the users list (users of the selected agent), pick a registered model and
-**Apply** it to a user. The proxy writes the model entry — including its
-`api_key` — into that user's picoclaw `config.json`, so the user's agent
-authenticates with the assigned model on its next turn.
-
-> A newly provisioned user starts on the agent's **default** model pinned in
-> `crab/crab-shell-proxy/config.yaml` (with the key from the environment).
-> Assigning a registered model here **overrides** that for the specific user.
-
-### 5.3 Remove a model
-
-Delete a registered model from the agent's registry with its delete action.
-Users already assigned that model keep their current `config.json` until
-reassigned.
+Each row says whether the file is **set here** or **inherited**. Opening the
+editor preloads what the agent actually runs — resolved down the cascade
+(this scope → the tenant below it → the agent template) — so you edit a real
+identity instead of a blank page; **saving** is what makes it this scope's.
+**Clear** removes it at this scope and the workspaces fall back to the broader
+scope, or to the template.
 
 ---
 
-## 6. Members
+## 6. Models
+
+Two separate things: an **inventory** of models the proxy can serve, and the
+**ladder** that decides which of them a given workspace resolves to.
+
+### 6.1 The inventory (register once)
+
+One inventory for the whole proxy. A model is registered once — with its
+credentials — and every scope points at that record instead of holding its own
+copy. Fill:
+
+- **provider** — e.g. `zhipu`, `deepseek`, `openai`.
+- **model_name** — the picoclaw `model_name` (e.g. `glm-4.7`).
+- **litellm model** — the provider-side model id (often equal to `model_name`).
+- **api_base** — the provider base URL.
+- **api_key** — write-only; stored server-side, never echoed back.
+
+Models are listed as **in service** or **retired/held back**; *deprecate* a model
+to take it out of service without deleting the record.
+
+### 6.2 The ladder (who gets what)
+
+Read the ladder downwards: each rung covers fewer people than the one above and
+overrides it — instance-wide rungs, then the tenant, then the subscription. The
+**narrowest rung with a model wins**, and that is what a newly provisioned
+workspace lands on.
+
+If **nothing resolves** for a scope, new workspaces under it are **refused** —
+so before clearing the rung in effect, check what (if anything) is set above it.
+Rungs you lack authority to read stay hidden; an instance-wide rung may still be
+covering the scope.
+
+### 6.3 Pins (one person)
+
+A **pin** assigns a registered model to a single user and outranks every rung
+above. Use it for one person who needs something different — to move a whole
+group, set the rung for their scope instead. Pins live under a **subscription**
+(that is where users are), and a user only appears once they have a workspace,
+i.e. after their first chat.
+
+---
+
+## 7. Config
+
+Per-instance `config.json` repair, and bulk edits of one key across a
+subscription.
+
+- **Bulk** (one subscription at a time): name a **dotted path** to one value
+  (e.g. `tools.web.brave.enabled`), **read the current distribution first** —
+  what each member holds now — and only then write. Instances whose key is
+  absent, blocked by a conflicting path, or whose config is unreadable are
+  excluded from the bulk write and listed for repair one at a time. Keys the
+  **proxy owns** (it rewrites them on every materialization) are refused: a bulk
+  change there could not survive.
+- **Single instance**: the raw editor opens a member's `config.json` as
+  formatted **JSON** or as a **tree**, validates it, and writes it back.
+
+A config change lands on the instance's next start. The restart control on the
+panel decides how that bounce happens — **now** (the default), **schedule** it
+for a time you pick, or **notice**: leave it to the member, who sees a
+pending-restart notice in chat. The choice is per-session, not stored.
+
+---
+
+## 8. Members
 
 The **Members** tab lists the users of the selected **subscription**, grouped by
-agent (role). Use it to see who exists per agent before assigning models
-(section 5) or reviewing shared material. A **tenant** scope has no member list
-(members live at the subscription level).
+agent (role). From here you can:
+
+- **Invite** an account to an agent by email, at **read** or **write** access
+  (write is what chatting requires; read is view-only).
+- **Revoke** an account's access to that agent.
+- See who exists per agent before pinning models (section 6) or reviewing shared
+  material.
+
+A **tenant** scope has no member list (members live at the subscription level).
 
 ---
 
-## 7. Branding
+## 9. Branding
 
-Instance-wide branding (logo shown as the tenant avatar in the chat sidebar).
-This tab is **staff-only** and is not per-scope.
+Instance-wide branding: the app name, the logo shown as the tenant avatar in the
+chat sidebar, and the app icon. This tab is **staff-only** and is not per-scope.
 
 ---
 
-## 8. How roles gate access to an agent
+## 10. How roles gate access to an agent
 
-Reaching an agent at all is a **mycelium** concern, not a chat-webapp one. The
-gateway routes are `protectedByRoles` (roles `alpha` / `beta`), so an account
-must hold the matching guest-role to talk to that agent. Roles are assigned in
-**mycelium-webapp** (Mycelium's own admin UI) via the
-Staff → tenant → subscription → guest-invite flow. Once a user holds the role,
-they appear under **Members** (section 6) and can be assigned a model.
+Reaching an agent at all is a **mycelium** concern. The gateway routes are
+`protectedByRoles` (one role per agent: `alpha`, `beta`, `hermes-glm`, …), so an
+account must hold the matching guest-role to talk to that agent, with `write` for
+chat itself. Granting it is either the **Members** tab above (which drives
+mycelium over JSON-RPC for you) or **mycelium-webapp** — Mycelium's own admin UI
+— via the Staff → tenant → subscription → guest-invite flow. Once a user holds
+the role, they appear under **Members** and can be pinned a model.

--- a/docs/ADMIN_GUIDE.pt-br.md
+++ b/docs/ADMIN_GUIDE.pt-br.md
@@ -1,8 +1,9 @@
 # Guia do Administrador
 
 Operações do dia-a-dia pela **área de admin do chat-webapp**: injetar arquivos,
-secrets e skills compartilhados nos agentes dos usuários, registrar modelos por
-agente e atribuí-los a usuários individuais, revisar membros e definir branding.
+segredos e skills compartilhados nos agentes dos usuários, definir os arquivos de
+identidade do agente, decidir qual modelo as pessoas recebem, consertar a
+configuração das instâncias, convidar membros e definir a marca.
 
 Para *criar* um novo agente, veja [Criando um Agente Customizado](./CREATE_CUSTOM_AGENT.pt-br.md).
 Para subir/resetar o stack inteiro, veja o
@@ -10,137 +11,213 @@ Para subir/resetar o stack inteiro, veja o
 
 ---
 
-## 1. Quem administra, e escopos
+## 1. Quem administra, e o que você escolhe primeiro
 
 A área de admin fica acessível pelo **chat-webapp** para contas que gerenciam um
 **escopo**. Um escopo é:
 
-- **Tenant** — tudo sob um tenant.
-- **Subscription** — uma conta de subscription sob um tenant.
+- **Tenant** — tudo dentro de um tenant.
+- **Subscription** — uma conta de subscription dentro de um tenant.
 
-Tudo na área de admin opera **sobre o escopo selecionado** (a trilha de escopo
-no topo). As mudanças cascateiam para os containers picoclaw dos usuários
-daquele escopo. **Branding** é a exceção — é global à instância e só staff edita.
+A tela é **agent-first**: você escolhe o agente (`alpha`, `beta`, `hermes-glm`, …)
+antes de qualquer tenant ou subscription, porque os agentes vêm da configuração do
+proxy deste deploy e existem antes de qualquer tenant. Depois você escolhe o
+escopo na trilha lateral, e cada seção age sobre esse par **(agente, escopo)**. As
+mudanças descem para os containers dos usuários daquele escopo.
 
-O modelo mental: você edita material **compartilhado** num escopo, o proxy
-sincroniza numa visão **efetiva**, e o container de cada usuário monta essa
-visão como somente-leitura. Um usuário nunca vê o workspace privado de outro —
-apenas o material compartilhado que você injetou no escopo dele.
+Duas coisas não são seções de agente: **Membros** (a lista de membros pertence a
+uma subscription, sejam quais forem os agentes que ela roda) e **Marca**
+(instance-wide, só staff).
+
+O modelo mental: você edita material **compartilhado** em um escopo, o proxy
+sincroniza numa visão **efetiva**, e o container de cada usuário monta essa visão
+como somente-leitura. Um usuário nunca vê o workspace privado de outro — só o
+material compartilhado que você injetou no escopo dele.
+
+As seções abaixo têm o nome das abas: **Arquivos · Segredos · Skills ·
+Identidade · Modelos · Configuração**, mais **Membros** e **Marca**.
 
 ---
 
-## 2. Shared files (arquivos compartilhados)
+## 2. Arquivos
 
-Injeta arquivos arbitrários no workspace do agente de cada usuário do escopo.
+Injete arquivos arbitrários no workspace do agente de cada usuário do escopo.
 
-1. Abra **Shared files**.
+1. Abra **Arquivos**.
 2. Escolha o escopo.
-3. Faça upload dos arquivos.
+3. Suba os arquivos.
 
 Os agentes dos usuários passam a vê-los no workspace. Use para documentos de
 referência, datasets ou qualquer conteúdo estático que os agentes devam ler.
 
 ---
 
-## 3. Shared secrets (secrets compartilhados)
+## 3. Segredos
 
-Fornece secrets (chaves de API, tokens, strings de conexão) aos agentes de um
-escopo **sem** embuti-los em templates ou imagens.
+Forneça segredos (API keys, tokens, strings de conexão) aos agentes de um escopo
+**sem** embuti-los em templates ou imagens.
 
 Formatos suportados:
 
-- **dotenv** — linhas `KEY=value`.
-- **json** — um objeto JSON plano de pares chave/valor.
-- **file** — upload de um arquivo de secret como está.
+- **dotenv** — linhas `CHAVE=valor`.
+- **json** — um objeto JSON plano de chave/valor.
+- **file** — suba um arquivo de segredo como está.
 
-> O formato **nativo** de secret do picoclaw (model API key) **não** está
-> disponível aqui de propósito. Credenciais de modelo são gerenciadas por agente
-> na aba **Model** (seção 5), não como secret compartilhado.
+> O formato de segredo **nativo** do picoclaw (a API key do modelo) é
+> deliberadamente **indisponível** aqui. Credenciais de modelo são gerenciadas na
+> aba **Modelos** (seção 6), não como segredo compartilhado.
 
-Os secrets são gravados no store de shared-secrets do escopo e sincronizados na
-visão efetiva montada somente-leitura no agente de cada usuário.
+Os segredos vão para o store de segredos compartilhados do escopo e são
+sincronizados na visão efetiva montada somente-leitura em cada agente.
 
 ---
 
-## 4. Shared skills (skills compartilhadas)
+## 4. Skills
 
-Envia skills (um `SKILL.md` mais arquivos de apoio opcionais) para os agentes de
+Empurre skills (um `SKILL.md` mais arquivos de apoio opcionais) para os agentes de
 todos os usuários de um escopo. Uma skill é uma pasta com um `SKILL.md`
 (frontmatter YAML `name` + `description`, depois um corpo Markdown) — o mesmo
-formato usado em `workspace/skills/<name>/` de um template.
+formato usado em `workspace/skills/<nome>/` de um template.
 
-1. Abra **Shared skills**, escolha o escopo.
+1. Abra **Skills**, escolha o escopo.
 2. Adicione uma skill:
-   - escrevendo/editando o documento `SKILL.md` inline, ou
-   - fazendo upload de um **zip** da pasta da skill.
-3. Arquive ou exclua uma skill para removê-la do escopo.
+   - escrevendo/editando o `SKILL.md` inline, ou
+   - subindo um **zip** da pasta da skill.
+3. Arquive ou apague uma skill para removê-la do escopo.
 
 O proxy sincroniza as skills do escopo na visão effective-skills e a monta
-somente-leitura no agente de cada usuário. Editar uma skill re-sincroniza no
-lugar (o inode do mount é preservado, então agentes em execução a enxergam).
+somente-leitura em cada agente. Editar uma skill re-sincroniza no lugar (o inode
+do mount é preservado, então agentes rodando pegam a mudança).
 
 ---
 
-## 5. Model — registro por agente e atribuição por usuário
+## 5. Identidade (persona)
 
-A aba **Model** permite ao admin registrar modelos LLM **por agente** e então
-atribuir um modelo registrado a **usuários individuais** daquele agente. É
-admin-only: usuários comuns não trocam o próprio modelo.
+Os quatro arquivos que o agente lê como identidade, entregues a todo workspace do
+par (agente, escopo) selecionado — sobrepondo o template do agente, com o escopo
+mais específico vencendo o mais amplo:
 
-### 5.1 Registrar um modelo (por agente)
+| Arquivo | O que é | Como é entregue |
+|---|---|---|
+| `AGENT.md` | o que o agente faz e como se comporta | **somente-leitura** |
+| `SOUL.md` | a voz / personalidade dele | **somente-leitura** |
+| `HEARTBEAT.md` | a lista de tarefas recorrentes | **somente-leitura** |
+| `USER.md` | o que se sabe sobre o usuário | **só semente** |
 
-1. Abra **Model**.
-2. Escolha o **Agent** (ex.: `alpha`, `beta`) no topo.
-3. Em **Register model**, preencha:
-   - **provider** — ex.: `zhipu`, `deepseek`, `openai`.
-   - **model_name** — o `model_name` do picoclaw (ex.: `glm-4.7`).
-   - **litellm model** — o id do modelo no provedor (frequentemente igual ao `model_name`).
-   - **api_base** — a URL base do provedor (ex.: `https://open.bigmodel.cn/api/paas/v4`).
-   - **api_key** — write-only; guardada no servidor, nunca devolvida.
-4. **Register.** O modelo entra no registry daquele agente.
+O conjunto é **fixo e fechado** — esses endpoints escrevem na raiz de um
+workspace, então um nome de arquivo arbitrário seria uma primitiva de escrita
+arbitrária alcançando todo container do escopo. O proxy recusa qualquer outro
+nome.
 
-Modelos registrados são **por agente e globais ao agente** — a mesma lista fica
-disponível para atribuir a qualquer usuário daquele agente.
+- **Arquivos somente-leitura** não podem ser alterados pelo membro no workspace, e
+  uma edição não sobrevive a um restart.
+- **`USER.md` continua gravável**: o agente registra ali o que aprende sobre o
+  usuário. Defini-lo aqui determina de onde um workspace **novo** parte; nunca
+  sobrescreve um existente.
 
-### 5.2 Atribuir um modelo a um usuário
-
-Na lista de usuários (usuários do agente selecionado), escolha um modelo
-registrado e **Apply** para um usuário. O proxy grava a entrada do modelo —
-incluindo a `api_key` — no `config.json` do picoclaw daquele usuário, então o
-agente dele passa a autenticar com o modelo atribuído no próximo turno.
-
-> Um usuário recém-provisionado começa no modelo **default** do agente, fixado
-> em `crab/crab-shell-proxy/config.yaml` (com a chave do ambiente). Atribuir um
-> modelo registrado aqui **sobrescreve** isso para aquele usuário específico.
-
-### 5.3 Remover um modelo
-
-Exclua um modelo registrado do registry do agente pela ação de delete. Usuários
-já atribuídos mantêm o `config.json` atual até serem reatribuídos.
+Cada linha diz se o arquivo está **definido aqui** ou **herdado**. Abrir o editor
+pré-carrega o que o agente realmente roda — resolvido pela cascata (este escopo →
+o tenant abaixo → o template do agente) — para você editar uma identidade real em
+vez de uma página em branco; **salvar** é o que torna o arquivo deste escopo.
+**Limpar** o remove neste escopo e os workspaces voltam ao escopo mais amplo, ou
+ao template.
 
 ---
 
-## 6. Members (membros)
+## 6. Modelos
 
-A aba **Members** lista os usuários da **subscription** selecionada, agrupados
-por agente (role). Use para ver quem existe por agente antes de atribuir modelos
-(seção 5) ou revisar material compartilhado. Um escopo **tenant** não tem lista
-de membros (membros vivem no nível de subscription).
+Duas coisas separadas: um **inventário** de modelos que o proxy pode servir, e a
+**escada** que decide qual deles um workspace resolve.
+
+### 6.1 O inventário (registre uma vez)
+
+Um inventário para o proxy inteiro. Um modelo é registrado uma vez — com as
+credenciais — e cada escopo aponta para esse registro em vez de guardar a própria
+cópia. Preencha:
+
+- **provider** — ex.: `zhipu`, `deepseek`, `openai`.
+- **model_name** — o `model_name` do picoclaw (ex.: `glm-4.7`).
+- **litellm model** — o id do modelo no provider (em geral igual ao `model_name`).
+- **api_base** — a URL base do provider.
+- **api_key** — write-only; guardada no servidor, nunca devolvida.
+
+Os modelos aparecem como **em serviço** ou **aposentados/retidos**; *deprecar* um
+modelo o tira de serviço sem apagar o registro.
+
+### 6.2 A escada (quem recebe o quê)
+
+Leia a escada de cima para baixo: cada degrau cobre menos gente que o de cima e o
+sobrepõe — degraus instance-wide, depois o tenant, depois a subscription. O
+**degrau mais estreito com um modelo vence**, e é nele que um workspace recém
+provisionado cai.
+
+Se **nada resolve** para um escopo, novos workspaces ali são **recusados** —
+então, antes de limpar o degrau em vigor, verifique o que (se algo) está definido
+acima dele. Degraus que você não tem autoridade para ler ficam ocultos; um degrau
+instance-wide pode estar cobrindo o escopo mesmo assim.
+
+### 6.3 Pins (uma pessoa)
+
+Um **pin** atribui um modelo registrado a um único usuário e supera todos os
+degraus acima. Use para uma pessoa que precisa de algo diferente — para mover um
+grupo inteiro, defina o degrau do escopo dela. Pins vivem numa **subscription** (é
+onde os usuários estão), e um usuário só aparece depois de ter workspace, isto é,
+depois do primeiro chat.
 
 ---
 
-## 7. Branding
+## 7. Configuração
 
-Branding global da instância (o logo mostrado como avatar do tenant na sidebar
-do chat). Essa aba é **staff-only** e não é por-escopo.
+Conserto de `config.json` por instância, e edição em massa de uma chave numa
+subscription.
+
+- **Em massa** (uma subscription por vez): informe um **caminho pontuado** para um
+  valor (ex.: `tools.web.brave.enabled`), **leia primeiro a distribuição atual** —
+  o que cada membro tem hoje — e só então escreva. Instâncias cuja chave está
+  ausente, bloqueada por um caminho conflitante, ou cujo config está ilegível são
+  excluídas da escrita em massa e listadas para conserto individual. Chaves que o
+  **proxy possui** (ele as reescreve a cada materialização) são recusadas: uma
+  mudança em massa ali não sobreviveria.
+- **Instância única**: o editor cru abre o `config.json` de um membro como **JSON**
+  formatado ou como **árvore**, valida e grava de volta.
+
+Uma mudança de config vale no próximo start da instância. O controle de restart
+no painel decide como essa parada acontece — **agora** (o padrão), **agendada**
+para um horário que você escolhe, ou **aviso**: deixada para o membro, que vê o
+aviso de restart pendente no chat. A escolha é por sessão, não é armazenada.
 
 ---
 
-## 8. Como roles liberam acesso a um agente
+## 8. Membros
 
-Alcançar um agente é uma questão do **mycelium**, não do chat-webapp. As rotas
-do gateway são `protectedByRoles` (roles `alpha` / `beta`), então uma conta
-precisa ter a guest-role correspondente para falar com aquele agente. Roles são
-atribuídas no **mycelium-webapp** (a UI de admin do próprio Mycelium) pelo fluxo
-Staff → tenant → subscription → guest-invite. Quando o usuário tem a role, ele
-aparece em **Members** (seção 6) e pode receber a atribuição de um modelo.
+A aba **Membros** lista os usuários da **subscription** selecionada, agrupados por
+agente (papel). Dali você pode:
+
+- **Convidar** uma conta para um agente por e-mail, com acesso **read** ou
+  **write** (write é o que o chat exige; read é só visualização).
+- **Revogar** o acesso de uma conta àquele agente.
+- Ver quem existe por agente antes de fixar modelos (seção 6) ou revisar material
+  compartilhado.
+
+Um escopo **tenant** não tem lista de membros (membros vivem no nível da
+subscription).
+
+---
+
+## 9. Marca
+
+Marca instance-wide: o nome do app, o logo mostrado como avatar do tenant na
+sidebar do chat, e o ícone do app. Esta aba é **só para staff** e não é por
+escopo.
+
+---
+
+## 10. Como os papéis liberam o acesso a um agente
+
+Alcançar um agente é assunto do **mycelium**. As rotas do gateway são
+`protectedByRoles` (um papel por agente: `alpha`, `beta`, `hermes-glm`, …), então
+uma conta precisa do guest-role correspondente para falar com aquele agente, com
+`write` para o chat em si. Conceder isso é a aba **Membros** acima (que fala com o
+mycelium por JSON-RPC no seu lugar) ou o **mycelium-webapp** — a UI de admin do
+próprio Mycelium — pelo fluxo Staff → tenant → subscription → guest-invite. Uma
+vez com o papel, o usuário aparece em **Membros** e pode receber um pin de modelo.

--- a/docs/CREATE_CUSTOM_AGENT.md
+++ b/docs/CREATE_CUSTOM_AGENT.md
@@ -12,9 +12,12 @@ picoclaw config — that users can chat with through the portal.
 An **agent** is one named picoclaw personality (e.g. `alpha`, `beta`). Two pieces
 define it:
 
-1. **An entry in `crab/crab-shell-proxy/config.yaml`** — the agent's name, which
-   mycelium service routes to it, which LLM model it uses, and which **template**
-   it clones from.
+1. **An entry in the proxy's agent catalog** — the agent's name, which mycelium
+   service routes to it, which LLM model it uses, and which **template** it
+   clones from. The catalog is `crab/crab-shell-proxy/config.yaml`, baked into
+   the proxy image (standalone and prod). The Dokploy deploy **mounts** its own
+   copy instead, `deploy/dokploy/crab-shell-proxy.config.yaml`, so there the
+   catalog is edited without rebuilding.
 2. **A template directory** on disk — the files that get copied into every user's
    private workspace the first time they chat with the agent (persona, skills,
    picoclaw config).
@@ -147,7 +150,7 @@ Add an entry under `agents:` in `crab/crab-shell-proxy/config.yaml`:
 ```yaml
 agents:
   meuagente:
-    serviceName: "picoclaw-meuagente"   # must match the mycelium service key (4.5)
+    serviceName: "meuagente"            # must match the mycelium service key (4.5)
     token: { env: "MYC_PICOCLAW_MEUAGENTE_TOKEN" }
     template: "meuagente"               # -> data/templates/meuagente/
     mode: "continuous"                  # or "scale-to-zero"
@@ -161,12 +164,32 @@ agents:
 > **Mode:** `continuous` keeps the container running so the in-memory session
 > isn't reset between turns; `scale-to-zero` stops it after `idleTimeout`.
 
+> **Harness:** omitting `harness` gives you picoclaw (the default), driven over
+> the Pico Protocol. `harness: hermes` runs a hermes-agent container instead,
+> driven over its OpenAI-compatible API server — see the `hermes-glm` entry in
+> `crab/crab-shell-proxy/config.yaml` for the extra `model` fields it takes
+> (`baseUrl`, `keyEnvName`) and its much longer `startupDeadline`.
+
 ### 4.5 Register the mycelium route
 
-In `deploy/standalone/config.standalone.toml` (and the matching `deploy/<mode>/config.*.toml`), copy the existing `picoclaw-alpha` service
-block and rename it to `picoclaw-meuagente` (the callers hit
-`/picoclaw-meuagente/...`). Keep the same `token = { env = ... }`,
-`healthCheckPath`, and `group` role settings — just change the name.
+Copy the existing `[[alpha]]` service block (its `[[alpha.secret]]` and every
+`[[alpha.path]]`) and rename it to `meuagente`. The service key **is** the first
+path segment, so callers hit `/meuagente/...` — there is no `picoclaw-` prefix.
+Keep the same `token = { env = ... }`, `healthCheckPath`, `group` role settings
+and the full path set — just change the name.
+
+Do it in **every mode you deploy**, they are separate files:
+
+| Mode | File | Agents it declares today |
+|---|---|---|
+| standalone | `deploy/standalone/config.standalone.toml` | alpha, beta, hermes-glm |
+| prod | `deploy/prod/config.base.toml` | alpha, beta, hermes-glm |
+| dokploy | `deploy/dokploy/config.base.toml` | alpha, beta |
+
+The `protectedByRoles` blocks also declare the guest-role: mycelium auto-creates
+a role named after the service at boot, so a new agent brings its own role —
+granting it to an account is still the Staff → tenant → subscription →
+guest-invite flow.
 
 ### 4.6 Set the environment variables
 
@@ -182,14 +205,20 @@ injected into each user's `.security.yml`.
 
 ### 4.7 Rebuild and restart
 
-`config.yaml` is **baked into** the crab-shell-proxy image (a proxy-side agent
-change needs a rebuild), while the mycelium config is now **mounted** from
-`deploy/<mode>/` (config.standalone.toml / config.base.toml), so a route change
-there only needs a restart. The safe catch-all is still a rebuild:
+The mycelium config is **mounted** from `deploy/<mode>/` (config.standalone.toml
+/ config.base.toml), so a route change only needs a restart. The agent catalog
+depends on the mode: `crab/crab-shell-proxy/config.yaml` is **baked into** the
+proxy image (standalone, prod → rebuild), while dokploy mounts
+`deploy/dokploy/crab-shell-proxy.config.yaml` (→ restart). The safe catch-all
+locally is a rebuild:
 
 ```bash
 docker compose up -d --build crab-shell-proxy mycelium-gateway
 ```
+
+In prod/dokploy the proxy runs a **published image**, so a catalog change baked
+into `crab/crab-shell-proxy/config.yaml` only lands after that image is rebuilt
+and pushed — this is exactly why the dokploy deploy mounts its own copy.
 
 The **template files** live in the mounted `/data` volume, so editing them later
 does not need a rebuild — but remember the first-provision rule (section 3).
@@ -202,8 +231,8 @@ does not need a rebuild — but remember the first-provision rule (section 3).
 - [ ] `data/templates/<name>/.security.yml` exists (model_list has your model; no keys)
 - [ ] `data/templates/<name>/workspace/{AGENT.md,SOUL.md,USER.md}` written
 - [ ] Optional `workspace/memory/` and `workspace/skills/<skill>/SKILL.md`
-- [ ] Agent entry added to `crab/crab-shell-proxy/config.yaml` (`template:` points to `<name>`)
-- [ ] Route added to `deploy/standalone/config.standalone.toml` (`picoclaw-<name>`)
+- [ ] Agent entry added to the proxy catalog — `crab/crab-shell-proxy/config.yaml`, plus `deploy/dokploy/crab-shell-proxy.config.yaml` if you deploy with Dokploy (`template:` points to `<name>`)
+- [ ] Route added to the gateway config of every mode you deploy (`[[<name>]]`, callers hit `/<name>/...`)
 - [ ] `.env` has `MYC_PICOCLAW_<NAME>_TOKEN` and `PICOCLAW_<NAME>_API_KEY`
 - [ ] `docker compose up -d --build crab-shell-proxy mycelium-gateway`
 - [ ] Templates finalized **before** users start chatting
@@ -215,8 +244,9 @@ does not need a rebuild — but remember the first-provision rule (section 3).
 - **"My template changes didn't show up."** You (or the user) already chatted
   with the agent — returning users aren't re-seeded. Test with a fresh user, or
   reset that user's data dir.
-- **"I added an agent but requests 404."** The mycelium route (4.5) is missing or
-  the gateway wasn't rebuilt; callers must hit `/picoclaw-<name>/...`.
+- **"I added an agent but requests 404."** The mycelium route (4.5) is missing
+  from the config that mode mounts, or the gateway wasn't restarted; callers must
+  hit `/<name>/...`, the literal service key.
 - **"Model auth fails."** `apiKeyEnv` in `config.yaml` must name a real env var,
   and `model.name` must match a `model_name` in the template's `.security.yml`
   `model_list`.

--- a/docs/CREATE_CUSTOM_AGENT.pt-br.md
+++ b/docs/CREATE_CUSTOM_AGENT.pt-br.md
@@ -13,9 +13,12 @@ picoclaw próprios — com quem os usuários podem conversar pelo portal.
 Um **agente** é uma personalidade picoclaw nomeada (ex.: `alpha`, `beta`). Duas
 peças o definem:
 
-1. **Uma entrada em `crab/crab-shell-proxy/config.yaml`** — o nome do agente, qual
+1. **Uma entrada no catálogo de agentes do proxy** — o nome do agente, qual
    serviço do mycelium roteia até ele, qual modelo LLM ele usa e de qual
-   **template** ele é clonado.
+   **template** ele é clonado. O catálogo é o `crab/crab-shell-proxy/config.yaml`,
+   embutido na imagem do proxy (standalone e prod). O deploy Dokploy **monta** a
+   própria cópia, `deploy/dokploy/crab-shell-proxy.config.yaml`, então lá o
+   catálogo é editado sem rebuild.
 2. **Um diretório de template** no disco — os arquivos copiados para o workspace
    privado de cada usuário na primeira vez que ele conversa com o agente (persona,
    skills, config do picoclaw).
@@ -150,7 +153,7 @@ Adicione uma entrada em `agents:` no `crab/crab-shell-proxy/config.yaml`:
 ```yaml
 agents:
   meuagente:
-    serviceName: "picoclaw-meuagente"   # precisa bater com a chave do serviço no mycelium (4.5)
+    serviceName: "meuagente"            # precisa bater com a chave do serviço no mycelium (4.5)
     token: { env: "MYC_PICOCLAW_MEUAGENTE_TOKEN" }
     template: "meuagente"               # -> data/templates/meuagente/
     mode: "continuous"                  # ou "scale-to-zero"
@@ -165,12 +168,33 @@ agents:
 > ser reiniciada entre turnos; `scale-to-zero` para o container após o
 > `idleTimeout`.
 
+> **Harness:** sem `harness` você tem picoclaw (o padrão), conduzido pelo Pico
+> Protocol. `harness: hermes` roda um container hermes-agent, conduzido pelo
+> servidor de API OpenAI-compatível dele — veja a entrada `hermes-glm` no
+> `crab/crab-shell-proxy/config.yaml` para os campos extras de `model`
+> (`baseUrl`, `keyEnvName`) e o `startupDeadline` bem mais longo que ele exige.
+
 ### 4.5 Registre a rota no mycelium
 
-No `deploy/standalone/config.standalone.toml` (e o `deploy/<modo>/config.*.toml` correspondente), copie o bloco de serviço `picoclaw-alpha`
-existente e renomeie para `picoclaw-meuagente` (os chamadores acessam
-`/picoclaw-meuagente/...`). Mantenha o mesmo `token = { env = ... }`,
-`healthCheckPath` e as configs de `group`/role — só troque o nome.
+Copie o bloco de serviço `[[alpha]]` existente (o `[[alpha.secret]]` e todos os
+`[[alpha.path]]`) e renomeie para `meuagente`. A chave do serviço **é** o
+primeiro segmento do path, então os chamadores acessam `/meuagente/...` — não há
+prefixo `picoclaw-`. Mantenha o mesmo `token = { env = ... }`,
+`healthCheckPath`, as configs de `group`/role e o conjunto completo de paths —
+só troque o nome.
+
+Faça isso em **todo modo que você implanta**, são arquivos separados:
+
+| Modo | Arquivo | Agentes que ele declara hoje |
+|---|---|---|
+| standalone | `deploy/standalone/config.standalone.toml` | alpha, beta, hermes-glm |
+| prod | `deploy/prod/config.base.toml` | alpha, beta, hermes-glm |
+| dokploy | `deploy/dokploy/config.base.toml` | alpha, beta |
+
+Os blocos `protectedByRoles` também declaram o guest-role: o mycelium cria no
+boot um papel com o nome do serviço, então um agente novo já traz o papel dele —
+concedê-lo a uma conta continua sendo o fluxo Staff → tenant → subscription →
+guest-invite.
 
 ### 4.6 Defina as variáveis de ambiente
 
@@ -186,14 +210,21 @@ no `.security.yml` de cada usuário.
 
 ### 4.7 Rebuild e restart
 
-`config.yaml` é **baked** na imagem do crab-shell-proxy (mudança do lado do proxy
-exige rebuild), enquanto o config do mycelium agora é **montado** de `deploy/<modo>/`
-(config.standalone.toml / config.base.toml), então uma mudança de rota lá só precisa
-de restart. O atalho seguro ainda é rebuildar:
+O config do mycelium é **montado** de `deploy/<modo>/` (config.standalone.toml /
+config.base.toml), então uma mudança de rota só precisa de restart. O catálogo de
+agentes depende do modo: o `crab/crab-shell-proxy/config.yaml` é **embutido** na
+imagem do proxy (standalone, prod → rebuild), enquanto o dokploy monta o
+`deploy/dokploy/crab-shell-proxy.config.yaml` (→ restart). Localmente, o atalho
+seguro é rebuildar:
 
 ```bash
 docker compose up -d --build crab-shell-proxy mycelium-gateway
 ```
+
+Em prod/dokploy o proxy roda uma **imagem publicada**, então uma mudança de
+catálogo embutida no `crab/crab-shell-proxy/config.yaml` só chega depois que essa
+imagem for rebuildada e publicada — é exatamente por isso que o deploy dokploy
+monta a própria cópia.
 
 Os **arquivos do template** vivem no volume montado `/data`, então editá-los
 depois não exige rebuild — mas lembre da regra do primeiro provisionamento
@@ -207,8 +238,8 @@ depois não exige rebuild — mas lembre da regra do primeiro provisionamento
 - [ ] `data/templates/<nome>/.security.yml` existe (model_list tem seu modelo; sem keys)
 - [ ] `data/templates/<nome>/workspace/{AGENT.md,SOUL.md,USER.md}` escritos
 - [ ] Opcional: `workspace/memory/` e `workspace/skills/<skill>/SKILL.md`
-- [ ] Entrada do agente adicionada em `crab/crab-shell-proxy/config.yaml` (`template:` aponta para `<nome>`)
-- [ ] Rota adicionada em `deploy/standalone/config.standalone.toml` (`picoclaw-<nome>`)
+- [ ] Entrada do agente adicionada no catálogo do proxy — `crab/crab-shell-proxy/config.yaml`, mais o `deploy/dokploy/crab-shell-proxy.config.yaml` se você implanta com Dokploy (`template:` aponta para `<nome>`)
+- [ ] Rota adicionada na config do gateway de todo modo que você implanta (`[[<nome>]]`, chamadores acessam `/<nome>/...`)
 - [ ] `.env` tem `MYC_PICOCLAW_<NOME>_TOKEN` e `PICOCLAW_<NOME>_API_KEY`
 - [ ] `docker compose up -d --build crab-shell-proxy mycelium-gateway`
 - [ ] Templates finalizados **antes** de os usuários começarem a conversar
@@ -221,8 +252,9 @@ depois não exige rebuild — mas lembre da regra do primeiro provisionamento
   conversou com o agente — usuários recorrentes não são re-semeados. Teste com um
   usuário novo, ou resete o diretório de dados daquele usuário.
 - **"Adicionei um agente mas as requisições dão 404."** A rota do mycelium (4.5)
-  está faltando ou o gateway não foi rebuildado; os chamadores precisam acessar
-  `/picoclaw-<nome>/...`.
+  está faltando na config que aquele modo monta, ou o gateway não foi
+  reiniciado; os chamadores precisam acessar `/<nome>/...`, a chave literal do
+  serviço.
 - **"A autenticação do modelo falha."** O `apiKeyEnv` no `config.yaml` precisa
   nomear uma env var real, e o `model.name` precisa bater com um `model_name` no
   `model_list` do `.security.yml` do template.

--- a/fungi/mycelium/Dockerfile.standalone
+++ b/fungi/mycelium/Dockerfile.standalone
@@ -10,20 +10,27 @@
 # pinned commit -- so the whole image is reproducible from the git ref alone.
 #
 # Pin with --build-arg MYCELIUM_GIT_REF=<commit-sha> to move to a newer
-# revision; the default below is the commit tagged 9.0.0-rc.12 (resolved via
-# `git rev-parse 9.0.0-rc.12^{commit}`). It carries the staff-bootstrap web
+# revision; the default below is the commit tagged 9.0.0-rc.13 (resolved via
+# `git rev-parse 9.0.0-rc.13^{commit}`). It carries the staff-bootstrap web
 # onboarding flow (commit 8d8933b3, released in rc.4) this stack's
 # config.standalone.toml opts into via `staffBootstrapSecret`, and the
 # human-friendly stub email render + wired file email transport (#169, rc.7) --
 # the latter directly relevant here, since standalone mode uses the stub/file
 # email transport.
 #
-# What rc.8 through rc.12 changed is NOT recorded here, because nobody checked.
+# What rc.8 through rc.13 changed is NOT recorded here, because nobody checked.
 # Read upstream's release notes before assuming this bump was inert.
+#
+# THIS DEFAULT IS NOT WHAT GETS BUILT ON ITS OWN. docker-compose.yaml passes
+# MYCELIUM_GIT_REF as a build arg, which overrides the ARG below -- so a bump
+# here has to be mirrored in docker-compose.yaml and deploy/standalone/.env.example
+# (and in the operator's own .env, which overrides both). The published-image
+# modes pin the SAME release by tag instead: MYCELIUM_IMAGE_TAG=9.0.0-rc.13 in
+# deploy/prod/ and deploy/dokploy/. All five move together.
 # ==============================================================================
 
 ARG MYCELIUM_GIT_URL=https://github.com/LepistaBioinformatics/mycelium.git
-ARG MYCELIUM_GIT_REF=92ff0230740b497ff5790da7ea87bbdd7660b4c2
+ARG MYCELIUM_GIT_REF=9298ecb44a69ced91cb2d7d3356a716aedca858b
 
 # ? ----------------------------------------------------------------------------
 # ? Build stage


### PR DESCRIPTION
An audit of `deploy/prod/` and `deploy/dokploy/` against the standalone deploy found the gateway **routing** already in sync — `alpha`/`beta` are byte-identical across all three configs, and the `/v1/admin/*` wildcard covers every admin route the proxy registers today. What had drifted was everything around it.

## Mycelium version, now 9.0.0-rc.13 everywhere

Five places decided the version and disagreed: the committed tree was rc.7 throughout while the operator's own standalone `.env` ran rc.12 — so prod would have shipped a mycelium nobody had tested against. Aligned `Dockerfile.standalone` (ARG), `docker-compose.yaml` (the build arg, which **overrides** that ARG — now stated in both files), `deploy/standalone/.env.example`, and `MYCELIUM_IMAGE_TAG` in the prod/dokploy compose files and env examples.

Tag `9.0.0-rc.13` → `9298ecb44a69ced91cb2d7d3356a716aedca858b`; the image exists on GHCR.

## `deploy/prod` was a copy of dokploy that was never adapted

Its `config.base.toml` carried dokploy's `https://*.example.com` origins and a "TLS terminates at Traefik" note — inside the mode whose own header says *no Traefik*. Rendering the merge showed `mycelium-webapp` built with `VITE_MYCELIUM_API_URL=http://localhost:8080` while the gateway allowed only the https origins: following the file as written gives a CORS wall on the admin UI.

- `allowedOrigins` now match what the mode actually serves, with the change-them-together-with-the-build-arg rule spelled out.
- `domainUrl` keeps its `►►► REPLACE` marker — prod is the mode with real SMTP, so a localhost value there mails unusable magic links.
- `docker-compose.prod.yaml` also inherited the base file's **temporary** `127.0.0.1:18080` proxy publish, because `ports` concatenates across `-f` layers. Reset it: in production the gateway is the only entry point, loopback included.

## hermes-glm: prod mirrors standalone, dokploy stays picoclaw-only

Both are defensible; prod was just incoherent — it **routed** `hermes-glm` while its `.env.example` documented neither `MYC_HERMES_GLM_TOKEN` nor `PROXY_GLM_API_KEY`, so the gateway would advertise the agent and inject an empty bearer. Added both to prod. dokploy declares the agent in neither its gateway config nor its mounted proxy catalog, so its compose no longer passes those two variables at all (they were resolving to empty and warning).

## The one-time Postgres schema step was wrong **and** incomplete

Documented as `postgres/sql/up.sql`; the real path at this tag is `adapters/diesel_postgres/sql/up.sql`. Worse, that file is not the whole schema: it ships `kv_artifact` and the `message_queue` claim index but **not** `instance_settings`, `resource_audit_log`, or `tenant.encrypted_dek`/`kek_version`. A deploy following the old instructions came up with tables missing.

Both READMEs now document the two steps (`up.sql`, then every `migrations/` script), the required `-v db_password`, the benign `role already exists`, and how to verify.

## Documentation

- **READMEs** — new **Deploy modes** section: the section both compose headers already pointed at and which did not exist. Covers the three profiles, what to edit before each, the schema step, and registering the `subscriptionAccount.created` webhook via `systemManager.webhooks.create`. Fixed: spawned containers are `crabshell-<agent>-<hash>`, so the reset recipe's `--filter name=picoclaw` matched nothing; standalone keeps accounts in the `mycelium-data` SQLite volume, not "the Postgres volume"; the third agent and its role.
- **CREATE_CUSTOM_AGENT** (en+pt) — routes are `/<name>/...`, never `/picoclaw-<name>/`; a new agent has to land in all three deploy TOMLs and, for dokploy, in the mounted proxy catalog; documented the `harness` field.
- **ADMIN_GUIDE** (en+pt) — rewritten for the agent-first screen and the real tab names. **Identity** (persona), **Config** (bulk key edits + per-instance JSON) and Members invite/revoke were entirely undocumented.
- **Stale comments** — `docker-compose.yaml`'s header still drew `/picoclaw-alpha/*` routes, and `config.standalone.toml` still described `picoclaw-openai-proxy` sidecars plus a paragraph that contradicted itself about route naming.
- Dropped `PICOCLAW_IMAGE`/`TZ`/`LOG_LEVEL` from all three env examples: no compose references them and the proxy reads none of them.

## Verification

Three compose renders (standalone, prod, dokploy) with empty stderr, all three TOMLs parse, and no leftover references to the old tag, SHAs, route prefix or `up.sql` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)