### PR TITLE
chore(deploy): drop the hermes-glm routes, vars and operator docs

### DIFF
--- a/.specs/features/hermes-removal/DECISION.md
+++ b/.specs/features/hermes-removal/DECISION.md
@@ -1,0 +1,160 @@
+# Decision: Hermes is withdrawn from the shipped surface
+
+**Date:** 2026-08-09
+**Status:** Executed.
+**Scope:** `zombie-crab-project` (root), `crab/crab-shell-proxy`, `crab/crab-exoskeleton-webapp`.
+
+---
+
+## The decision
+
+The **Hermes harness** (Nous Research `hermes-agent`, driven over its OpenAI-compatible HTTP API) is
+**removed from every shipped artifact** and demoted to a **future implementation**.
+
+It was not removed because it did not work. It was implemented, and **verified working end-to-end
+against a real z.ai/GLM deployment** — a signed-in user chatted with a Hermes agent through the
+gateway. It is removed for **compatibility with the infrastructure this project actually runs on.**
+
+## Why
+
+| Problem | Detail |
+|---|---|
+| **Startup budget** | The container needs a **180s** startup deadline against the proxy's **35s** global health-wait. `Agent.StartupDeadline` exists solely because of this. |
+| **Turn latency — the real blocker** | Turns sat **near mycelium's 60s `gatewayTimeout`**. Not reliably over it; *near* it. A fraction of real turns therefore time out at the gateway while the container is still working, and the user sees a failure for a turn that succeeded. **Never solved.** |
+| **Image weight** | 71 bundled skills plus Chromium under `s6`, pulled **per user**. On a scale-to-zero deployment that is a per-user cold-start cost. |
+| **Invocation fragility** | It must be started as `gateway run`. With the image default it exits on its own seconds after boot. |
+| **Auth workaround** | It needs `GATEWAY_ALLOW_ALL_USERS=true`, or it silently returns **empty replies**. Safe only because each container is per-user — an invariant that must be re-checked if it is ever relaxed. |
+| **Structural mismatch** | Everything lives in one flat `/opt/data`. Persona injection, projects and personal models are all picoclaw `config.json` / workspace-layout constructs, so Hermes was **excluded** from each of them rather than merely unimplemented. |
+
+**The cost was never code volume.** It was that "agent" meant two things in every reader's head, and
+every future change — config, admin API, model inventory, webapp tab logic, three mycelium TOMLs, two
+compose files — paid that tax for a branch **no deployment exercised.**
+
+## What was withdrawn
+
+- **Proxy:** `internal/hermes/`, `internal/docker/provision_hermes.go`,
+  `internal/docker/defaulttemplate/hermes/`, `config.HarnessHermes`, `Config.HermesImage`,
+  `ModelConfig.KeyEnvName`, the secret-gating branches and `Config.DisabledAgents`, the
+  `hermesAPIPort`/`endpoint` branches, the `Hermes Turner` field and `turnerFor`/`turnModelFor`.
+- **Root:** the `[[hermes-glm]]` mycelium service block in `deploy/prod/config.base.toml` and
+  `deploy/standalone/config.standalone.toml`; the `MYC_HERMES_GLM_TOKEN` / `PROXY_GLM_API_KEY`
+  passthroughs in `docker-compose.yaml` and every `.env.example`; the Hermes commentary in the
+  dokploy deploy files.
+- **Webapp:** the Hermes-specific comments, the per-agent harness `<Badge>`, and the Hermes test
+  fixtures.
+
+## What was deliberately KEPT
+
+**The generic harness seam stays dormant** (OD-1 Option A):
+
+`Agent.Harness` (validated, `picoclaw` the only accepted value), `turn.Request` / `turn.Sink`, the
+`Turner` interface, `docker.Target.Harness`, `harnessPort`/`endpoint`, the
+`defaulttemplate/<harness>/` layout, the admin API's `harness` field, and the model-inventory
+rejection gate with all three of its tests.
+
+Reasons, in order of weight:
+
+1. **Picoclaw flows through these paths today.** Touching them is the risk, not the Hermes code.
+2. **`harness` is a live API contract.** The admin API publishes it, `openapi.json` documents it, and
+   the webapp reads it to decide which admin tabs an agent offers.
+3. **`chat-progress-events` built `turn.Sink` on this seam**, and it is in-tree.
+4. **Option B would have lost coverage.** The three model-inventory rejection tests would have been
+   deleted along with the gate they cover — a coverage loss dressed as a simplification.
+5. **`ModelConfig.BaseURL` has a live non-Hermes consumer**: `migrate_models.go` imports it as the
+   model registry's `APIBase`.
+
+Consequence to accept honestly: **a discriminator with one legal value.** To a newcomer that reads as
+scaffolding. It is the price of not refactoring the one runtime that must not break.
+
+### Also kept: two back-compat behaviours
+
+- The webapp treats an **absent** `harness` as picoclaw. An older proxy reports no harness at all.
+- The webapp still handles `501 projects_unsupported`. The server-side 501 is gone, but a deployed
+  older proxy still returns it.
+
+Both are *version* skew, not harness variety.
+
+## Secondary decisions made during execution
+
+- **Dead guards were deleted, not left returning `true`.** `projectsSupported`,
+  `userModelsSupported` and the `Harness != HarnessHermes` term in the persona/project bind-drift
+  case were all constant-true once Hermes was gone. A trivially-true predicate is speculative
+  scaffolding. **Do not re-litigate this** — a re-add writes them fresh against the new profile.
+- **Test fixtures were rewritten against a synthetic harness value rather than deleted**, in both the
+  proxy and the webapp. Both suites tested the *false* branch of a picoclaw-only filter through a
+  Hermes agent; that branch is still live code. In the webapp this departs from HRM-37/38's literal
+  wording, which said to drop the assertions.
+- **Shipped feature specs were NOT rewritten.** ~20 spec docs across the three repos mention Hermes.
+  They are accurate records of what was true when they shipped. They are grep survivors; this file
+  and the withdrawal banners are what a reader finds instead.
+- **`harness: hermes` now fails at `Load`** rather than defaulting. A stale operator config must fail
+  loudly — silently defaulting would hand a user a picoclaw container under a role provisioned for
+  Hermes.
+
+## Where the implementation lives — recovery
+
+| SHA | What |
+|---|---|
+| `d2f0a9a` | multi-harness support + Hermes |
+| `748e0fe` | gate hermes agents on their secrets |
+| `3e9e95c` | model administration rejects non-picoclaw agents |
+
+**Read this first on a re-add:**
+`crab/crab-shell-proxy/.specs/features/multi-harness-support/implementation-notes.md` — the runtime
+findings from the live E2E. A deleted file is recoverable from git; *why `gateway run` instead of the
+image default* was not written down anywhere until that file existed.
+
+The design record stays at `.specs/features/multi-harness-support/` in both this repo
+(`spec.md`, `investigation.md`) and the proxy (`design.md`, `tasks.md`), each carrying a withdrawal
+banner.
+
+### One behaviour worth restoring on a re-add
+
+**`DisabledAgents`.** An agent whose required secrets were unset removed *itself* from `cfg.Agents` at
+`Load` instead of failing the whole proxy — so a config declaring an agent this deployment is not
+provisioned for degraded to "that agent does not exist" rather than "the proxy will not boot". Both
+append sites were inside `Harness == HarnessHermes` branches, so the mechanism died with the removal.
+The *idea* is good and general; it should come back, ideally not tied to one harness.
+
+---
+
+## Operational residue — documented, not automated
+
+Nothing below is cleaned up by this change. All of it is harmless if ignored.
+
+| ID | Item | Harmless if ignored? |
+|---|---|---|
+| HRM-48 | mycelium accounts still holding the auto-declared `hermes-glm` **guest-role grant**, now that the TOML block is gone | **Yes.** A grant to a service that no longer routes. It grants access to nothing. Cleaning it up requires a per-account revoke; not worth scripting. |
+| HRM-49 | per-user Hermes **workspace directories** under `<containerDataRoot>/tenants/…` | **Yes — and none exist.** `data/tenants` was empty at baseline. The removal deliberately does **not** delete user data as a side effect; if one existed it would be left untouched. |
+| HRM-50 | a pulled `nousresearch/hermes-agent` **image** | **Yes.** Not present locally at baseline. `docker image rm` if disk matters. |
+| HRM-51 | a **running** Hermes container | **Yes — none exist.** Only `crabshell-alpha-…` on `sipeed/picoclaw:latest` at baseline. |
+| HRM-34 | dead `MYC_HERMES_GLM_TOKEN` / `PROXY_GLM_API_KEY` vars in a local `deploy/*/.env` | **Yes.** Unread by anything now. **`deploy/standalone/.env` is gitignored and holds a real z.ai key** — operator-owned, never committed, never echoed. |
+
+### Two failure modes to know about
+
+- **Partial TOML update.** If mycelium still routes `hermes-glm` because only one of the deploy TOMLs
+  was updated, the proxy answers the turn as an **unknown service** (no agent matches
+  `x-mycelium-service-name`) — not a 500. There are **three** TOMLs, not two:
+  `deploy/prod/`, `deploy/standalone/`, `deploy/dokploy/`.
+- **Stale proxy config.** A `config.yaml` still declaring `harness: hermes` makes the proxy **refuse
+  to start**, with an error naming `picoclaw` as the accepted value. This is intentional.
+
+---
+
+## Verification at execution time
+
+Measured against a baseline captured **before** any edit, because both gates have pre-existing
+failures and "green" would have been the wrong target:
+
+| Gate | Result |
+|---|---|
+| proxy `go build ./...`, `go vet ./...` | clean |
+| proxy `go test ./...` | passes everywhere except `internal/docker`, which fails **the same 9 `lchown … operation not permitted` tests as the baseline**, diffed name-for-name (a sandbox permission limit, unrelated to this change) |
+| webapp `vitest run` | **56 files / 776 tests** — unchanged from baseline, because coverage was rewritten rather than deleted |
+| webapp `tsc --noEmit` | **the same 6 pre-existing test-file errors** as baseline, diffed identical |
+| webapp `next build` | succeeds |
+| landing page | untouched in both locales — no file under `lib/i18n/landing.ts`, `components/landing/` or `landing.module.css` is in the diff |
+
+**Not run in this environment:** the live stack boot (compose up, sign in, chat with `alpha` through
+the gateway, confirm no picoclaw container was recreated). That gate requires a running deployment and
+must be exercised before merge.

--- a/.specs/features/hermes-removal/DECISION.md
+++ b/.specs/features/hermes-removal/DECISION.md
@@ -155,6 +155,20 @@ failures and "green" would have been the wrong target:
 | webapp `next build` | succeeds |
 | landing page | untouched in both locales — no file under `lib/i18n/landing.ts`, `components/landing/` or `landing.module.css` is in the diff |
 
-**Not run in this environment:** the live stack boot (compose up, sign in, chat with `alpha` through
-the gateway, confirm no picoclaw container was recreated). That gate requires a running deployment and
-must be exercised before merge.
+Also checked after the change: `gofmt -l` in the proxy lists **exactly the same 5 pre-existing files**
+as before (none of them touched by this work); the three deploy TOMLs were re-parsed with `tomllib`;
+and no `.env` file was committed (TRAP-6 — `deploy/standalone/.env` is gitignored and holds a real
+z.ai key). The webapp has no ESLint configuration and CI builds images only, so there is no lint gate
+to run.
+
+## Known gaps
+
+1. **The live stack boot was NOT run** — compose up, sign in, chat with `alpha` through the gateway,
+   confirm no picoclaw container was recreated. That gate needs a running deployment and **must be
+   exercised before merge.**
+2. **The `state.db` schema is not recorded**, though P1 story 2 criterion 2 asks for it. The proxy
+   never opened that file, so neither the code nor its history holds the schema, and there was no
+   running Hermes container to inspect. `implementation-notes.md` says so explicitly and gives the
+   command to get it, rather than guessing at a shape a future reader would trust.
+3. **`deploy/standalone/.env` still holds the dead `MYC_HERMES_GLM_TOKEN` / `PROXY_GLM_API_KEY`
+   vars** (HRM-34). Operator-owned local hygiene; harmless, and never to be committed.

--- a/.specs/features/hermes-removal/spec.md
+++ b/.specs/features/hermes-removal/spec.md
@@ -528,6 +528,17 @@ pointer bump depends on the proxy and webapp merges.
 | HRM-48..51 | operational residue | P3 | Tasks | Pending |
 | HRM-52..58 | drift (§H) | P1 / P2 | Tasks | Pending |
 
+### ⚠️ One acceptance criterion is NOT fully met
+
+P1 story 2, criterion 2 requires `implementation-notes.md` to record, among other things, **"the
+`state.db` session/message schema"**. It does **not**. The proxy never opened that file, so nothing
+in the codebase or its history records the schema, and the execution session had no running Hermes
+container to inspect. Rather than write a plausible-sounding shape that a future reader would trust
+without re-deriving — which would defeat the document's entire purpose — the file states that the
+schema was never recorded and gives the command to obtain it (`sqlite3 <userDir>/state.db .schema`)
+on a re-add. **Every other item in that criterion is recorded.** Treat this as a known, deliberate
+gap, not an oversight.
+
 **Coverage:** 58 requirements. Under ED-1 (Option A), **HRM-23 is out of scope entirely**, and
 HRM-21/22/26/27 apply in their comment-only form. See `tasks.md` for the ID→task map.
 **Blocked on:** nothing. OD-1 resolved (ED-1).

--- a/.specs/features/hermes-removal/spec.md
+++ b/.specs/features/hermes-removal/spec.md
@@ -1,7 +1,8 @@
 # hermes-agent Removal Specification
 
-**Status:** Specified — NOT approved for execution. This document maps the work; it does not
-authorize it. Nothing has been removed.
+**Status:** **Approved for execution.** OD-1 resolved as **Option A**. See
+§Execution Decisions and §Baseline Refresh — the original mapping below is kept verbatim as the
+historical record, and every line number in it is superseded by the refresh.
 
 **Decision this encodes:** Hermes (Nous Research `hermes-agent`) is withdrawn from the project for
 **compatibility with the current infrastructure**, and demoted to a **future implementation**. The
@@ -25,6 +26,68 @@ number here as indicative: re-run the greps in §Verification before editing any
 **Where the implementation lives, for recovery:** `crab-shell-proxy` commits `d2f0a9a`
 (multi-harness support + Hermes), `748e0fe` (gate hermes agents on their secrets), `3e9e95c`
 (model administration rejects non-picoclaw agents).
