### PR TITLE
ci: publish the patched picoclaw image to GHCR

### DIFF
--- a/.github/workflows/release-picoclaw-glob.yml
+++ b/.github/workflows/release-picoclaw-glob.yml
@@ -1,0 +1,176 @@
+# Build and publish the PATCHED picoclaw image (deploy/picoclaw-glob) to GHCR.
+#
+# Until now this image existed only on whichever machine ran `docker build`, which
+# is why every published-image deploy had to fall back to stock picoclaw and lose
+# the agent-projects feature (see docker-compose.dokploy.yaml's note on
+# CRAB_PICOCLAW_IMAGE). Publishing it removes that fork in the road.
+#
+# WHY NOT `push: branches: [main]`, LIKE THE WEBAPP'S WORKFLOW
+#
+# That image IS the repository. This one is UPSTREAM's source plus two patches, so
+# a commit here almost never changes it -- a README edit or a submodule bump would
+# re-clone picoclaw, re-apply the patches and re-run the Go tests for nothing. And
+# with `latest` resolving to whatever upstream released most recently, an unrelated
+# push could silently republish `:latest` built from a release nobody vetted --
+# defeating the "a patch that no longer applies cleanly is a signal" property the
+# Dockerfile exists to protect. So: manual dispatch, plus pushes that actually
+# touch deploy/picoclaw-glob/.
+#
+# WHICH UPSTREAM VERSION GETS BUILT
+#
+#   dispatch, input `latest` (default)  -> newest sipeed/picoclaw RELEASE, resolved
+#                                          here and logged, so the build still
+#                                          receives a concrete pinned tag
+#   dispatch, input `vX.Y.Z`            -> that tag, validated to exist first
+#   push to deploy/picoclaw-glob/**     -> the ARG default pinned in the Dockerfile
+#
+# That last one is deliberate: a patch edit must be rebuilt against the bytes the
+# patch was written for, not against whatever upstream has shipped since.
+#
+# NO BUILD CACHE HERE, unlike the webapp's workflow. The two `go test` steps inside
+# the Dockerfile ARE this image's acceptance check; with a layer cache a rebuild at
+# the same version replays them and a green run stops being evidence that they ran
+# this time. The build is infrequent -- correctness is worth more than the minutes.
+name: release-picoclaw-glob
+
+on:
+  workflow_dispatch:
+    inputs:
+      picoclaw_version:
+        description: 'sipeed/picoclaw tag to build (e.g. v0.3.1), or "latest" for the newest release'
+        required: false
+        default: latest
+      publish_latest:
+        description: 'Also tag the image as :latest'
+        type: boolean
+        required: false
+        default: true
+  push:
+    branches: [main]
+    paths:
+      - 'deploy/picoclaw-glob/**'
+      - '.github/workflows/release-picoclaw-glob.yml'
+
+concurrency:
+  group: release-picoclaw-glob
+  cancel-in-progress: false
+
+env:
+  IMAGE: ghcr.io/lepistabioinformatics/picoclaw
+
+jobs:
+  build-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      # Resolve and VALIDATE before the build. `git clone --branch <x>` fails deep
+      # inside the Dockerfile with an error that doesn't name the real problem, so a
+      # bad version is caught here instead -- cheaply, and in words.
+      - name: Resolve picoclaw version
+        id: ver
+        env:
+          GH_TOKEN: ${{ github.token }}
+          INPUT: ${{ inputs.picoclaw_version }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${INPUT}" ]; then
+            # push event: the pin the patches were written against, read from the
+            # Dockerfile so this workflow never becomes a second place to update.
+            TAG="$(grep -m1 -oE '^ARG PICOCLAW_TAG=.+' deploy/picoclaw-glob/Dockerfile | cut -d= -f2)"
+            echo "push event -- using the Dockerfile pin: ${TAG}"
+          elif [ "${INPUT}" = "latest" ]; then
+            TAG="$(gh api repos/sipeed/picoclaw/releases/latest --jq .tag_name)"
+            echo "input 'latest' resolved to the newest release: ${TAG}"
+          else
+            TAG="${INPUT}"
+            echo "explicitly requested version: ${TAG}"
+          fi
+
+          if [ -z "${TAG}" ]; then
+            echo "::error::Could not determine which picoclaw version to build."
+            exit 1
+          fi
+
+          # Does it actually exist? A 404 here is far more legible than a clone
+          # failing halfway through the build.
+          if ! gh api "repos/sipeed/picoclaw/git/ref/tags/${TAG}" >/dev/null 2>&1; then
+            echo "::error::Tag '${TAG}' does not exist in sipeed/picoclaw."
+            exit 1
+          fi
+
+          # v0.3.1 -> 0.3.1-glob, the name docker-compose.dokploy.yaml already cites.
+          echo "tag=${TAG}"              >> "$GITHUB_OUTPUT"
+          echo "image_tag=${TAG#v}-glob" >> "$GITHUB_OUTPUT"
+
+      - name: Decide tags
+        id: tags
+        env:
+          EVENT: ${{ github.event_name }}
+          INPUT: ${{ inputs.picoclaw_version }}
+          WANT_LATEST: ${{ inputs.publish_latest }}
+          IMAGE_TAG: ${{ steps.ver.outputs.image_tag }}
+        run: |
+          set -euo pipefail
+          TAGS="${IMAGE}:${IMAGE_TAG}"
+
+          # `:latest` only on a dispatch that asked for "latest" and ticked the box.
+          #
+          # A push to deploy/picoclaw-glob/** is excluded on purpose: it builds the
+          # Dockerfile's PIN, so moving :latest to it would demote the tag if a newer
+          # version had already been published. A dispatch with a hand-picked version
+          # is excluded for the same reason -- that's the kind of regression that
+          # ships silently and confuses everyone months later.
+          if [ "${EVENT}" = "workflow_dispatch" ] \
+             && [ "${INPUT}" = "latest" ] \
+             && [ "${WANT_LATEST}" = "true" ]; then
+            TAGS="${TAGS}"$'\n'"${IMAGE}:latest"
+          fi
+
+          {
+            echo "list<<TAGS_EOF"
+            echo "${TAGS}"
+            echo "TAGS_EOF"
+          } >> "$GITHUB_OUTPUT"
+          echo "tags to publish:"; echo "${TAGS}"
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: deploy/picoclaw-glob
+          file: deploy/picoclaw-glob/Dockerfile
+          platforms: linux/amd64
+          push: true
+          build-args: |
+            PICOCLAW_TAG=${{ steps.ver.outputs.tag }}
+          tags: ${{ steps.tags.outputs.list }}
+          labels: |
+            org.opencontainers.image.title=picoclaw (zombie-crab patches)
+            org.opencontainers.image.description=sipeed/picoclaw ${{ steps.ver.outputs.tag }} + dispatch-selector-glob + vision-unsupported-glm
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.version=${{ steps.ver.outputs.image_tag }}
+
+      - name: Summary
+        run: |
+          {
+            echo "### picoclaw-glob published"
+            echo ""
+            echo "- upstream: \`${{ steps.ver.outputs.tag }}\`"
+            echo "- image: \`${IMAGE}:${{ steps.ver.outputs.image_tag }}\`"
+            echo ""
+            echo "The routing and vision \`go test\` suites ran inside the build,"
+            echo "with no layer cache -- so this result is from this run."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/deploy/picoclaw-glob/Dockerfile
+++ b/deploy/picoclaw-glob/Dockerfile
@@ -52,6 +52,20 @@
 # on an upgrade, which is exactly what should happen: the ~15 changed lines need
 # to be re-checked against the new upstream, not silently skipped or
 # fuzzy-applied. Bump PICOCLAW_TAG deliberately, and re-run the routing tests.
+#
+# WHERE THE PUBLISHED IMAGE COMES FROM
+#
+# This image no longer has to be built by hand:
+# .github/workflows/release-picoclaw-glob.yml publishes it to
+# ghcr.io/lepistabioinformatics/picoclaw as `<version>-glob` (plus `latest`), so a
+# deploy that pulls every other image can pull this one too. The workflow always
+# passes PICOCLAW_TAG explicitly -- resolving "latest" to a concrete release tag
+# first, never handing a moving ref to the clone below.
+#
+# The ARG default therefore governs only a local `docker build` and a rebuild
+# triggered by editing the patches. That case wants the pin, not the newest
+# release: a patch edit must be validated against the bytes the patch was written
+# for. Keep it a concrete tag.
 
 ARG PICOCLAW_TAG=v0.3.1
 


### PR DESCRIPTION
## What

Adds `.github/workflows/release-picoclaw-glob.yml`, which builds `deploy/picoclaw-glob/` and publishes it to `ghcr.io/lepistabioinformatics/picoclaw` as `<version>-glob` (plus `latest`) — the name `docker-compose.dokploy.yaml` already suggested in its `CRAB_PICOCLAW_IMAGE` note.

## Why

The patched image could only ever be built by hand, so it existed on one dev machine. Every published-image deploy therefore had to point `CRAB_PICOCLAW_IMAGE` at stock picoclaw and silently lose the agent-projects feature: stock picoclaw matches `agents.dispatch` selectors by exact string equality, so the wildcard rule never fires and every project chat is answered by the main agent.

## Design notes

**Trigger is `workflow_dispatch` + pushes touching `deploy/picoclaw-glob/**`**, not every push to `main` like the webapp's workflow. That image *is* the repository; this one is upstream's source plus two patches, so a README edit or a submodule bump would re-clone, re-patch and re-test for nothing. And with `latest` resolving dynamically, an unrelated push could republish `:latest` from a release nobody vetted — defeating the "a patch that no longer applies cleanly is a signal" property `Dockerfile` exists to protect.

**Version resolution**, always to a concrete tag before the build:

| Trigger | `PICOCLAW_TAG` |
|---|---|
| dispatch, input `latest` (default) | newest `sipeed/picoclaw` release, resolved and logged |
| dispatch, input `vX.Y.Z` | that tag, validated to exist first |
| push to `deploy/picoclaw-glob/**` | the `ARG` pin read from the Dockerfile |

The push case is deliberate: a patch edit must be rebuilt against the bytes the patch was written for. Reading the pin from the Dockerfile keeps this workflow from becoming a second place to update.

**Validation before the build** — `git clone --branch <x>` fails deep inside the Dockerfile with an error that doesn't name the real problem, so an unknown tag is rejected up front with one that does.

**No layer cache**, unlike the webapp's workflow. The two `go test` steps inside the Dockerfile are this image's acceptance check; cached, they replay and a green run stops being evidence that they ran this time. The build is infrequent — correctness is worth the minutes.

**`:latest` only on a dispatch that asked for `latest`.** Never from a push event (which builds the pin) and never from a hand-picked version — moving that tag backwards is the kind of regression that ships silently.

## One-time step after merge

Confirm the GHCR package is **public** in its settings, so deploys can pull it unauthenticated. If it lands private, every host pulling it needs a registry credential.

## Not in this PR

`docker-compose.dokploy.yaml` still defaults `CRAB_PICOCLAW_IMAGE` to stock picoclaw, and its comment still explains why. Flipping that default is a product decision for this repo's maintainers, not a side effect of publishing the image — happy to follow up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)