+
+---
+
+## Execution Decisions
+
+Taken at the start of the execution session, after re-deriving the baseline. These close OD-1 and
+the two questions the spec could not anticipate.
+
+| # | Decision | Rationale |
+|---|---|---|
+| **ED-1** | **OD-1 = Option A.** The Hermes profile goes; the generic harness seam stays dormant with `picoclaw` as its only legal value. | `chat-progress-events` built `turn.Sink` on that seam and it is in-tree; the `harness` field is a live admin-API contract the webapp reads; Option B would delete the three model-scope rejection tests along with the gate they cover (a coverage loss, not a simplification) and would edit live registry-import code (`migrate_models.go` reads `mc.BaseURL` into `APIBase`) for no behavioural gain. |
+| **ED-2** | **Dead guards are deleted, not left returning `true`.** `projectsSupported`, `userModelsSupported` and the `Harness != HarnessHermes` term in the persona/project bind-drift case all go, with their call sites collapsed. | With Hermes gone all three are constant-true. Keeping a trivially-true predicate is exactly the speculative scaffolding the project's coding rules forbid. The two `501 Not Implemented` responses they guarded become unreachable and are removed with them. |
+| **ED-3** | **Branch off `main`, three PRs.** `chore/hermes-removal` in root, proxy and webapp, each based on `origin/main`. | All three repos had `feat/user-owned-models` **already merged into `origin/main`** at the start of this session, so branching off `main` is conflict-free *and* still contains the drifted surface (`projects.go`, `user_models.go`). The stacked-PR downside the question weighed does not materialise. |
+| **ED-4** | The webapp's `projects_unsupported` / 501 client handling is **kept**. | ED-2 removes the server-side 501, but a deployed older proxy still returns it. This is the same back-compat argument that preserves the absent-`harness` case (P2 AC-2). Annotated, not deleted. |
+
+## Baseline Refresh
+
+Re-derived at execution time. **The original §Baseline is stale — use this table.**
+
+| Repo | Revision | Working tree |
+|---|---|---|
+| `zombie-crab-project` (root) | `chore/hermes-removal` off `origin/main` = `5190f25` | clean |
+| `crab/crab-shell-proxy` | `chore/hermes-removal` off `origin/main` = `3250b32` | clean |
+| `crab/crab-exoskeleton-webapp` | `chore/hermes-removal` off `origin/main` = `86f1f65` | clean |
+
+### What the drift changed
+
+1. **TRAP-3 has dissolved.** The webapp tree is clean; there is no in-flight work to collide with.
+   P2 stays P2 by priority (nothing in it is *wrong* after P1) but it is no longer *blocked*, so it
+   ships in this same cut.
+2. **There is a THIRD mycelium TOML.** `deploy/dokploy/config.base.toml`, plus
+   `deploy/dokploy/.env.example`. HRM-28/29 covered only `prod` and `standalone`. Dokploy already
+   ships without a `[[hermes-glm]]` service block but carries Hermes *commentary* and dead-var
+   notes. → HRM-52.
+3. **HRM-24 is already satisfied.** The proxy's `config.yaml` declares only `alpha` and `beta`; the
+   `hermes-glm` agent block is gone from it already. Nothing to cut.
+4. **Two NEW live runtime gates appeared** — code, not comments: `internal/httpapi/projects.go:66,85,226,258`
+   and `internal/httpapi/user_models.go:47-51,63`. → HRM-53, HRM-54 (resolved per ED-2).
+5. **A new Hermes exclusion in the recreate path**: `internal/docker/manager.go:307-315`, the
+   persona/project bind-drift case. → HRM-55 (resolved per ED-2).
+6. **The `hermes` references in the two live TOMLs multiplied** well beyond the single service block
+   HRM-28/29 describe — `config.standalone.toml` also at 7, 122, 136, 230-231, 311-312, 460-461,
+   531-532, and `deploy/prod/config.base.toml` similarly. → folded into HRM-28/29.
+7. **`docker-compose.dokploy.yaml` grew a Hermes comment block** at 87-89 on top of the HRM-32 line.
+8. **Far more spec docs mention Hermes than HRM-47 lists.** → HRM-56 sets one uniform policy.
+9. **New minor comment sites**: `internal/docker/provision.go:51`, `internal/docker/persona_test.go:321`,
+   `internal/httpapi/handlers.go:232`, `lib/projects.ts:60`, `app/api/projects/route.ts:10`,
+   `app/chat/use-projects.ts:58`, `app/chat/projects-bar.tsx:76`. → HRM-57.
+
+### Pre-existing gate failures — measured, not assumed
+
+Captured **before** any edit, so the after-state is comparable. Both are pre-existing and unrelated
+to Hermes; neither may be treated as caused by this change, and neither may be used to excuse a new
+failure.
+
+| Gate | Baseline result |
+|---|---|
+| proxy `go build ./...` | clean |
+| proxy `go vet ./...` | clean |
+| proxy `go test ./...` | **`internal/docker` FAILS**: 9 tests, all `lchown … operation not permitted` (sandbox cannot chown). Every other package passes. |
+| webapp `vitest run` | **green — 56 files, 776 tests** |
+| webapp `tsc --noEmit` | **6 pre-existing errors**, all in test files, all about `project` / `sessionKey` optionality: `app/chat/{canvas-activity,conversation-bursts,conversation-filter,history-cache}.test.ts`, `app/chat/scheduled-tasks.test.tsx`. The spec's "tsc clean" gate is **not achievable** at baseline; the real gate is "still exactly these 6". |
 
 ---
 
@@ -68,7 +131,13 @@ and every future change pays that tax.
 
 ---
 
-## OD-1: Open Decision — how deep does the removal cut? ⚠️ BLOCKS EXECUTION
+## OD-1: ✅ RESOLVED — Option A (see ED-1)
+
+*The fork below is kept for the reasoning it records. It no longer blocks anything.
+Requirements marked `[OD-1:B]` are **out of scope** and stay unimplemented: HRM-23, the field
+removals in HRM-21/22, and the deletions in HRM-26/27.*
+
+### OD-1: Open Decision — how deep does the removal cut? ~~⚠️ BLOCKS EXECUTION~~
 
 The **Hermes profile** goes either way. What is undecided is the **generic harness seam** underneath
 it. This is the only real fork, and it must be answered before task breakdown.
@@ -136,6 +205,12 @@ structs in-memory, bypassing `Load` validation, so an arbitrary value works.
 
 **TRAP-6 — `deploy/standalone/.env` holds a real z.ai key.** Gitignored via `deploy/**/.env`
 (`.gitignore:5`), confirmed by `git check-ignore`. Never commit it, never echo its contents.
+
+**TRAP-7 — `"hermes-glm"` as a pure string fixture.** `components/ui/avatar.tsx:62` and
+`components/ui/avatar.initials.test.ts:9` use the literal `"hermes-glm"` only as a sample identifier
+for initials extraction (it reads as `HG`). It has nothing to do with the harness, and the test
+asserts on the string, so rewriting it would change a passing test for no reason. **Untouched, and
+an explicit grep survivor.** Found during execution, after the original mapping.
 
 ---
 
@@ -335,6 +410,20 @@ I can decide what to clean up by hand.
 | HRM-50 | a pulled `nousresearch/hermes-agent` image | Yes; **not present locally** at baseline |
 | HRM-51 | a running Hermes container | **None exist** at baseline (only `crabshell-alpha-…` on `sipeed/picoclaw:latest`) |
 
+### H. Drift — surface that appeared after the original mapping
+
+Added at execution time. Every ID here is new; none is `[OD-1:B]`.
+
+| ID | Location | What |
+|---|---|---|
+| HRM-52 | `deploy/dokploy/config.base.toml:15-18,159,206-207,273-274,412-413,479-480`, `deploy/dokploy/.env.example:36-37`, `deploy/dokploy/crab-shell-proxy.config.yaml` | **the third TOML.** It has no `[[hermes-glm]]` block to cut, but its header explains hermes' *absence* relative to an upstream default that will no longer have one, and its per-feature notes justify themselves against the hermes harness. Reword so each note stands on its own. Supersedes HRM-33 for the `crab-shell-proxy.config.yaml` part. |
+| HRM-53 | `internal/httpapi/projects.go:66,77-87,226,258` | delete `projectsSupported` and its three call sites; the `501 projects_unsupported` becomes unreachable and goes with it (ED-2). Keep the 404-on-unknown-project misroute guard the doc comment mentions — that is a different mechanism and still live. |
+| HRM-54 | `internal/httpapi/user_models.go:46-51,63-67` | delete `userModelsSupported`, its call site, and its `501` (ED-2). |
+| HRM-55 | `internal/docker/manager.go:305-317` | drop the `agent.Harness != config.HarnessHermes &&` term from the persona/project bind-drift recreate case and the paragraph explaining it (ED-2). **The drift check itself must keep firing for picoclaw** — this is the one place it belongs, and removing it would strand admin persona saves. |
+| HRM-56 | proxy `.specs/features/{restart-control/design.md,persona-injection/*.md,memory-graph-mcp/{spec,progress}.md,admin-bulk-instance-config/spec.md,model-registry-source-of-truth/spec.md,chat-progress-events/spec.md}`, webapp `.specs/features/{persona-injection-admin/spec.md,agent-first-admin/{spec,design,tasks}.md,admin-bulk-instance-config/{spec,tasks}.md,chat-responsiveness/{design,tasks}.md}`, root `.specs/features/**` | **uniform policy, superseding HRM-47's narrower list: shipped feature specs are NOT rewritten.** They are accurate records of what was true when they shipped. They become grep survivors, and the withdrawal banner (HRM-42/43) plus DECISION.md (HRM-40) are what a reader finds. Only `.specs/project/{ROADMAP,STATE}.md` — the *living* docs — are edited (HRM-44/45/46). |
+| HRM-57 | `internal/docker/provision.go:51`, `internal/docker/persona_test.go:321`, `internal/httpapi/handlers.go:232`, webapp `lib/projects.ts:60`, `app/api/projects/route.ts:10`, `app/chat/use-projects.ts:58`, `app/chat/projects-bar.tsx:76`, `lib/tools.ts:2` | residual comments naming hermes or "a harness with no projects". Proxy side: reword to state the picoclaw fact directly. Webapp side: keep the back-compat behaviour (ED-4) and reword the comments to say *why* it is back-compat rather than naming hermes. |
+| **HRM-58** | root `README.md`, `README.pt-br.md`, `docs/ADMIN_GUIDE{,.pt-br}.md`, `docs/CREATE_CUSTOM_AGENT{,.pt-br}.md` | **USER-FACING DOCS — the gap the whole mapping missed, and the only requirement here that is a correctness bug rather than tidying.** These are shipped operator documentation, so HRM-56's "shipped specs are not rewritten" policy does **not** cover them: unlike a spec, a README is read as instructions for the code as it is now. They told an operator to set `MYC_HERMES_GLM_TOKEN` / `PROXY_GLM_API_KEY` (variables nothing reads any more), advertised three agents when the stack ships two, listed `hermes-glm` in the deploy-mode comparison and the guest-role lists, and — worst — `CREATE_CUSTOM_AGENT.md` documented **`harness: hermes` as a valid choice**, which after HRM-12 makes the proxy refuse to boot. Both locales. Rewritten to describe picoclaw-only, with `harness` documented as omit-it and any other value called out as a deliberate hard failure. |
+
 ---
 
 ## Edge Cases
@@ -368,29 +457,61 @@ grep -rn "hermes\|Hermes\|Harness\|harness" --exclude-dir=.git --exclude-dir=.cl
 grep -rn -i "hermes" --exclude-dir=.git --exclude-dir=data .
 ```
 
-Gates:
+Gates — **measured against the §Baseline Refresh figures, not against "green"**:
 
 | Repo | Command | Expected |
 |---|---|---|
-| proxy | `go build ./... && go vet ./... && go test ./...` | green, **except** the pre-existing `internal/docker` chown failures caused by a sandbox permission limit. Confirm they are the *same* failures as before the change (`git stash -u` comparison) — they must not mask a real one. |
-| webapp | `next build`, `tsc --noEmit`, `vitest run` | green |
+| proxy | `go build ./... && go vet ./...` | clean |
+| proxy | `go test ./...` | every package passes **except** `internal/docker`, which must fail with **exactly the same 9 `lchown … operation not permitted` tests as the captured baseline** — no more, no fewer, no different names |
+| webapp | `vitest run` | **56 files / 776 tests**, minus only the assertions HRM-37/38 deliberately remove |
+| webapp | `tsc --noEmit` | **exactly the same 6 pre-existing errors** listed in §Baseline Refresh |
+| webapp | `next build` | succeeds |
 | stack | boot compose, sign in, chat with `alpha` through the gateway | reply lands; no container recreated |
-| both | `grep -ri hermes` | survivors are only spec/doc files, the two `zero-scale-stateless-hermes-agent.md` pattern refs, and the webapp until P2 lands |
+| both | `grep -ri hermes` | matches the survivor list below, exactly |
+
+### The grep survivor list — pass/fail, not judgement
+
+After the change, `grep -ri hermes` across both repos SHALL return hits **only** in:
+
+1. `.specs/features/hermes-removal/**` — this spec, `tasks.md`, `DECISION.md`. The record itself.
+2. `.specs/features/multi-harness-support/**` (root and proxy) — the future-implementation record,
+   now banner-headed, plus `implementation-notes.md`.
+3. **Any other `.specs/features/**` file** — shipped feature specs, per HRM-56's not-rewritten
+   policy.
+4. `.specs/project/{ROADMAP,STATE}.md` (root and proxy) — where the deferral and the decision are
+   *supposed* to be named.
+5. The two `zero-scale-stateless-hermes-agent.md` pattern references (TRAP-1) — **picoclaw's**
+   architecture, not the Nous product.
+6. `components/ui/avatar.tsx` and `components/ui/avatar.initials.test.ts` (TRAP-7) — a string
+   fixture.
+7. Landing-page copy using the word *harness* (TRAP-2) — which `grep -i hermes` does not match
+   anyway, but is listed so the distinction stays explicit.
+8. `docs/CREATE_CUSTOM_AGENT{,.pt-br}.md` — a **cross-reference** to
+   `.specs/features/hermes-removal/DECISION.md`, pointing a reader who wonders why `harness` takes
+   only one value at the answer. Deliberate (HRM-58).
+9. `internal/config/config_test.go` — `TestUnknownHarnessIsRejected` **deliberately** names
+   `harness: hermes` as the stale value `Load` must refuse, and asserts the error echoes it. This is
+   the executable form of the spec's first Edge Case; the string is the test's subject, not a
+   leftover. **The only legitimate `hermes` hit in Go code.**
+
+**Any hit in a `.go`, `.ts`, `.tsx`, `.toml`, `.yaml` or `.env.example` file outside that list is a
+failure.**
 
 ---
 
 ## Sequencing
 
-Three repos, three PRs. The root pointer bump depends on the proxy merge.
+Three repos, three PRs, all on `chore/hermes-removal` off each repo's `origin/main` (ED-3). The root
+pointer bump depends on the proxy and webapp merges.
 
-1. **Proxy PR** — HRM-01..27, HRM-41, HRM-43, HRM-46. Self-contained and independently verifiable.
-2. **Root PR** — HRM-28..34, HRM-40, HRM-42, HRM-44, HRM-45, HRM-47. Either omit the submodule
-   pointer bump or state plainly that it targets an unmerged proxy branch.
-3. **Webapp PR (P2)** — HRM-35..39, branched off the webapp's committed HEAD at that time, after the
-   in-flight work has landed.
+1. **Proxy PR** — HRM-01..27, HRM-41, HRM-43, HRM-46, HRM-53, HRM-54, HRM-55, HRM-57 (proxy half).
+   Self-contained and independently verifiable.
+2. **Webapp PR** — HRM-35..39, HRM-57 (webapp half). Independent of the proxy under Option A: the
+   `harness` API field survives, so nothing here is contract-coupled.
+3. **Root PR** — HRM-28..34, HRM-40, HRM-42, HRM-44, HRM-45, HRM-52, **HRM-58**, plus the refreshed
+   spec and `tasks.md`. State plainly if the submodule pointer bump targets unmerged branches.
 
-Under `[OD-1:B]`, steps 1 and 3 become one coordinated change: the admin API contract breaks, so the
-webapp cannot lag.
+~~Under `[OD-1:B]`, steps 1 and 3 become one coordinated change.~~ Not applicable — ED-1 chose A.
 
 ---
 
@@ -405,15 +526,19 @@ webapp cannot lag.
 | HRM-35..39 | webapp | P2 | Tasks | Pending |
 | HRM-40..47 | documentation + preservation | P1 knowledge | Tasks | Pending |
 | HRM-48..51 | operational residue | P3 | Tasks | Pending |
+| HRM-52..58 | drift (§H) | P1 / P2 | Tasks | Pending |
 
-**Coverage:** 51 requirements, 0 mapped to tasks (no `tasks.md` yet), 0 verified.
-**Blocked on:** OD-1. HRM-22, HRM-23, HRM-26, HRM-27 and the P2 priority all change shape with it.
+**Coverage:** 58 requirements. Under ED-1 (Option A), **HRM-23 is out of scope entirely**, and
+HRM-21/22/26/27 apply in their comment-only form. See `tasks.md` for the ID→task map.
+**Blocked on:** nothing. OD-1 resolved (ED-1).
 
 ---
 
 ## Success Criteria
 
-- [ ] `go build`/`go vet`/`go test` green in the proxy (chown failures confirmed pre-existing).
+- [ ] `go build`/`go vet` clean; `go test ./...` fails **only** the 9 baseline chown tests, verified
+      name-for-name against the captured baseline.
+- [ ] `vitest run` green; `tsc --noEmit` shows **exactly** the 6 baseline errors.
 - [ ] A signed-in user chats with `alpha` through the gateway; no picoclaw container was recreated.
 - [ ] A stale `harness: hermes` config is refused at startup with a clear error.
 - [ ] `grep -ri hermes` across both repos returns only the documented survivors.

--- a/.specs/features/hermes-removal/tasks.md
+++ b/.specs/features/hermes-removal/tasks.md
@@ -1,0 +1,346 @@
+# hermes-agent Removal — Tasks
+
+Derived from `spec.md` under **ED-1 (OD-1 Option A)**, **ED-2 (delete dead guards)** and
+**ED-3 (branch off `main`, three PRs)**.
+
+`[P]` marks tasks that can run in parallel with their siblings. Everything else is sequential within
+its phase. Phases are ordered by PR: **P → W → R**, but P and W are genuinely independent under
+Option A (the `harness` admin-API field survives, so no contract couples them).
+
+**Gate for every task:** the commands in `spec.md` §Verification, compared against the
+§Baseline Refresh figures — *not* against "green". The proxy's `internal/docker` package fails 9
+chown tests at baseline and must keep failing exactly those; the webapp has 6 pre-existing `tsc`
+errors and must keep exactly those.
+
+---
+
+## Phase P — Proxy (`crab/crab-shell-proxy`, branch `chore/hermes-removal`)
+
+### P1 — Delete the Hermes-only files
+
+- **What:** remove the five files that exist only to serve the Hermes profile.
+- **Where:** `internal/hermes/turn.go`, `internal/hermes/turn_test.go`,
+  `internal/docker/provision_hermes.go`, `internal/docker/defaulttemplate/hermes/config.yaml`,
+  `internal/docker/defaulttemplate/hermes/SOUL.md` (and the now-empty `internal/hermes/` and
+  `internal/docker/defaulttemplate/hermes/` dirs).
+- **Depends on:** nothing.
+- **Done when:** the files are gone. `go build ./...` **will fail** here — P2 and P3 fix it. Do not
+  chase the build green inside this task.
+- **Covers:** HRM-01..05.
+
+### P2 — Unwire Hermes from `config`
+
+- **What:** delete `HarnessHermes`, `Config.HermesImage` + its default, `ModelConfig.KeyEnvName`,
+  the two secret-gating branches, `Config.DisabledAgents`, and tighten harness validation to
+  `{"", picoclaw}` with an error naming only the accepted value. Keep `Agent.Harness` and the
+  `"" → picoclaw` defaulting (P1 story AC-3). Reword every doc comment that frames a field as
+  picoclaw-vs-hermes to state the picoclaw fact directly.
+- **Where:** `internal/config/config.go` — the constant block, `ModelConfig`, `Agent.Harness` /
+  `StartupDeadline` docs, `Config.HermesImage`, `Config.DisabledAgents`, `Load`'s two
+  `Harness == HarnessHermes` branches, `applyDefaults`' `HermesImage` default, `validate`'s harness
+  switch.
+- **Depends on:** nothing (parallel with P1 in principle; sequenced here so the build breaks once).
+- **Reuses:** the existing `validate` error style — `fmt.Errorf("agent %q: …", key, …)`.
+- **Done when:** `Load` rejects `harness: hermes` naming `picoclaw`; an omitted `harness` still
+  defaults to picoclaw; no `HermesImage`/`KeyEnvName`/`DisabledAgents` identifier remains.
+- **Tests:** P7.
+- **Covers:** HRM-08..13, HRM-04 (the `KeyEnvName` consumer dies with P1).
+
+### P3 — Collapse the harness branches in `docker` and `httpapi`
+
+- **What:** remove every `Harness == HarnessHermes` branch and the Hermes turner plumbing, letting
+  each site collapse to its picoclaw form.
+  - `manager.go`: drop `hermesAPIPort`; `harnessPort` returns `PicoclawPort`; `endpoint` returns the
+    `ws://…/pico/ws` form; `EnsureRunning`'s `provisionHermes`/`createHermes` branches go; reword
+    the `Target` docs.
+  - `handlers.go`: drop the `Hermes Turner` field, `turnerFor`, and `turnModelFor`'s Hermes branch.
+  - `handlers.go:668` and `sse.go:106`: `s.turnerFor(tgt.Harness)` → `s.Pico`.
+  - `main.go`: drop the `internal/hermes` import, the `Hermes:` field, and the `DisabledAgents`
+    startup log (dead per TRAP-4).
+- **Where:** `internal/docker/manager.go`, `internal/httpapi/handlers.go`, `internal/httpapi/sse.go`,
+  `cmd/crab-shell-proxy/main.go`.
+- **Depends on:** P1, P2.
+- **Done when:** `go build ./... && go vet ./...` **clean**. `grep -ri hermes` over `*.go` returns
+  nothing outside the tests P7 rewrites.
+- **Covers:** HRM-06, HRM-07, HRM-14..18, HRM-21 (comment-only), HRM-22 (comment-only).
+
+### P4 — Delete the dead guards (ED-2)
+
+- **What:** `projectsSupported`, `userModelsSupported` and the `Harness != HarnessHermes` term in the
+  bind-drift recreate case are all constant-true once Hermes is gone. Delete the two helpers, their
+  four call sites, and the two now-unreachable `501` responses. Drop the term from the `case` in
+  `manager.go`.
+- **Where:** `internal/httpapi/projects.go:66,77-87,226,258`, `internal/httpapi/user_models.go:46-51,63-67`,
+  `internal/docker/manager.go:305-317`.
+- **Depends on:** P2 (`HarnessHermes` must already be gone).
+- **Done when:** no `…Supported(agent)` predicate remains; **the persona/project bind-drift check
+  still fires for picoclaw** — this is load-bearing, an admin persona save cannot reach an existing
+  container without it; the 404-on-unknown-project guard is untouched.
+- **Tests:** existing `internal/httpapi` and `internal/docker` suites must not regress beyond
+  baseline.
+- **Covers:** HRM-53, HRM-54, HRM-55.
+
+### P5 — Reword the residual proxy comments
+
+- **What:** comments that only make sense with two harnesses.
+- **Where:** `internal/docker/provision.go:51`, `internal/docker/migrate_models.go:63,139`,
+  `internal/docker/persona_test.go:321`, `internal/httpapi/admin.go:108-112`,
+  `internal/httpapi/admin_model_scopes.go:41,61`, `internal/turn/turn.go` package + field docs.
+- **Depends on:** P3.
+- **Done when:** each comment states the picoclaw fact on its own terms. **`migrate_models.go:139`'s
+  anti-orphaning rationale survives the edit** — enumerating workspaces from disk rather than from
+  `cfg.Agents` is still the correct behaviour and an Edge Case depends on it. The
+  `admin_model_scopes` gate itself is **kept** (Option A) with its comment corrected to say the
+  inventory governs picoclaw, which is now every agent.
+- **Covers:** HRM-19, HRM-20, HRM-22, HRM-57 (proxy half).
+
+### P6 — `config.yaml`
+
+- **What:** confirm no `hermes-glm` agent block remains, and that no `hermesImage`/`keyEnvName` key
+  is referenced.
+- **Where:** `config.yaml`.
+- **Depends on:** P2.
+- **Done when:** verified. **Expected to be a no-op** — the block is already absent at this baseline
+  (spec §Baseline Refresh item 3). Record that in the commit body rather than inventing a change.
+- **Covers:** HRM-24.
+
+### P7 — Tests
+
+- **What:**
+  - `internal/config/config_test.go`: delete `hermesSample`, `TestHermesDisabledWhenSecretsMissing`,
+    `TestHermesEnabledWhenSecretsPresent`. **Add** a case pinning HRM-12: an unknown harness value is
+    rejected by `Load`, and an omitted one still defaults to picoclaw.
+  - `internal/httpapi/admin_model_scopes_test.go`: rewrite the `hermesService` fixture to a
+    **synthetic** non-picoclaw harness value (the fixtures build `config.Agent` in memory, bypassing
+    `Load`, so an arbitrary string works). **Keep all three rejection tests and
+    `TestAdminAgentsReportsTheHarness`** — the gate still exists under Option A (TRAP-5).
+  - `internal/docker/migrate_models_test.go:225`: comment only.
+  - `internal/httpapi/sse_progress_test.go`: `Harness:` fixture value stays (`[OD-1:B]` only).
+- **Depends on:** P2, P3, P4, P5.
+- **Done when:** `go test ./...` — every package passes except `internal/docker`, which fails
+  **exactly** the 9 baseline chown tests. Diff the failing test names against the captured baseline;
+  a 10th failure is a real regression, not a sandbox artefact.
+- **Covers:** HRM-25, HRM-26, HRM-27.
+
+### P8 [P] — `implementation-notes.md`: the runtime findings
+
+- **What:** new file recording what git cannot hand back — the knowledge earned in the live E2E.
+  Must cover, at minimum: the `Cmd: ["gateway","run"]` requirement and what happens without it; the
+  180s startup deadline versus the 35s global health-wait; `GATEWAY_ALLOW_ALL_USERS=true` and why it
+  is safe per-user; `model.base_url` being required for OpenAI-compatible providers; the
+  provider-specific in-container key env name (`GLM_API_KEY` for provider `zai`) not being derivable
+  from the provider; the absence of any API-only mode; the `state.db` session/message schema; and the
+  unresolved turn-latency problem against the gateway's 60s timeout.
+- **Where:** `.specs/features/multi-harness-support/implementation-notes.md` (proxy).
+- **Depends on:** nothing.
+- **Done when:** a reader can answer "what will bite me if I re-add this?" from the file alone.
+- **Covers:** HRM-41. **This is the highest-value task in the whole change** — P1 story 2.
+
+### P9 [P] — Proxy docs
+
+- **What:** withdrawal banner on `.specs/features/multi-harness-support/{design,tasks}.md`;
+  the deferral + decision entries in the proxy's own `.specs/project/{ROADMAP,STATE}.md`.
+- **Where:** as listed.
+- **Depends on:** nothing.
+- **Done when:** the banner states implemented → verified live → withdrawn, the reason
+  ("current infra compatibility"), the recovery SHAs `d2f0a9a`/`748e0fe`/`3e9e95c`, and links
+  `implementation-notes.md` and root `DECISION.md`. **Shipped feature specs are not rewritten**
+  (HRM-56).
+- **Covers:** HRM-43, HRM-46.
+
+### P10 — Commit and PR
+
+- **What:** commit Phase P, open the proxy PR.
+- **Depends on:** P1..P9.
+- **Done when:** gates recorded in the PR body, including the baseline comparison for the chown
+  failures.
+
+---
+
+## Phase W — Webapp (`crab/crab-exoskeleton-webapp`, branch `chore/hermes-removal`)
+
+Independent of Phase P under Option A.
+
+### W1 — `lib/admin.ts` and `app/admin/agent-scope.ts`
+
+- **What:** reword the `Agent.harness` field doc and the `picoclawAgentKeys` rationale, and the four
+  `agent-scope.ts` comments. **The filter itself stays** — it still correctly passes every agent, and
+  the absent-`harness` case is live back-compat for an older proxy.
+- **Where:** `lib/admin.ts:38-49`, `app/admin/agent-scope.ts:24,28,33,66`.
+- **Depends on:** nothing.
+- **Done when:** no comment names hermes; the back-compat reason is stated as *version* skew, not
+  harness variety.
+- **Covers:** HRM-35, HRM-36.
+
+### W2 — Webapp tests
+
+- **What:** drop the `{ key: "hermes-glm", harness: "hermes" }` and `{ key: "nous", harness: "hermes" }`
+  fixtures and the assertions that only make sense with a second harness. **Keep** the
+  "absent harness counts as picoclaw" cases in both files — an older proxy reports no harness at all.
+- **Where:** `app/admin/agent-scope.test.ts:6-104`, `lib/admin.test.ts:68-79`.
+- **Depends on:** W1.
+- **Done when:** `vitest run` green. **`components/ui/avatar.initials.test.ts:9` is untouched**
+  (TRAP-7 — a string fixture, not a harness).
+- **Covers:** HRM-37, HRM-38.
+
+### W3 — The harness badge
+
+- **What:** `app/admin/agent-gate.tsx:69` renders `{agent.harness && <Badge>{agent.harness}</Badge>}`.
+  Every agent now reports `picoclaw`, so it renders a constant badge on every agent — noise, not
+  information. Remove it. Reword the two comments.
+- **Where:** `app/admin/agent-gate.tsx:69`, `app/admin/admin-screen.tsx:271`, `lib/tools.ts:2`.
+- **Depends on:** W1.
+- **Done when:** the badge is gone; `lib/tools.ts`'s example identifier no longer uses `hermes-glm`.
+- **Covers:** HRM-39.
+
+### W4 — `projects_unsupported` back-compat (ED-4)
+
+- **What:** the proxy's 501 disappears in P4, but a deployed older proxy still returns it. **Keep the
+  handling**; reword the comments to say it is version back-compat rather than naming a harness.
+- **Where:** `lib/projects.ts:60`, `app/api/projects/route.ts:10`, `app/chat/use-projects.ts:58`,
+  `app/chat/projects-bar.tsx:76`.
+- **Depends on:** nothing.
+- **Done when:** behaviour unchanged, comments no longer imply a second harness exists.
+- **Covers:** HRM-57 (webapp half), ED-4.
+
+### W5 — Gates and PR
+
+- **What:** `vitest run`, `tsc --noEmit`, `next build`; confirm the landing page is untouched in en
+  and pt-BR (TRAP-2); commit and open the PR.
+- **Depends on:** W1..W4.
+- **Done when:** vitest green minus only the deliberately-removed assertions; `tsc` shows **exactly**
+  the 6 baseline errors; `git diff --stat` touches **no** file under `lib/i18n/landing.ts`,
+  `components/landing/`, or `landing.module.css`.
+- **Covers:** P2 AC-3.
+
+---
+
+## Phase R — Root (`zombie-crab-project`, branch `chore/hermes-removal`)
+
+### R1 — The two live mycelium TOMLs
+
+- **What:** delete the `[[hermes-glm]]` service block (services, secret, every path) from both, and
+  reword the surrounding commentary that enumerates agents or justifies a per-feature omission
+  against the hermes harness.
+- **Where:** `deploy/prod/config.base.toml`, `deploy/standalone/config.standalone.toml` — the service
+  block **and** the comment sites at 7, 122, 136, 230-231, 311-312, 460-461, 531-532 (standalone;
+  prod similarly — re-derive, do not trust these numbers).
+- **Depends on:** nothing.
+- **Done when:** no `hermes` string survives in either file, and **the `alpha` and `beta` service
+  definitions are byte-identical to before** (`git diff` shows changes only in the removed block and
+  the reworded comments). P1 AC-4.
+- **Covers:** HRM-28, HRM-29.
+
+### R2 — The third TOML and dokploy
+
+- **What:** `deploy/dokploy/config.base.toml` has no block to cut, but its header explains hermes'
+  *absence* relative to an upstream default that will no longer have one, and its per-feature notes
+  justify themselves against the hermes harness. Same for `.env.example:36-37` and
+  `crab-shell-proxy.config.yaml` — whose header also claims a hermes agent auto-disables without its
+  secrets, which P2 makes **false**.
+- **Where:** `deploy/dokploy/config.base.toml:15-18,159,206-207,273-274,412-413,479-480`,
+  `deploy/dokploy/.env.example:36-37`, `deploy/dokploy/crab-shell-proxy.config.yaml:4-10`.
+- **Depends on:** nothing.
+- **Done when:** every note stands on its own without referencing a second harness, and no false
+  auto-disable claim remains.
+- **Covers:** HRM-52, HRM-33.
+
+### R3 — Compose and env examples
+
+- **What:** drop the `MYC_HERMES_GLM_TOKEN` / `PROXY_GLM_API_KEY` passthroughs and their comments;
+  reword the dokploy compose comment that cites "drop hermes-glm" as the example customization.
+- **Where:** `docker-compose.yaml:108-110,116-118`, `docker-compose.dokploy.yaml:87-89,150`,
+  `deploy/standalone/.env.example:29,34-35`.
+- **Depends on:** nothing.
+- **Done when:** no hermes var or comment remains in any committed compose or example file.
+- **Covers:** HRM-30, HRM-31, HRM-32.
+
+### R3b — User-facing documentation (HRM-58)
+
+- **What:** the gap the original mapping missed entirely, and the only part of Phase R that fixes a
+  **correctness bug** rather than tidying prose. Six shipped operator docs described the stack as
+  shipping three agents, told the reader to set `MYC_HERMES_GLM_TOKEN` / `PROXY_GLM_API_KEY`, listed
+  `hermes-glm` among the guest-roles and in the deploy-mode comparison, and — worst —
+  `CREATE_CUSTOM_AGENT.md` documented **`harness: hermes` as a valid choice**, which after P2 makes
+  the proxy refuse to boot.
+- **Where:** `README.md`, `README.pt-br.md`, `docs/ADMIN_GUIDE{,.pt-br}.md`,
+  `docs/CREATE_CUSTOM_AGENT{,.pt-br}.md`.
+- **Depends on:** P2 (the validation change is what makes the old text wrong).
+- **Done when:** both locales describe picoclaw-only; `harness` is documented as *omit it*, with any
+  other value called out as a deliberate hard failure and cross-linked to `DECISION.md`. **HRM-56's
+  "shipped specs are not rewritten" policy does NOT apply here** — a README is read as instructions
+  for the code as it is now, not as a record of what was once true.
+- **Covers:** HRM-58.
+
+### R4 — `DECISION.md`
+
+- **What:** the record a future reader hits first.
+- **Where:** `.specs/features/hermes-removal/DECISION.md` (new).
+- **Depends on:** nothing.
+- **Done when:** it states the reason (current-infra compatibility), what was withdrawn, the recovery
+  SHAs `d2f0a9a`/`748e0fe`/`3e9e95c`, **the OD-1 choice actually made and why** (ED-1), **ED-2's
+  deletion of the dead guards** so it is not re-litigated, the `DisabledAgents` behaviour worth
+  restoring on a re-add (TRAP-4), and the HRM-48..51 residue list with harmless-if-ignored marked per
+  item.
+- **Covers:** HRM-40, HRM-48..51, P3 story.
+
+### R5 [P] — Root docs
+
+- **What:** withdrawal banner on `.specs/features/multi-harness-support/{spec,investigation.md}`;
+  `STATE.md` decision entry **and** the correction at `STATE.md:57-60` — the "Hermes still reads it"
+  claim is now false, but **the caveat it documents must survive**: `config.yaml`'s `agent.Model` is
+  a migration seed with no runtime effect, which is now unconditionally true. `ROADMAP.md`: mark
+  multi-harness deferred, **line 97 untouched** (TRAP-1).
+- **Where:** as listed.
+- **Depends on:** R4 (to cross-link).
+- **Done when:** the three TRAP-1 sites have each been judged individually — the two
+  `zero-scale-stateless-hermes-agent.md` references are **picoclaw's** architecture and stay.
+- **Covers:** HRM-42, HRM-44, HRM-45.
+
+### R6 — Spec bookkeeping
+
+- **What:** commit the refreshed `spec.md` and this `tasks.md`; fill the traceability statuses.
+- **Depends on:** all of P, W, R.
+- **Covers:** HRM-56 (the not-rewritten policy is recorded, not executed).
+
+### R7 — Final verification
+
+- **What:** run the full §Verification gate set; run the survivor-list grep and check it **line by
+  line** against spec.md's seven-item list; boot the stack and chat with `alpha`.
+- **Depends on:** everything.
+- **Done when:** every Success Criterion is ticked with evidence, or explicitly reported as not run.
+- **Note:** the live stack boot needs compose up and a signed-in session. If it cannot be run in this
+  environment, say so plainly rather than inferring the result from the unit tests.
+
+### R8 — Local hygiene (operator, optional)
+
+- **What:** remove the dead `MYC_HERMES_GLM_TOKEN` / `PROXY_GLM_API_KEY` vars from
+  `deploy/standalone/.env`.
+- **Depends on:** R3.
+- **Note:** **TRAP-6 — that file is gitignored and holds a real z.ai key. Never commit it, never
+  echo its contents.** Operator-owned; may be skipped.
+- **Covers:** HRM-34.
+
+---
+
+## ID → Task Map
+
+| ID | Task | ID | Task |
+|---|---|---|---|
+| HRM-01..05 | P1 | HRM-30..32 | R3 |
+| HRM-06,07 | P3 | HRM-33 | R2 |
+| HRM-08..13 | P2 | HRM-34 | R8 |
+| HRM-14..18 | P3 | HRM-35,36 | W1 |
+| HRM-19,20 | P5 | HRM-37,38 | W2 |
+| HRM-21,22 | P3, P5 | HRM-39 | W3 |
+| HRM-23 | — *out of scope, `[OD-1:B]`* | HRM-40 | R4 |
+| HRM-24 | P6 *(expected no-op)* | HRM-41 | P8 |
+| HRM-25..27 | P7 | HRM-42 | R5 |
+| HRM-28,29 | R1 | HRM-43 | P9 |
+| HRM-44,45 | R5 | HRM-52 | R2 |
+| HRM-46 | P9 | HRM-53,54,55 | P4 |
+| HRM-47 | superseded by HRM-56 | HRM-56 | R6 |
+| HRM-48..51 | R4 | **HRM-58** | **R3b** |
+| HRM-57 | P5, W4 | | |
+
+**Unmapped:** none. **Out of scope:** HRM-23 (`[OD-1:B]`).

--- a/.specs/features/multi-harness-support/investigation.md
+++ b/.specs/features/multi-harness-support/investigation.md
@@ -1,5 +1,23 @@
 # multi-harness-support — Feasibility Investigation
 
+> **⚠️ WITHDRAWN — implemented, verified live, then removed.**
+>
+> The Hermes (Nous Research `hermes-agent`) harness described here **shipped and worked
+> end-to-end** against a real z.ai/GLM deployment, and was then removed for **current
+> infrastructure compatibility**: a 180s startup deadline against a 35s global health-wait, turns
+> sitting near mycelium's 60s `gatewayTimeout` (never solved), a heavyweight per-user image, and a
+> second code branch no deployment exercised.
+>
+> This document is kept as the **future-implementation record** — it is not a description of the
+> current stack. Nothing below is in the shipped surface today. The generic harness seam *is* kept
+> dormant, so a re-add is "write the profile".
+>
+> - **The decision, and exactly what was withdrawn:** `../hermes-removal/DECISION.md`
+>   (with the operational residue list) and `../hermes-removal/spec.md`.
+> - **What was learned by running it** — read this first on a re-add:
+>   `crab/crab-shell-proxy/.specs/features/multi-harness-support/implementation-notes.md`.
+> - **Recovery SHAs:** `d2f0a9a`, `748e0fe`, `3e9e95c`.
+
 **Status:** Investigation (pre-spec). No implementation committed.
 **Question:** Can `crab-shell-proxy` orchestrate agent runtimes *other than* picoclaw, and
 specifically what does it take to run **Nous Research's Hermes Agent** (`nousresearch/hermes-agent`)?

--- a/.specs/features/multi-harness-support/spec.md
+++ b/.specs/features/multi-harness-support/spec.md
@@ -1,5 +1,23 @@
 # multi-harness-support Specification
 
+> **⚠️ WITHDRAWN — implemented, verified live, then removed.**
+>
+> The Hermes (Nous Research `hermes-agent`) harness described here **shipped and worked
+> end-to-end** against a real z.ai/GLM deployment, and was then removed for **current
+> infrastructure compatibility**: a 180s startup deadline against a 35s global health-wait, turns
+> sitting near mycelium's 60s `gatewayTimeout` (never solved), a heavyweight per-user image, and a
+> second code branch no deployment exercised.
+>
+> This document is kept as the **future-implementation record** — it is not a description of the
+> current stack. Nothing below is in the shipped surface today. The generic harness seam *is* kept
+> dormant, so a re-add is "write the profile".
+>
+> - **The decision, and exactly what was withdrawn:** `../hermes-removal/DECISION.md`
+>   (with the operational residue list) and `../hermes-removal/spec.md`.
+> - **What was learned by running it** — read this first on a re-add:
+>   `crab/crab-shell-proxy/.specs/features/multi-harness-support/implementation-notes.md`.
+> - **Recovery SHAs:** `d2f0a9a`, `748e0fe`, `3e9e95c`.
+
 **Status (2026-07-21):** P1 "chat works with a Hermes-backed agent" slice **implemented** in
 `crab-shell-proxy` (working tree; not yet committed). Implementation design/tasks live in the
 submodule: `crab/crab-shell-proxy/.specs/features/multi-harness-support/{design.md,tasks.md}`.

--- a/.specs/project/ROADMAP.md
+++ b/.specs/project/ROADMAP.md
@@ -123,6 +123,16 @@ Telegram / MS Teams channels.
 
 - Production hardening (TLS termination, secret rotation, Docker-socket privilege — see AD-009 R2)
 - Per-user (not just per-agent) lifecycle mode overrides
+- **multi-harness support (DEFERRED — withdrawn 2026-08-09)** — orchestrating a
+  non-picoclaw agent runtime behind the same proxy. Hermes Agent (Nous Research)
+  was implemented and **verified working end-to-end**, then withdrawn for current
+  infrastructure compatibility: a 180s startup deadline against a 35s global
+  health-wait, and turns sitting near mycelium's 60s `gatewayTimeout` (never
+  solved). The generic harness seam is kept dormant, so a re-add is "write the
+  profile". Decision: `.specs/features/hermes-removal/DECISION.md`. Design record:
+  `.specs/features/multi-harness-support/`. **Start from**
+  `crab/crab-shell-proxy/.specs/features/multi-harness-support/implementation-notes.md`
+  — the runtime findings from the live E2E.
 - **conversation-tree-view** (PLANNED) — optional "Tree" view mode in the chat
   sidebar: a vertical time-ordered spine where each conversation is a colored
   lane and each message is a dot, reconciling the agent's continuous per-session

--- a/.specs/project/STATE.md
+++ b/.specs/project/STATE.md
@@ -22,6 +22,37 @@ still operator-gated (needs the backend stack). M4 (crab-shell-proxy) live-conta
 
 ## Recent Decisions (Last 60 days)
 
+### AD-014: the Hermes harness is withdrawn; the seam stays dormant (2026-08-09)
+
+**Decision (user-directed).** Hermes (Nous Research `hermes-agent`) is removed from every
+shipped artifact and demoted to a future implementation. **It was not removed because it
+failed** — it was implemented and verified end-to-end against a real z.ai/GLM deployment.
+It is removed for **current infrastructure compatibility**: a 180s startup deadline against
+the proxy's 35s global health-wait, a heavyweight per-user image (71 skills + chromium under
+s6), and — the actual blocker — turns sitting **near mycelium's 60s `gatewayTimeout`**, which
+was never solved. Carrying it meant every layer kept a second branch no deployment exercised.
+
+**OD-1 resolved as Option A:** the *profile* goes, the *generic harness seam* stays dormant.
+`Agent.Harness` (validated, `picoclaw` the only accepted value), `turn.Request`/`turn.Sink`,
+the `Turner` interface, `Target.Harness` and the admin API's `harness` field are all kept —
+picoclaw flows through them, `harness` is a live API contract the webapp branches on, and
+`chat-progress-events` built `turn.Sink` on top of them. Accepted cost: a discriminator with
+one legal value.
+
+**Three consequences worth remembering:**
+- A stale `harness: hermes` config now **fails at `Load`** rather than defaulting to picoclaw
+  — defaulting would hand a user a picoclaw container under a role provisioned for Hermes.
+- `Config.DisabledAgents` died with it (both append sites were inside Hermes branches). Its
+  *behaviour* — an agent self-disabling when its deployment lacks its secrets — is worth
+  restoring on any re-add, ideally not tied to one harness.
+- Test fixtures were rewritten against a **synthetic** non-picoclaw harness value rather than
+  deleted, in both the proxy and the webapp: the picoclaw-only filters are still live code and
+  those were the only tests of their false branch.
+
+**Full record:** `.specs/features/hermes-removal/DECISION.md`.
+**Recovery SHAs:** `d2f0a9a`, `748e0fe`, `3e9e95c`.
+**The expensive knowledge:** `crab/crab-shell-proxy/.specs/features/multi-harness-support/implementation-notes.md`.
+
 ### AD-013: one proxy-level model inventory is the single source of truth (2026-07-26)
 
 **Decision (user-directed).** Model selection had **two** systems writing
@@ -55,9 +86,12 @@ it clobbered. Both are deleted. `internal/registry` (bbolt at
    read-modify-write, so without pruning every model a workspace ever used keeps its key
    forever. `PublicModel` has no key field at all, so leaking one requires adding a field.
 5. **`config.yaml`'s `agent.Model` is now a migration seed with no runtime effect.** Editing
-   it after the migration does nothing. **Hermes still reads it** — its key is injected as a
-   container env var under `keyEnvName`, a different mechanism — so "single source of truth"
-   holds for picoclaw agents only until that is folded in.
+   it after the migration does nothing. This is **unconditionally** true as of 2026-08-09:
+   it was previously qualified with "Hermes still reads it" (its key was injected as a
+   container env var under `keyEnvName`, a different mechanism), and the Hermes harness has
+   since been withdrawn — see `.specs/features/hermes-removal/DECISION.md`. `keyEnvName` is
+   gone with it, so "single source of truth" now holds for every agent. The caveat that the
+   field is a seed and not a live setting still stands, and still surprises people.
 6. **Boot migration** imports `config.yaml`, `registered-models/*.json` and the old override
    files, then reads **every existing workspace's own `config.json`** to record what it is
    running. Without that step every existing user reads as unassigned and the first

--- a/README.md
+++ b/README.md
@@ -148,18 +148,15 @@ for the self-heal behavior.
 
 **3. Configure `.env`.** Copy the matching `deploy/<mode>/.env.example` (standalone / prod / dokploy — see [Deploy modes](#deploy-modes)) to `.env` at the repo root and set:
 
-- `MYC_PICOCLAW_ALPHA_TOKEN` / `MYC_PICOCLAW_BETA_TOKEN` / `MYC_HERMES_GLM_TOKEN`
-  — bearer tokens Mycelium injects and crab-shell-proxy validates per agent.
-- `PICOCLAW_ALPHA_API_KEY` / `PICOCLAW_BETA_API_KEY` / `PROXY_GLM_API_KEY` — each
-  agent's **own** LLM key, read from the environment (never stored in config or
-  images).
+- `MYC_PICOCLAW_ALPHA_TOKEN` / `MYC_PICOCLAW_BETA_TOKEN` — bearer tokens Mycelium
+  injects and crab-shell-proxy validates per agent.
+- `PICOCLAW_ALPHA_API_KEY` / `PICOCLAW_BETA_API_KEY` — each agent's **own** LLM
+  key, read from the environment (never stored in config or images).
 - `MYC_STANDALONE_BOOTSTRAP_SECRET` — gates the one-time Staff bootstrap.
 
-The stack ships three agents: `alpha` and `beta` (picoclaw) and `hermes-glm` (a
-hermes-agent instance from Nous Research, driven over its OpenAI-compatible
-server instead of the Pico Protocol). An agent whose
-token or provider key is unset is auto-disabled by the proxy at startup, so you
-can run only the ones you have keys for.
+The stack ships two agents, `alpha` and `beta`, both picoclaw. Each needs its
+token and its LLM key set, or the proxy will not start — add or remove agents in
+the proxy's `config.yaml` together with the matching Gateway service block.
 
 Which provider/model each agent uses is declared in
 [`crab/crab-shell-proxy/config.yaml`](./crab/crab-shell-proxy/config.yaml) (e.g.
@@ -188,8 +185,8 @@ cold-starts *your own* container; `docker ps` will show
 tenant + subscription + account triple — a container name has a 63-char limit,
 so the identity lives in the container's labels, not in its name).
 
-> The gateway routes are `protectedByRoles` (roles `alpha` / `beta` /
-> `hermes-glm`), so an account must hold the matching guest-role to reach an
+> The gateway routes are `protectedByRoles` (roles `alpha` / `beta`), so an
+> account must hold the matching guest-role to reach an
 > instance. Roles can be granted from the **chat-webapp admin area**
 > (Members → invite) or from **`mycelium-webapp`**
 > (`http://localhost:${MYCELIUM_WEBAPP_PORT:-8081}`) — Mycelium's own admin UI —
@@ -290,7 +287,7 @@ its `.env.example` and the gateway config that mode mounts — copy the matching
 | Storage | SQLite in `mycelium-data` | `mycelium-postgres` | `mycelium-postgres` |
 | E-mail | stub — magic links land in the log | real SMTP | real SMTP |
 | Ingress | published host ports | published host ports | Traefik, one domain per service |
-| Agents | alpha · beta · hermes-glm | alpha · beta · hermes-glm | alpha · beta |
+| Agents | alpha · beta | alpha · beta | alpha · beta |
 | Gateway config | `deploy/standalone/config.standalone.toml` | `deploy/prod/config.base.toml` | `deploy/dokploy/config.base.toml` |
 | Agent catalog | baked in the proxy image | baked in the proxy image | mounted: `deploy/dokploy/crab-shell-proxy.config.yaml` |
 

--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -150,18 +150,16 @@ para o comportamento de auto-recuperação.
 
 **3. Configure o `.env`.** Copie o `deploy/<modo>/.env.example` correspondente (standalone / prod / dokploy — veja [Modos de deploy](#modos-de-deploy)) para `.env` na raiz do repositório e defina:
 
-- `MYC_PICOCLAW_ALPHA_TOKEN` / `MYC_PICOCLAW_BETA_TOKEN` / `MYC_HERMES_GLM_TOKEN`
+- `MYC_PICOCLAW_ALPHA_TOKEN` / `MYC_PICOCLAW_BETA_TOKEN`
   — bearer tokens que o Mycelium injeta e o crab-shell-proxy valida por agente.
-- `PICOCLAW_ALPHA_API_KEY` / `PICOCLAW_BETA_API_KEY` / `PROXY_GLM_API_KEY` — a
-  chave LLM **própria** de cada agente, lida do ambiente (nunca guardada em
-  config ou imagem).
+- `PICOCLAW_ALPHA_API_KEY` / `PICOCLAW_BETA_API_KEY` — a chave LLM **própria** de
+  cada agente, lida do ambiente (nunca guardada em config ou imagem).
 - `MYC_STANDALONE_BOOTSTRAP_SECRET` — libera o bootstrap único de Staff.
 
-A stack traz três agentes: `alpha` e `beta` (picoclaw) e `hermes-glm` (uma
-instância do hermes-agent, da Nous Research, conduzida pelo servidor
-OpenAI-compatível dele em vez do Pico Protocol). Um agente cujo token ou chave de
-provider esteja vazio é auto-desabilitado pelo proxy no startup, então dá para
-rodar só os que você tem chave.
+A stack traz dois agentes, `alpha` e `beta`, ambos picoclaw. Cada um precisa do
+seu token e da sua chave LLM definidos, ou o proxy não sobe — para adicionar ou
+remover agentes, edite o `config.yaml` do proxy junto com o bloco de serviço
+correspondente no Gateway.
 
 Qual provider/model cada agente usa é declarado em
 [`crab/crab-shell-proxy/config.yaml`](./crab/crab-shell-proxy/config.yaml) (ex.:
@@ -190,8 +188,8 @@ o cold-start do *seu próprio* container; o `docker ps` mostrará
 tenant + subscription + conta — nome de container tem limite de 63 caracteres,
 então a identidade fica nas labels, não no nome).
 
-> As rotas do gateway são `protectedByRoles` (papéis `alpha` / `beta` /
-> `hermes-glm`), então uma conta precisa ter o guest-role correspondente para
+> As rotas do gateway são `protectedByRoles` (papéis `alpha` / `beta`), então uma
+> conta precisa ter o guest-role correspondente para
 > alcançar uma instância. Os papéis podem ser concedidos pela **área de admin do
 > chat-webapp** (Membros → convidar) ou pelo **`mycelium-webapp`**
 > (`http://localhost:${MYCELIUM_WEBAPP_PORT:-8081}`) — a UI de admin do próprio
@@ -297,7 +295,7 @@ modo.
 | Armazenamento | SQLite no `mycelium-data` | `mycelium-postgres` | `mycelium-postgres` |
 | E-mail | stub — os magic-links caem no log | SMTP real | SMTP real |
 | Entrada | portas publicadas no host | portas publicadas no host | Traefik, um domínio por serviço |
-| Agentes | alpha · beta · hermes-glm | alpha · beta · hermes-glm | alpha · beta |
+| Agentes | alpha · beta | alpha · beta | alpha · beta |
 | Config do gateway | `deploy/standalone/config.standalone.toml` | `deploy/prod/config.base.toml` | `deploy/dokploy/config.base.toml` |
 | Catálogo de agentes | embutido na imagem do proxy | embutido na imagem do proxy | montado: `deploy/dokploy/crab-shell-proxy.config.yaml` |
 

--- a/deploy/dokploy/.env.example
+++ b/deploy/dokploy/.env.example
@@ -32,10 +32,9 @@ CRAB_WEBHOOK_SECRET=change-me-to-a-long-random-secret
 
 # ─── Per-agent bearer tokens (mycelium injects, the proxy validates) ──────────
 # Distinct random values per agent, e.g. openssl rand -hex 32
-# This mode runs picoclaw ONLY: neither deploy/dokploy/config.base.toml nor
-# deploy/dokploy/crab-shell-proxy.config.yaml declares hermes-glm, so there is no
-# MYC_HERMES_GLM_TOKEN / PROXY_GLM_API_KEY here. Adding the agent back means
-# adding it to BOTH of those files plus its two variables.
+# One variable per agent declared in BOTH deploy/dokploy/config.base.toml and
+# deploy/dokploy/crab-shell-proxy.config.yaml. Adding an agent means editing both
+# of those files plus adding its token here.
 MYC_PICOCLAW_ALPHA_TOKEN=change-me-alpha
 MYC_PICOCLAW_BETA_TOKEN=change-me-beta
 

--- a/deploy/dokploy/config.base.toml
+++ b/deploy/dokploy/config.base.toml
@@ -272,7 +272,7 @@ methods = ["POST", "DELETE"]
 #
 # A project IS a picoclaw agents.list entry plus a dispatch rule, written into
 # the user's config.json — so this route only means anything for an agent that
-# answers 501 there rather than routing a project chat to the ordinary agent.
+# reads it.
 group = { protectedByRoles = [{ name = "alpha" }] }
 path = "/v1/projects"
 secretName = "alpha-authorization-header"
@@ -478,7 +478,7 @@ methods = ["POST", "DELETE"]
 #
 # A project IS a picoclaw agents.list entry plus a dispatch rule, written into
 # the user's config.json — so this route only means anything for an agent that
-# answers 501 there rather than routing a project chat to the ordinary agent.
+# reads it.
 group = { protectedByRoles = [{ name = "beta" }] }
 path = "/v1/projects"
 secretName = "beta-authorization-header"

--- a/deploy/dokploy/config.base.toml
+++ b/deploy/dokploy/config.base.toml
@@ -12,10 +12,10 @@
 # deps) -- this file changes ONLY the infrastructure sections; the API-gateway
 # routing below is the same as config.standalone.toml (crab-shell-proxy:8080,
 # protectedByRoles) with ONE deliberate omission: this mode runs picoclaw only,
-# so there is no `[[hermes-glm]]` service here. That matches
+# so there is one service block per agent here. That matches
 # deploy/dokploy/crab-shell-proxy.config.yaml, which drops the same agent from
-# the proxy's catalog. Re-adding hermes means editing BOTH files and supplying
-# MYC_HERMES_GLM_TOKEN + PROXY_GLM_API_KEY.
+# the proxy's catalog. Adding an agent means editing BOTH files and supplying its
+# MYC_<AGENT>_TOKEN.
 #
 # Differences vs. standalone, all infra:
 #   - vault disabled; core/jwt/hmac/token secrets resolved from env (base mode
@@ -156,7 +156,7 @@ target = "stdout"
 
 # ==============================================================================
 # API GATEWAY ROUTE CONFIGURATION -- the same routes as config.standalone.toml
-# for alpha and beta; hermes-glm is deliberately absent (see the header). See
+# for alpha and beta. See
 # that file's `[api.services]` comment block for the full routing, header
 # contract, and protectedByRoles rationale. A route added to one of the three
 # deploy TOMLs has to be added to the others.
@@ -203,8 +203,8 @@ methods = ["GET"]
 # GET needs only read; every mutation must require write, and that is enforced
 # in-proxy by the same profile chain /v1/secrets uses.
 #
-# Not declared for hermes-glm: a personal model IS a picoclaw model_list entry,
-# and the hermes harness never reads config.json. The proxy answers 501 there.
+# A personal model IS a picoclaw model_list entry, written into the user's
+# config.json — so this route only means anything for an agent that reads it.
 group = { protectedByRoles = [{ name = "alpha" }] }
 path = "/v1/models/*"
 secretName = "alpha-authorization-header"
@@ -270,8 +270,8 @@ methods = ["POST", "DELETE"]
 # write, and that is enforced in-proxy by the same profile chain /v1/secrets
 # uses. A read-only member reaching a mutation gets a 403 there.
 #
-# Not declared for hermes-glm: a project IS a picoclaw agents.list entry plus a
-# dispatch rule, and the hermes harness never reads config.json. The proxy
+# A project IS a picoclaw agents.list entry plus a dispatch rule, written into
+# the user's config.json — so this route only means anything for an agent that
 # answers 501 there rather than routing a project chat to the ordinary agent.
 group = { protectedByRoles = [{ name = "alpha" }] }
 path = "/v1/projects"
@@ -409,8 +409,8 @@ methods = ["GET"]
 # GET needs only read; every mutation must require write, and that is enforced
 # in-proxy by the same profile chain /v1/secrets uses.
 #
-# Not declared for hermes-glm: a personal model IS a picoclaw model_list entry,
-# and the hermes harness never reads config.json. The proxy answers 501 there.
+# A personal model IS a picoclaw model_list entry, written into the user's
+# config.json — so this route only means anything for an agent that reads it.
 group = { protectedByRoles = [{ name = "beta" }] }
 path = "/v1/models/*"
 secretName = "beta-authorization-header"
@@ -476,8 +476,8 @@ methods = ["POST", "DELETE"]
 # write, and that is enforced in-proxy by the same profile chain /v1/secrets
 # uses. A read-only member reaching a mutation gets a 403 there.
 #
-# Not declared for hermes-glm: a project IS a picoclaw agents.list entry plus a
-# dispatch rule, and the hermes harness never reads config.json. The proxy
+# A project IS a picoclaw agents.list entry plus a dispatch rule, written into
+# the user's config.json — so this route only means anything for an agent that
 # answers 501 there rather than routing a project chat to the ordinary agent.
 group = { protectedByRoles = [{ name = "beta" }] }
 path = "/v1/projects"

--- a/deploy/dokploy/crab-shell-proxy.config.yaml
+++ b/deploy/dokploy/crab-shell-proxy.config.yaml
@@ -1,13 +1,11 @@
 # =============================================================================
 # crab-shell-proxy config for the DOKPLOY deploy (mounted, overrides the image's
 # baked /etc/crab-shell-proxy/config.yaml). Edit THIS file to customize the agent
-# catalog for your deployment. The upstream default's `hermes-glm` agent has been
-# REMOVED here (this deploy runs picoclaw only); add a hermes block back if you
-# want the hermes harness.
+# catalog for your deployment.
 #
-# Note: a hermes agent is also auto-disabled at startup when its token/provider
-# key are unset (see crab-shell-proxy internal/config.Load), so leaving one in
-# without its secrets is harmless too.
+# Every agent declared here needs a matching mycelium service in
+# deploy/dokploy/config.base.toml and a token in .env — an agent declared in only
+# one of the three is either unroutable or advertised without a bearer.
 #
 # Kept in sync with crab/crab-shell-proxy/config.yaml (the upstream default).
 # Machine-specific fields still come from env (CRAB_HOST_DATA_ROOT, CRAB_NETWORK).

--- a/deploy/prod/.env.example
+++ b/deploy/prod/.env.example
@@ -20,22 +20,18 @@ CHAT_WEBAPP_PORT=3000
 MYCELIUM_WEBAPP_PORT=8081
 
 # --- Per-agent bearer tokens ------------------------------------------------
-# One per agent routed in deploy/prod/config.base.toml. hermes-glm IS routed
-# there (same agent set as standalone), so its token belongs here too: leaving
-# it empty makes the gateway advertise the agent and inject an empty bearer,
-# which fails at request time instead of at boot. To run prod WITHOUT hermes,
-# drop its `[[hermes-glm]]` blocks from config.base.toml and mount a
-# crab-shell-proxy config.yaml without the agent (that is what deploy/dokploy
+# One per agent routed in deploy/prod/config.base.toml. Every routed agent needs
+# its token here: leaving one empty makes the gateway advertise the agent and
+# inject an empty bearer, which fails at request time instead of at boot. To run
+# prod without an agent, drop its `[[<agent>]]` blocks from config.base.toml AND
+# mount a crab-shell-proxy config.yaml without it (that is what deploy/dokploy
 # does).
 MYC_PICOCLAW_ALPHA_TOKEN=change-me-alpha
 MYC_PICOCLAW_BETA_TOKEN=change-me-beta
-MYC_HERMES_GLM_TOKEN=change-me-hermes-glm
 
 # --- Per-instance LLM API keys ----------------------------------------------
 PICOCLAW_ALPHA_API_KEY=sk-your-alpha-key
 PICOCLAW_BETA_API_KEY=sk-your-beta-key
-# z.ai/GLM key for the hermes-glm agent (unset => the proxy auto-disables it)
-PROXY_GLM_API_KEY=your-zai-glm-key
 
 # --- chat-webapp Postgres ---------------------------------------------------
 CHAT_WEBAPP_DB_USER=chatwebapp

--- a/deploy/prod/config.base.toml
+++ b/deploy/prod/config.base.toml
@@ -9,7 +9,7 @@
 # The default local stack still uses config.standalone.toml (SQLite, no external
 # deps) -- this file changes ONLY the infrastructure sections; the API-gateway
 # routing below is IDENTICAL to config.standalone.toml (crab-shell-proxy:8080,
-# protectedByRoles, the full alpha/beta/hermes-glm route set).
+# protectedByRoles, the full alpha/beta route set).
 #
 # THIS MODE IS NOT THE TRAEFIK ONE. It keeps the base file's PUBLISHED HOST PORTS
 # (gateway :8080, chat-webapp :3000, mycelium-webapp :8081) and terminates no TLS
@@ -175,7 +175,7 @@ target = "stdout"
 
 # ==============================================================================
 # API GATEWAY ROUTE CONFIGURATION -- IDENTICAL to config.standalone.toml,
-# agent for agent (alpha, beta, hermes-glm). See that file's `[api.services]`
+# agent for agent (alpha, beta). See that file's `[api.services]`
 # comment block for the full routing, header contract, and protectedByRoles
 # rationale. Kept in sync verbatim: only the infrastructure sections above
 # differ between standalone and base mode. A route added to one of the three
@@ -223,8 +223,8 @@ methods = ["GET"]
 # GET needs only read; every mutation must require write, and that is enforced
 # in-proxy by the same profile chain /v1/secrets uses.
 #
-# Not declared for hermes-glm: a personal model IS a picoclaw model_list entry,
-# and the hermes harness never reads config.json. The proxy answers 501 there.
+# A personal model IS a picoclaw model_list entry, written into the user's
+# config.json — so this route only means anything for an agent that reads it.
 group = { protectedByRoles = [{ name = "alpha" }] }
 path = "/v1/models/*"
 secretName = "alpha-authorization-header"
@@ -290,8 +290,8 @@ methods = ["POST", "DELETE"]
 # write, and that is enforced in-proxy by the same profile chain /v1/secrets
 # uses. A read-only member reaching a mutation gets a 403 there.
 #
-# Not declared for hermes-glm: a project IS a picoclaw agents.list entry plus a
-# dispatch rule, and the hermes harness never reads config.json. The proxy
+# A project IS a picoclaw agents.list entry plus a dispatch rule, written into
+# the user's config.json — so this route only means anything for an agent that
 # answers 501 there rather than routing a project chat to the ordinary agent.
 group = { protectedByRoles = [{ name = "alpha" }] }
 path = "/v1/projects"
@@ -429,8 +429,8 @@ methods = ["GET"]
 # GET needs only read; every mutation must require write, and that is enforced
 # in-proxy by the same profile chain /v1/secrets uses.
 #
-# Not declared for hermes-glm: a personal model IS a picoclaw model_list entry,
-# and the hermes harness never reads config.json. The proxy answers 501 there.
+# A personal model IS a picoclaw model_list entry, written into the user's
+# config.json — so this route only means anything for an agent that reads it.
 group = { protectedByRoles = [{ name = "beta" }] }
 path = "/v1/models/*"
 secretName = "beta-authorization-header"
@@ -496,8 +496,8 @@ methods = ["POST", "DELETE"]
 # write, and that is enforced in-proxy by the same profile chain /v1/secrets
 # uses. A read-only member reaching a mutation gets a 403 there.
 #
-# Not declared for hermes-glm: a project IS a picoclaw agents.list entry plus a
-# dispatch rule, and the hermes harness never reads config.json. The proxy
+# A project IS a picoclaw agents.list entry plus a dispatch rule, written into
+# the user's config.json — so this route only means anything for an agent that
 # answers 501 there rather than routing a project chat to the ordinary agent.
 group = { protectedByRoles = [{ name = "beta" }] }
 path = "/v1/projects"
@@ -580,162 +580,5 @@ methods = ["GET"]
 group = "protected"
 path = "/v1/admin/*"
 secretName = "beta-authorization-header"
-acceptInsecureRouting = true
-methods = ["GET", "POST", "PUT", "DELETE"]
-
-# ------------------------------------------------------------------------------
-# hermes-glm: a Nous Research hermes-agent instance (harness = "hermes" in
-# crab-shell-proxy/config.yaml), routed to the same crab-shell-proxy downstream.
-# crab-shell-proxy tells it apart via x-mycelium-service-name = "hermes-glm" and
-# drives the container over its OpenAI-compatible API server (:8642) instead of
-# the Pico Protocol. Same auth/role contract as the picoclaw services above: the
-# "hermes-glm" guest-role is auto-declared here; granting it to an account still
-# needs the Staff -> tenant -> subscription -> guest-invite chain (M3).
-# ------------------------------------------------------------------------------
-
-[[hermes-glm]]
-host = "crab-shell-proxy:8080"
-protocol = "http"
-healthCheckPath = "/healthz"
-discoverable = true
-serviceType = "rest-api"
-isContextApi = false
-openapiPath = "/doc/openapi.json"
-capabilities = ["chat"]
-description = "Hermes-agent (Nous Research, GLM via z.ai) - an OpenAI-compatible personal chat agent. Each user gets an isolated container; send chat via POST /v1/chat/completions."
-
-[[hermes-glm.secret]]
-name = "hermes-glm-authorization-header"
-authorizationHeader = { headerName = "Authorization", prefix = "Bearer", token = { env = "MYC_HERMES_GLM_TOKEN" } }
-
-[[hermes-glm.path]]
-group = { protectedByRoles = [{ name = "hermes-glm", permission = "write" }] }
-path = "/v1/chat/completions"
-secretName = "hermes-glm-authorization-header"
-acceptInsecureRouting = true
-methods = ["POST"]
-
-[[hermes-glm.path]]
-group = { protectedByRoles = [{ name = "hermes-glm" }] }
-path = "/v1/models"
-secretName = "hermes-glm-authorization-header"
-acceptInsecureRouting = true
-methods = ["GET"]
-
-[[hermes-glm.path]]
-group = { protectedByRoles = [{ name = "hermes-glm" }] }
-path = "/v1/sessions/history"
-secretName = "hermes-glm-authorization-header"
-acceptInsecureRouting = true
-methods = ["GET"]
-
-[[hermes-glm.path]]
-group = { protectedByRoles = [{ name = "hermes-glm" }] }
-path = "/v1/sessions/resolve"
-secretName = "hermes-glm-authorization-header"
-acceptInsecureRouting = true
-methods = ["GET"]
-
-[[hermes-glm.path]]
-group = "protected"
-path = "/v1/subscriptions"
-secretName = "hermes-glm-authorization-header"
-acceptInsecureRouting = true
-methods = ["GET"]
-
-[[hermes-glm.path]]
-group = { protectedByRoles = [{ name = "hermes-glm", permission = "write" }] }
-path = "/v1/secrets"
-secretName = "hermes-glm-authorization-header"
-acceptInsecureRouting = true
-methods = ["GET", "POST", "DELETE"]
-
-[[hermes-glm.path]]
-group = { protectedByRoles = [{ name = "hermes-glm", permission = "write" }] }
-path = "/v1/media"
-secretName = "hermes-glm-authorization-header"
-acceptInsecureRouting = true
-methods = ["GET", "POST", "DELETE"]
-
-[[hermes-glm.path]]
-# Uploads-tree organisation (create folder, move/rename, delete folder). ONE
-# wildcard block: `*` matches the following segment, and /v1/media itself already
-# has its own block above, so there is no "Multiple routes found" conflict.
-#
-# Same write gate as /v1/media, because these write into the same directory an
-# upload does. DELETE here is a RECURSIVE folder delete — the proxy refuses the
-# uploads root, and the interface names the file count before the member confirms.
-group = { protectedByRoles = [{ name = "hermes-glm", permission = "write" }] }
-path = "/v1/media/*"
-secretName = "hermes-glm-authorization-header"
-acceptInsecureRouting = true
-methods = ["POST", "DELETE"]
-
-[[hermes-glm.path]]
-group = { protectedByRoles = [{ name = "hermes-glm", permission = "write" }] }
-path = "/v1/memory"
-secretName = "hermes-glm-authorization-header"
-acceptInsecureRouting = true
-methods = ["GET", "PUT"]
-
-[[hermes-glm.path]]
-# Knowledge-graph memory (memory-graph-mcp): READ-ONLY views of the graph the
-# agent builds through its own native MCP server inside crab-shell-proxy.
-#
-# TWO blocks: mycelium's `*` matches a following segment, so it covers
-# /nodes, /search and /recent but not the bare /v1/memory-graph.
-#
-# Gated `write` like /v1/memory even though every method here is GET. The proxy
-# authorizes these with authorizeSecret -- the same write-access chain -- so a
-# read-only member is refused in-proxy regardless; gating lower here would only
-# move the 403 from the gateway to the proxy.
-#
-# There is deliberately NO /v1/mcp route: the agent reaches that endpoint
-# directly on the container network, never through the gateway.
-path = "/v1/memory-graph"
-group = { protectedByRoles = [{ name = "hermes-glm", permission = "write" }] }
-secretName = "hermes-glm-authorization-header"
-acceptInsecureRouting = true
-methods = ["GET"]
-
-[[hermes-glm.path]]
-path = "/v1/memory-graph/*"
-group = { protectedByRoles = [{ name = "hermes-glm", permission = "write" }] }
-secretName = "hermes-glm-authorization-header"
-acceptInsecureRouting = true
-methods = ["GET"]
-
-[[hermes-glm.path]]
-# Self-service restart (restart-control): GET reports whether this member's
-# instance still needs a bounce (and when an admin scheduled one); POST performs
-# it for the caller's OWN container only.
-#
-# ONE block covering both methods, gated on the role NAME (read), even though
-# POST must require write. The gateway matches routes by path alone and errors
-# with "Multiple routes found for the specified path" when two blocks share one
-# path -- so GET and POST cannot be gated differently here. The write requirement
-# for POST is enforced in-proxy instead, by the same profile chain /v1/secrets
-# uses; a read-only member reaching POST gets a 403 from the proxy.
-group = { protectedByRoles = [{ name = "hermes-glm" }] }
-path = "/v1/restart"
-secretName = "hermes-glm-authorization-header"
-acceptInsecureRouting = true
-methods = ["GET", "POST"]
-
-[[hermes-glm.path]]
-# Scheduled tasks (see the alpha /v1/cron comment).
-group = { protectedByRoles = [{ name = "hermes-glm" }] }
-path = "/v1/cron/*"
-secretName = "hermes-glm-authorization-header"
-acceptInsecureRouting = true
-methods = ["GET"]
-
-[[hermes-glm.path]]
-# All /v1/admin/* endpoints share group=protected + this secret; the
-# proxy enforces the exact path+method per route. Collapsed to one
-# wildcard (mycelium matches via the wildmatch crate).
-group = "protected"
-path = "/v1/admin/*"
-secretName = "hermes-glm-authorization-header"
 acceptInsecureRouting = true
 methods = ["GET", "POST", "PUT", "DELETE"]

--- a/deploy/prod/config.base.toml
+++ b/deploy/prod/config.base.toml
@@ -292,7 +292,7 @@ methods = ["POST", "DELETE"]
 #
 # A project IS a picoclaw agents.list entry plus a dispatch rule, written into
 # the user's config.json — so this route only means anything for an agent that
-# answers 501 there rather than routing a project chat to the ordinary agent.
+# reads it.
 group = { protectedByRoles = [{ name = "alpha" }] }
 path = "/v1/projects"
 secretName = "alpha-authorization-header"
@@ -498,7 +498,7 @@ methods = ["POST", "DELETE"]
 #
 # A project IS a picoclaw agents.list entry plus a dispatch rule, written into
 # the user's config.json — so this route only means anything for an agent that
-# answers 501 there rather than routing a project chat to the ordinary agent.
+# reads it.
 group = { protectedByRoles = [{ name = "beta" }] }
 path = "/v1/projects"
 secretName = "beta-authorization-header"

--- a/deploy/standalone/.env.example
+++ b/deploy/standalone/.env.example
@@ -26,13 +26,10 @@ MYCELIUM_GIT_REF=9298ecb44a69ced91cb2d7d3356a716aedca858b
 # openssl rand -hex 32 each
 MYC_PICOCLAW_ALPHA_TOKEN=change-me-alpha
 MYC_PICOCLAW_BETA_TOKEN=change-me-beta
-MYC_HERMES_GLM_TOKEN=change-me-hermes-glm
 
 # --- Per-instance LLM API keys ----------------------------------------------
 PICOCLAW_ALPHA_API_KEY=sk-your-alpha-key
 PICOCLAW_BETA_API_KEY=sk-your-beta-key
-# z.ai/GLM key for the hermes-glm agent (unset => hermes agent auto-disabled)
-PROXY_GLM_API_KEY=your-zai-glm-key
 
 # --- mycelium-gateway staff bootstrap ---------------------------------------
 # openssl rand -hex 32; leave empty to keep the bootstrap endpoints 404'd.

--- a/deploy/standalone/config.standalone.toml
+++ b/deploy/standalone/config.standalone.toml
@@ -310,7 +310,7 @@ methods = ["POST", "DELETE"]
 #
 # A project IS a picoclaw agents.list entry plus a dispatch rule, written into
 # the user's config.json — so this route only means anything for an agent that
-# answers 501 there rather than routing a project chat to the ordinary agent.
+# reads it.
 group = { protectedByRoles = [{ name = "alpha" }] }
 path = "/v1/projects"
 secretName = "alpha-authorization-header"
@@ -530,7 +530,7 @@ methods = ["POST", "DELETE"]
 #
 # A project IS a picoclaw agents.list entry plus a dispatch rule, written into
 # the user's config.json — so this route only means anything for an agent that
-# answers 501 there rather than routing a project chat to the ordinary agent.
+# reads it.
 group = { protectedByRoles = [{ name = "beta" }] }
 path = "/v1/projects"
 secretName = "beta-authorization-header"

--- a/deploy/standalone/config.standalone.toml
+++ b/deploy/standalone/config.standalone.toml
@@ -4,7 +4,7 @@
 # Adapted from mycelium-monorepo's settings/config.standalone.example.toml:
 # zero external runtime dependencies (SQLite instead of Postgres, in-process
 # moka cache instead of Redis, stub/file email transport). Declares one service
-# per agent ("alpha", "beta", "hermes-glm"), all routed to the single
+# per agent ("alpha", "beta"), all routed to the single
 # crab-shell-proxy downstream (see ../../docker-compose.yaml), instead of
 # upstream's single example route.
 #
@@ -119,7 +119,7 @@ target = "stdout"
 # ------------------------------------------------------------------------------
 # API GATEWAY ROUTE CONFIGURATION
 #
-# One named service per agent (alpha, beta, hermes-glm) -- ALL pointing at the
+# One named service per agent (alpha, beta) -- ALL pointing at the
 # same downstream, crab-shell-proxy:8080, over the compose-internal `zombie_net`
 # network. crab-shell-proxy tells the agents apart via the
 # x-mycelium-service-name header mycelium injects (the service key below,
@@ -133,7 +133,7 @@ target = "stdout"
 # mycelium's router takes the *first path segment* of the request as the
 # service name (adapters/mem_db/src/repositories/shared.rs::extract_path_parts)
 # and matches everything after it against `path` below -- so callers hit
-# /alpha/..., /beta/... and /hermes-glm/...: the literal TOML service keys, with
+# /alpha/... and /beta/...: the literal TOML service keys, with
 # no "picoclaw-" prefix (an earlier layout used one; the keys were renamed).
 #
 # `token = { env = "VAR_NAME" }` is the field-level env resolver fixed in
@@ -227,8 +227,8 @@ methods = ["GET"]
 # GET needs only read; every mutation must require write, and that is enforced
 # in-proxy by the same profile chain /v1/secrets uses.
 #
-# Not declared for hermes-glm: a personal model IS a picoclaw model_list entry,
-# and the hermes harness never reads config.json. The proxy answers 501 there.
+# A personal model IS a picoclaw model_list entry, written into the user's
+# config.json — so this route only means anything for an agent that reads it.
 group = { protectedByRoles = [{ name = "alpha" }] }
 path = "/v1/models/*"
 secretName = "alpha-authorization-header"
@@ -308,8 +308,8 @@ methods = ["POST", "DELETE"]
 # write, and that is enforced in-proxy by the same profile chain /v1/secrets
 # uses. A read-only member reaching a mutation gets a 403 there.
 #
-# Not declared for hermes-glm: a project IS a picoclaw agents.list entry plus a
-# dispatch rule, and the hermes harness never reads config.json. The proxy
+# A project IS a picoclaw agents.list entry plus a dispatch rule, written into
+# the user's config.json — so this route only means anything for an agent that
 # answers 501 there rather than routing a project chat to the ordinary agent.
 group = { protectedByRoles = [{ name = "alpha" }] }
 path = "/v1/projects"
@@ -457,8 +457,8 @@ methods = ["GET"]
 # GET needs only read; every mutation must require write, and that is enforced
 # in-proxy by the same profile chain /v1/secrets uses.
 #
-# Not declared for hermes-glm: a personal model IS a picoclaw model_list entry,
-# and the hermes harness never reads config.json. The proxy answers 501 there.
+# A personal model IS a picoclaw model_list entry, written into the user's
+# config.json — so this route only means anything for an agent that reads it.
 group = { protectedByRoles = [{ name = "beta" }] }
 path = "/v1/models/*"
 secretName = "beta-authorization-header"
@@ -528,8 +528,8 @@ methods = ["POST", "DELETE"]
 # write, and that is enforced in-proxy by the same profile chain /v1/secrets
 # uses. A read-only member reaching a mutation gets a 403 there.
 #
-# Not declared for hermes-glm: a project IS a picoclaw agents.list entry plus a
-# dispatch rule, and the hermes harness never reads config.json. The proxy
+# A project IS a picoclaw agents.list entry plus a dispatch rule, written into
+# the user's config.json — so this route only means anything for an agent that
 # answers 501 there rather than routing a project chat to the ordinary agent.
 group = { protectedByRoles = [{ name = "beta" }] }
 path = "/v1/projects"
@@ -616,162 +616,5 @@ methods = ["GET"]
 group = "protected"
 path = "/v1/admin/*"
 secretName = "beta-authorization-header"
-acceptInsecureRouting = true
-methods = ["GET", "POST", "PUT", "DELETE"]
-
-# ------------------------------------------------------------------------------
-# hermes-glm: a Nous Research hermes-agent instance (harness = "hermes" in
-# crab-shell-proxy/config.yaml), routed to the same crab-shell-proxy downstream.
-# crab-shell-proxy tells it apart via x-mycelium-service-name = "hermes-glm" and
-# drives the container over its OpenAI-compatible API server (:8642) instead of
-# the Pico Protocol. Same auth/role contract as the picoclaw services above: the
-# "hermes-glm" guest-role is auto-declared here; granting it to an account still
-# needs the Staff -> tenant -> subscription -> guest-invite chain (M3).
-# ------------------------------------------------------------------------------
-
-[[hermes-glm]]
-host = "crab-shell-proxy:8080"
-protocol = "http"
-healthCheckPath = "/healthz"
-discoverable = true
-serviceType = "rest-api"
-isContextApi = false
-openapiPath = "/doc/openapi.json"
-capabilities = ["chat"]
-description = "Hermes-agent (Nous Research, GLM via z.ai) - an OpenAI-compatible personal chat agent. Each user gets an isolated container; send chat via POST /v1/chat/completions."
-
-[[hermes-glm.secret]]
-name = "hermes-glm-authorization-header"
-authorizationHeader = { headerName = "Authorization", prefix = "Bearer", token = { env = "MYC_HERMES_GLM_TOKEN" } }
-
-[[hermes-glm.path]]
-group = { protectedByRoles = [{ name = "hermes-glm", permission = "write" }] }
-path = "/v1/chat/completions"
-secretName = "hermes-glm-authorization-header"
-acceptInsecureRouting = true
-methods = ["POST"]
-
-[[hermes-glm.path]]
-group = { protectedByRoles = [{ name = "hermes-glm" }] }
-path = "/v1/models"
-secretName = "hermes-glm-authorization-header"
-acceptInsecureRouting = true
-methods = ["GET"]
-
-[[hermes-glm.path]]
-group = { protectedByRoles = [{ name = "hermes-glm" }] }
-path = "/v1/sessions/history"
-secretName = "hermes-glm-authorization-header"
-acceptInsecureRouting = true
-methods = ["GET"]
-
-[[hermes-glm.path]]
-group = { protectedByRoles = [{ name = "hermes-glm" }] }
-path = "/v1/sessions/resolve"
-secretName = "hermes-glm-authorization-header"
-acceptInsecureRouting = true
-methods = ["GET"]
-
-[[hermes-glm.path]]
-group = "protected"
-path = "/v1/subscriptions"
-secretName = "hermes-glm-authorization-header"
-acceptInsecureRouting = true
-methods = ["GET"]
-
-[[hermes-glm.path]]
-group = { protectedByRoles = [{ name = "hermes-glm", permission = "write" }] }
-path = "/v1/secrets"
-secretName = "hermes-glm-authorization-header"
-acceptInsecureRouting = true
-methods = ["GET", "POST", "DELETE"]
-
-[[hermes-glm.path]]
-group = { protectedByRoles = [{ name = "hermes-glm", permission = "write" }] }
-path = "/v1/media"
-secretName = "hermes-glm-authorization-header"
-acceptInsecureRouting = true
-methods = ["GET", "POST", "DELETE"]
-
-[[hermes-glm.path]]
-# Uploads-tree organisation (create folder, move/rename, delete folder). ONE
-# wildcard block: `*` matches the following segment, and /v1/media itself already
-# has its own block above, so there is no "Multiple routes found" conflict.
-#
-# Same write gate as /v1/media, because these write into the same directory an
-# upload does. DELETE here is a RECURSIVE folder delete — the proxy refuses the
-# uploads root, and the interface names the file count before the member confirms.
-group = { protectedByRoles = [{ name = "hermes-glm", permission = "write" }] }
-path = "/v1/media/*"
-secretName = "hermes-glm-authorization-header"
-acceptInsecureRouting = true
-methods = ["POST", "DELETE"]
-
-[[hermes-glm.path]]
-group = { protectedByRoles = [{ name = "hermes-glm", permission = "write" }] }
-path = "/v1/memory"
-secretName = "hermes-glm-authorization-header"
-acceptInsecureRouting = true
-methods = ["GET", "PUT"]
-
-[[hermes-glm.path]]
-# Knowledge-graph memory (memory-graph-mcp): READ-ONLY views of the graph the
-# agent builds through its own native MCP server inside crab-shell-proxy.
-#
-# TWO blocks: mycelium's `*` matches a following segment, so it covers
-# /nodes, /search and /recent but not the bare /v1/memory-graph.
-#
-# Gated `write` like /v1/memory even though every method here is GET. The proxy
-# authorizes these with authorizeSecret -- the same write-access chain -- so a
-# read-only member is refused in-proxy regardless; gating lower here would only
-# move the 403 from the gateway to the proxy.
-#
-# There is deliberately NO /v1/mcp route: the agent reaches that endpoint
-# directly on the container network, never through the gateway.
-path = "/v1/memory-graph"
-group = { protectedByRoles = [{ name = "hermes-glm", permission = "write" }] }
-secretName = "hermes-glm-authorization-header"
-acceptInsecureRouting = true
-methods = ["GET"]
-
-[[hermes-glm.path]]
-path = "/v1/memory-graph/*"
-group = { protectedByRoles = [{ name = "hermes-glm", permission = "write" }] }
-secretName = "hermes-glm-authorization-header"
-acceptInsecureRouting = true
-methods = ["GET"]
-
-[[hermes-glm.path]]
-# Self-service restart (restart-control): GET reports whether this member's
-# instance still needs a bounce (and when an admin scheduled one); POST performs
-# it for the caller's OWN container only.
-#
-# ONE block covering both methods, gated on the role NAME (read), even though
-# POST must require write. The gateway matches routes by path alone and errors
-# with "Multiple routes found for the specified path" when two blocks share one
-# path -- so GET and POST cannot be gated differently here. The write requirement
-# for POST is enforced in-proxy instead, by the same profile chain /v1/secrets
-# uses; a read-only member reaching POST gets a 403 from the proxy.
-group = { protectedByRoles = [{ name = "hermes-glm" }] }
-path = "/v1/restart"
-secretName = "hermes-glm-authorization-header"
-acceptInsecureRouting = true
-methods = ["GET", "POST"]
-
-[[hermes-glm.path]]
-# Scheduled tasks (see the alpha /v1/cron comment).
-group = { protectedByRoles = [{ name = "hermes-glm" }] }
-path = "/v1/cron/*"
-secretName = "hermes-glm-authorization-header"
-acceptInsecureRouting = true
-methods = ["GET"]
-
-[[hermes-glm.path]]
-# All /v1/admin/* endpoints share group=protected + this secret; the
-# proxy enforces the exact path+method per route. Collapsed to one
-# wildcard (mycelium matches via the wildmatch crate).
-group = "protected"
-path = "/v1/admin/*"
-secretName = "hermes-glm-authorization-header"
 acceptInsecureRouting = true
 methods = ["GET", "POST", "PUT", "DELETE"]

--- a/docker-compose.dokploy.yaml
+++ b/docker-compose.dokploy.yaml
@@ -84,10 +84,9 @@ services:
         type: volume
         volume: {}
   crab-shell-proxy:
-    # picoclaw ONLY in this mode -- no MYC_HERMES_GLM_TOKEN / PROXY_GLM_API_KEY,
-    # matching the agent catalog mounted below and the services declared in
-    # deploy/dokploy/config.base.toml. Re-adding hermes means editing both of
-    # those files and adding the two variables back here.
+    # One token variable per agent, matching the catalog mounted below and the
+    # services declared in deploy/dokploy/config.base.toml. Adding an agent means
+    # editing both of those files and adding its variable here.
     environment:
       CRAB_CONTAINER_DATA_ROOT: /data
       CRAB_HOST_DATA_ROOT: ${CRAB_HOST_DATA_ROOT:-${PWD}/data}
@@ -147,7 +146,7 @@ services:
         bind:
           create_host_path: true
       # Deploy-owned agent catalog, overriding the image's baked config.yaml so
-      # operators can customize agents (e.g. drop hermes-glm) without a rebuild.
+      # operators can add or drop agents without a rebuild.
       - type: bind
         source: ./deploy/dokploy/crab-shell-proxy.config.yaml
         target: /etc/crab-shell-proxy/config.yaml

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,17 +5,16 @@
 # Protocol WS channel; crab-shell-proxy speaks that protocol directly in Go):
 #
 #   mycelium-gateway (standalone, :8080, published)
-#     |-- /alpha/v1/*       --\
-#     |-- /beta/v1/*        ----> crab-shell-proxy:8080
-#     `-- /hermes-glm/v1/*  --/     |  (agent from x-mycelium-service-name,
-#                                   |   user from the x-mycelium-profile accId)
-#                                   `--> crabshell-<agent>-<hash>:18790
-#                                        (spawned on demand, one per user;
-#                                         hermes agents answer on :8642 instead)
+#     |-- /alpha/v1/*  --\
+#     `-- /beta/v1/*   ----> crab-shell-proxy:8080
+#                              |  (agent from x-mycelium-service-name,
+#                              |   user from the x-mycelium-profile accId)
+#                              `--> crabshell-<agent>-<hash>:18790
+#                                   (spawned on demand, one per user)
 #
 # mycelium routes by first path segment == the TOML service key (see
-# deploy/standalone/config.standalone.toml), so callers hit /alpha/..., /beta/...
-# and /hermes-glm/... -- the literal keys, with no "picoclaw-" prefix. It strips
+# deploy/standalone/config.standalone.toml), so callers hit /alpha/... and
+# /beta/... -- the literal keys, with no "picoclaw-" prefix. It strips
 # that segment before forwarding, but injects x-mycelium-service-name so
 # crab-shell-proxy still knows which agent was addressed. The spawned agent
 # containers publish no host ports, and crab-shell-proxy publishes only the
@@ -163,17 +162,11 @@ services:
       CRAB_MCP_BASE_URL: ${CRAB_MCP_BASE_URL:-http://crab-shell-proxy:8080}
       MYC_PICOCLAW_ALPHA_TOKEN: ${MYC_PICOCLAW_ALPHA_TOKEN}
       MYC_PICOCLAW_BETA_TOKEN: ${MYC_PICOCLAW_BETA_TOKEN}
-      # hermes-glm agent (harness: hermes): the same shared bearer mycelium
-      # injects and the proxy validates.
-      MYC_HERMES_GLM_TOKEN: ${MYC_HERMES_GLM_TOKEN}
       # Per-instance LLM API keys (referenced by config.yaml's per-agent
       # model.apiKeyEnv). Real values live only in .env (gitignored) or your
       # secrets manager -- never in config.yaml or the image.
       PICOCLAW_ALPHA_API_KEY: ${PICOCLAW_ALPHA_API_KEY}
       PICOCLAW_BETA_API_KEY: ${PICOCLAW_BETA_API_KEY}
-      # z.ai/GLM key for hermes-glm (config.yaml model.apiKeyEnv). The proxy
-      # injects it into the hermes container as GLM_API_KEY (model.keyEnvName).
-      PROXY_GLM_API_KEY: ${PROXY_GLM_API_KEY}
     # TEMPORARY (direct-to-proxy testing of tenant-scoped-workspaces): the proxy
     # normally publishes no host port (mycelium-gateway is the only entry). This
     # exposes it on :18080 so first calls can be driven directly with a
@@ -224,7 +217,6 @@ services:
       # only in .env (gitignored), never in the committed TOML.
       MYC_PICOCLAW_ALPHA_TOKEN: ${MYC_PICOCLAW_ALPHA_TOKEN}
       MYC_PICOCLAW_BETA_TOKEN: ${MYC_PICOCLAW_BETA_TOKEN}
-      MYC_HERMES_GLM_TOKEN: ${MYC_HERMES_GLM_TOKEN}
       MYC_STANDALONE_BOOTSTRAP_SECRET: ${MYC_STANDALONE_BOOTSTRAP_SECRET}
     volumes:
       - mycelium-data:/data

--- a/docs/ADMIN_GUIDE.md
+++ b/docs/ADMIN_GUIDE.md
@@ -20,7 +20,7 @@ The admin area is reachable from **chat-webapp** to accounts that manage a
 - **Subscription** — one subscription account under a tenant.
 
 The screen is **agent-first**: you choose the agent (`alpha`, `beta`,
-`hermes-glm`, …) before any tenant or subscription, because agents come from the
+…) before any tenant or subscription, because agents come from the
 deployment's proxy configuration and exist before any tenant does. Then you pick
 the scope in the rail, and every section acts on that **(agent, scope)** pair.
 Changes cascade down to the agent containers of the users in that scope.
@@ -212,7 +212,7 @@ chat sidebar, and the app icon. This tab is **staff-only** and is not per-scope.
 ## 10. How roles gate access to an agent
 
 Reaching an agent at all is a **mycelium** concern. The gateway routes are
-`protectedByRoles` (one role per agent: `alpha`, `beta`, `hermes-glm`, …), so an
+`protectedByRoles` (one role per agent: `alpha`, `beta`, …), so an
 account must hold the matching guest-role to talk to that agent, with `write` for
 chat itself. Granting it is either the **Members** tab above (which drives
 mycelium over JSON-RPC for you) or **mycelium-webapp** — Mycelium's own admin UI

--- a/docs/ADMIN_GUIDE.pt-br.md
+++ b/docs/ADMIN_GUIDE.pt-br.md
@@ -19,7 +19,7 @@ A área de admin fica acessível pelo **chat-webapp** para contas que gerenciam 
 - **Tenant** — tudo dentro de um tenant.
 - **Subscription** — uma conta de subscription dentro de um tenant.
 
-A tela é **agent-first**: você escolhe o agente (`alpha`, `beta`, `hermes-glm`, …)
+A tela é **agent-first**: você escolhe o agente (`alpha`, `beta`, …)
 antes de qualquer tenant ou subscription, porque os agentes vêm da configuração do
 proxy deste deploy e existem antes de qualquer tenant. Depois você escolhe o
 escopo na trilha lateral, e cada seção age sobre esse par **(agente, escopo)**. As
@@ -215,7 +215,7 @@ escopo.
 ## 10. Como os papéis liberam o acesso a um agente
 
 Alcançar um agente é assunto do **mycelium**. As rotas do gateway são
-`protectedByRoles` (um papel por agente: `alpha`, `beta`, `hermes-glm`, …), então
+`protectedByRoles` (um papel por agente: `alpha`, `beta`, …), então
 uma conta precisa do guest-role correspondente para falar com aquele agente, com
 `write` para o chat em si. Conceder isso é a aba **Membros** acima (que fala com o
 mycelium por JSON-RPC no seu lugar) ou o **mycelium-webapp** — a UI de admin do

--- a/docs/CREATE_CUSTOM_AGENT.md
+++ b/docs/CREATE_CUSTOM_AGENT.md
@@ -164,11 +164,12 @@ agents:
 > **Mode:** `continuous` keeps the container running so the in-memory session
 > isn't reset between turns; `scale-to-zero` stops it after `idleTimeout`.
 
-> **Harness:** omitting `harness` gives you picoclaw (the default), driven over
-> the Pico Protocol. `harness: hermes` runs a hermes-agent container instead,
-> driven over its OpenAI-compatible API server — see the `hermes-glm` entry in
-> `crab/crab-shell-proxy/config.yaml` for the extra `model` fields it takes
-> (`baseUrl`, `keyEnvName`) and its much longer `startupDeadline`.
+> **Harness:** leave `harness` out. Picoclaw is the only runtime the proxy
+> orchestrates, and it is what an omitted `harness` defaults to. Any other value
+> makes the proxy **refuse to start** — deliberately, so a stale config fails loudly
+> rather than handing a user a picoclaw container under a role provisioned for
+> something else. A second harness was built once and withdrawn; see
+> `.specs/features/hermes-removal/DECISION.md`.
 
 ### 4.5 Register the mycelium route
 
@@ -182,8 +183,8 @@ Do it in **every mode you deploy**, they are separate files:
 
 | Mode | File | Agents it declares today |
 |---|---|---|
-| standalone | `deploy/standalone/config.standalone.toml` | alpha, beta, hermes-glm |
-| prod | `deploy/prod/config.base.toml` | alpha, beta, hermes-glm |
+| standalone | `deploy/standalone/config.standalone.toml` | alpha, beta |
+| prod | `deploy/prod/config.base.toml` | alpha, beta |
 | dokploy | `deploy/dokploy/config.base.toml` | alpha, beta |
 
 The `protectedByRoles` blocks also declare the guest-role: mycelium auto-creates

--- a/docs/CREATE_CUSTOM_AGENT.pt-br.md
+++ b/docs/CREATE_CUSTOM_AGENT.pt-br.md
@@ -168,11 +168,12 @@ agents:
 > ser reiniciada entre turnos; `scale-to-zero` para o container após o
 > `idleTimeout`.
 
-> **Harness:** sem `harness` você tem picoclaw (o padrão), conduzido pelo Pico
-> Protocol. `harness: hermes` roda um container hermes-agent, conduzido pelo
-> servidor de API OpenAI-compatível dele — veja a entrada `hermes-glm` no
-> `crab/crab-shell-proxy/config.yaml` para os campos extras de `model`
-> (`baseUrl`, `keyEnvName`) e o `startupDeadline` bem mais longo que ele exige.
+> **Harness:** deixe `harness` de fora. Picoclaw é o único runtime que o proxy
+> orquestra, e é o padrão quando `harness` é omitido. Qualquer outro valor faz o
+> proxy **recusar o boot** — de propósito, para que uma config obsoleta falhe de
+> forma explícita em vez de entregar um container picoclaw sob um papel provisionado
+> para outra coisa. Um segundo harness foi construído uma vez e retirado; veja
+> `.specs/features/hermes-removal/DECISION.md`.
 
 ### 4.5 Registre a rota no mycelium
 
@@ -187,8 +188,8 @@ Faça isso em **todo modo que você implanta**, são arquivos separados:
 
 | Modo | Arquivo | Agentes que ele declara hoje |
 |---|---|---|
-| standalone | `deploy/standalone/config.standalone.toml` | alpha, beta, hermes-glm |
-| prod | `deploy/prod/config.base.toml` | alpha, beta, hermes-glm |
+| standalone | `deploy/standalone/config.standalone.toml` | alpha, beta |
+| prod | `deploy/prod/config.base.toml` | alpha, beta |
 | dokploy | `deploy/dokploy/config.base.toml` | alpha, beta |
 
 Os blocos `protectedByRoles` também declaram o guest-role: o mycelium cria no


### PR DESCRIPTION
Completes the Hermes withdrawal. **Depends on** crab-shell-proxy#25 and
crab-exoskeleton-webapp#33 — the submodule pointers in this branch target those unmerged
branches, so **merge them first.**

Full decision record, including the OD-1 reasoning and the operational residue list:
`.specs/features/hermes-removal/DECISION.md`.

## Mycelium services

The whole `[[hermes-glm]]` block — service, secret and all 14 paths — is deleted from
`deploy/prod/config.base.toml` and `deploy/standalone/config.standalone.toml`. It ran to EOF in
both, so the cut is clean.

Checked afterwards: **all three TOMLs re-parse**, and the `alpha`/`beta` service definitions are
unchanged — the only `alpha`/`beta` lines in the diff are comments that used to enumerate
`hermes-glm` alongside them.

**There are THREE deploy TOMLs, not the two the spec mapped.** `deploy/dokploy/` already shipped
without the service block but carried commentary explaining its absence relative to an upstream
default that will no longer have one. Reworded so each note stands on its own — along with its
`.env.example` and the mounted `crab-shell-proxy.config.yaml`, whose header also claimed a Hermes
agent auto-disables without its secrets, which the proxy PR makes **false**.

## Compose and env

`MYC_HERMES_GLM_TOKEN` / `PROXY_GLM_API_KEY` are gone from `docker-compose.yaml` (both the proxy
and gateway services) and from **all three** `.env.example` files. `prod`'s was not in the mapped
set either.

## User-facing docs — the real gap, and the only correctness bug here

The spec mapped code thoroughly and **missed every operator-facing doc**. `README`, `ADMIN_GUIDE`
and `CREATE_CUSTOM_AGENT`, in **both locales**, told an operator to set variables nothing reads,
advertised three agents when the stack ships two, and listed `hermes-glm` among the guest-roles.

Worst: **`CREATE_CUSTOM_AGENT` documented `harness: hermes` as a valid choice**, which after the
proxy PR makes the proxy refuse to boot. `harness` is now documented as *omit it*, with any other
value called out as a deliberate hard failure.

Tracked as HRM-58, added to the spec during execution — a README is read as instructions for the
code as it is now, not as a record of what was once true.

## Shipped feature specs are deliberately NOT rewritten

~20 of them mention Hermes, and each is an accurate record of what was true when it shipped. The
withdrawal banners and `DECISION.md` are what a reader finds instead. Only the **living** project
docs are edited.

**TRAP-1 held.** The `zero-scale-stateless-hermes-agent.md` references in `ROADMAP.md`, `STATE.md`
and `.specs/features/crab-shell-proxy/` name **picoclaw's** scale-to-zero architecture, not the
Nous product. Five sites, each judged individually, all left alone — a blanket substitution would
have silently rewritten picoclaw's own architecture record.

`STATE.md`'s "**Hermes still reads it**" claim is corrected, and the caveat it documented —
`config.yaml`'s `agent.Model` is a migration seed with no runtime effect — is **preserved**, since
that is now unconditionally true.

## Also in this branch

The refreshed spec (OD-1 resolved, baseline re-derived against the real revisions, TRAP-7 and
HRM-52..58 added, the grep survivor list rewritten as a pass/fail check), the task breakdown, and
`DECISION.md`.

One follow-up commit repairs six comments the Hermes cut truncated: the project-route note was
three lines but only its first two mentioned Hermes, so the rewrite left a dangling fragment that
also asserted a `501` the proxy PR deletes.

## Verification

- All three deploy TOMLs re-parsed with `tomllib`.
- **No `.env` file committed.** `deploy/standalone/.env` is gitignored and holds a real z.ai key —
  it still carries the dead vars as operator-owned local hygiene, and was never touched here.

**NOT verified: the live stack boot** — compose up, sign in, chat with `alpha` through the gateway,
confirm no picoclaw container was recreated. That needs a running deployment and **should be
exercised before merge.** It is the one gate that would catch a partial routing update.

Known failure mode worth remembering: if only some of the three TOMLs are updated, the proxy
answers a `hermes-glm` turn as an **unknown service** (no agent matches
`x-mycelium-service-name`), not a 500.

🤖 Generated with [Claude Code](https://claude.com/claude-code)