### PR TITLE
docs(specs): spec the prevention half of the cut-stream problem; close the dock

### DIFF
--- a/.specs/features/background-turn-dock/spec.md
+++ b/.specs/features/background-turn-dock/spec.md
@@ -1,7 +1,8 @@
 # background-turn-dock — Spec
 
-**Status:** Implemented 2026-08-18, T-01..T-09. T-10 (operator verification against a
-live stack) NOT run — it is the only check that can falsify the feature end to end.
+**Status:** **FINISHED.** Implemented 2026-08-18 (T-01..T-09); T-10, the operator
+verification against a live stack, run and confirmed by the maintainer 2026-08-27. The
+feature is deployed. Four non-blocking improvements are listed at the end of `tasks.md`.
 One deviation, recorded in `tasks.md`: the mobile dock sits BELOW the composer, not above
 it (DEC-11 / FR-U8), because the composer lives inside the component the dock must
 outlive. FR-U1a amends the segment styling after first use (lane colours from the tree).

--- a/.specs/features/background-turn-dock/tasks.md
+++ b/.specs/features/background-turn-dock/tasks.md
@@ -202,7 +202,15 @@ resolve and not on subsequent re-renders.
 
 ## T-10 — operator verification (gated on a live stack)
 
-**Status: NOT RUN.** Needs the deployed stack; cannot be executed from a dev checkout.
+**Status: DONE — verified against the live stack by the maintainer, 2026-08-27.**
+The feature is deployed and exercised; T-01..T-10 are complete and `background-turn-dock`
+is **finished**.
+
+**Recorded honestly:** the six steps below were confirmed as a whole, not captured
+step-by-step, so this file does not claim per-step observed output it does not have. If a
+regression is ever suspected, re-run them individually — the steps are still the right
+script, and step 6 in particular (no container provisioned by the restore fan-out) is the
+one whose failure would be silent and expensive.
 
 **What.** The only check that can falsify the feature.
 **Depends on.** T-01..T-09.
@@ -220,6 +228,30 @@ resolve and not on subsequent re-renders.
 6. Confirm no container was provisioned by the restore fan-out (FR-P7) — check the proxy
    log for the reload.
 **Done when.** All six recorded in this spec directory with the observed output.
+*(Closed as above: confirmed as a whole rather than per step.)*
+
+---
+
+## Remaining improvements — the feature is finished, these are not blockers
+
+Kept here rather than in `## Not tasks` because, unlike the OQs, these are gaps in work
+that shipped rather than decisions that were deferred.
+
+**I-01 — T-06's route still has no test of its failure arms.**
+`app/api/chat/[instance]/running/route.ts` is now exercised in production, which is
+stronger evidence for the happy path than a unit test would be. It says nothing about the
+arms production does not routinely take: the row filter, `MyceliumConnectivityError` → 502
+`connectivity`, and 401 → `clearSession`. T-06's own status already warns that "T-07 covers
+it" is false — T-07 stubs `fetch` wholesale and never executes the file. Blocked on the
+repo having no route-test harness, which is why this is an improvement and not a defect.
+
+**I-02 — OQ-3, pruning `turns`.** DEC-8 leaves the map unpruned and this feature is what
+made that observable. Its own decision, unchanged by the feature being finished.
+
+**I-03 — OQ-2, a cap on the FR-R1 fan-out.** "Measure before capping" still stands; the
+deploy is what makes measuring possible for the first time.
+
+**I-04 — OQ-1, tab-title/favicon badging.** Deferred, not rejected.
 
 ---
 

--- a/.specs/features/picoclaw-incremental-streaming/investigation.md
+++ b/.specs/features/picoclaw-incremental-streaming/investigation.md
@@ -1,0 +1,205 @@
+# picoclaw-incremental-streaming — Feasibility Investigation
+
+**Status:** Investigation (pre-spec). No implementation, no commitment.
+**Date:** 2026-08-27.
+**Written alongside:** `.specs/features/turn-stream-continuity/` — read its `spec.md`
+DEC-8 first for why this is a *separate* feature and not part of that one.
+**picoclaw in production:** `ghcr.io/lepistabioinformatics/picoclaw:0.3.1-glob` — upstream
+`v0.3.1` plus this repo's two patches (`deploy/picoclaw-glob/`).
+
+## The question, as asked
+
+> *"Considere até se não houver uma maneira nativa, a possibilidade de implementarmos uma
+> conexão http no picoclaw para que melhoremos essa experiência."*
+
+## The framing correction that decides the answer
+
+**A different transport between the proxy and picoclaw cannot help, and it is worth being
+precise about why.**
+
+The member's symptom lives between their browser and mycelium. proxy ↔ picoclaw is
+server-to-server inside the Docker network: same host, no TLS, no edge proxy, no NAT, no
+carrier. Nothing about the member's connection reaches that hop, so replacing its
+WebSocket with HTTP changes nothing they would ever notice. The WebSocket is also not
+incidental — `internal/pico/turn.go` speaks picoclaw's Pico Protocol over it, and that
+protocol is bidirectional and frame-oriented in a way an HTTP request/response is not.
+
+**But there is a real picoclaw-side item behind the question, and it is upstream of the
+entire `turn-stream-continuity` feature.**
+
+picoclaw answers in **one terminal frame**. Measured, `chat-responsiveness` OQ-1, a trace
+in `processor.handle` over two real turns:
+
+```
+01:43:55  typing.start
+          …51 seconds of complete silence…
+```
+
+then the whole reply at once. That silence is what makes the SSE idle, what makes the idle
+connection reclaimable, and what makes `turn-store.ts`'s reveal driver a *simulation* of
+streaming rather than streaming — its own header says so. Every mitigation in
+`turn-stream-continuity` works around that silence. **This investigation is about removing
+it.**
+
+## 1. The proxy is already a streaming consumer — this is the load-bearing finding
+
+`internal/pico/turn.go:179` handles `"message.create"` **and `"message.update"`** in the
+same branch, and the branch is written for incremental delivery:
+
+```go
+prev := p.plain[pl.MessageID]
+p.plain[pl.MessageID] = pl.Content
+p.lastPlainID = pl.MessageID
+p.hasPlainContent = true
+// Cumulative content: emit only the newly-appended suffix.
+if len(pl.Content) > len(prev) {
+    p.sink.EmitContent(pl.Content[len(prev):])
+}
+```
+
+Cumulative-content bookkeeping, per `MessageID`, emitting only the new suffix. That is a
+delta consumer. `EmitContent` lands in `sse.go`'s `Content` sink, which writes an ordinary
+OpenAI content chunk to the browser.
+
+So: **if picoclaw sent updates, the proxy would already forward them as deltas, and the
+webapp would already render them.** No proxy change, no webapp change. The failure to
+stream is entirely upstream of `internal/pico`.
+
+Two smaller things fall out of the same read, and both are already correct:
+
+- The failure-detection path (`isProcessingError`) is deliberately tested against the
+  **cumulative** content and not the suffix, *"so a failure whose text arrives as an
+  update after a partial would otherwise slip through"*. Someone already thought about
+  updates arriving.
+- Attachment frames are handled **before** the plain-content branch, so a delivery cannot
+  erase the answer. Incremental updates do not disturb that ordering.
+
+## 2. picoclaw has a streaming interface, and its own pico channel implements it
+
+From `picoclaw-as-library/investigation.md` §2.5, recorded there as read in `v0.3.1` and
+not inferred:
+
+> Streaming: `StreamingCapable.BeginStream(ctx, chatID) (bus.Streamer, error)`, where
+> `Streamer` is `{Update, Finalize, Cancel}`. The pico channel implements it
+> (`pico.go:514`), so the path is exercised in production today.
+
+`Update` / `Finalize` / `Cancel` is exactly the shape that would produce
+`message.update` … `message.update` … `message.create`.
+
+**So the interface exists, the channel we use implements it, and the consumer already
+handles it — and yet the measured wire shows one frame.** That gap is the whole
+investigation, and it is *not yet explained*.
+
+## 3. What must be established before anything is proposed
+
+Ordered by cost, cheapest first. **Do not skip to (d).**
+
+**(a) Re-measure on the deployed image.** The 51s trace is from 2026-07-28. The deployed
+harness is `0.3.1-glob`. Confirm the one-frame behaviour still holds before investigating
+a behaviour that may have changed — the same trace in `processor.handle`, or simply
+logging every frame type and `MessageID` for one long turn.
+
+**(b) Read `pico.go:514` and its callers in `v0.3.1`.** Under what conditions does the
+pico channel's `BeginStream` get used? The likely candidates, none of them verified here:
+the agent loop only calls it for some message classes; it is gated on a config key; it is
+used for the *typing* indicator rather than for content; or the LLM call itself is
+non-streaming so there is nothing to update *with*.
+
+**(c) Check whether it is a configuration question.** `pkg/agent`/`pkg/config` in `v0.3.1`
+for anything gating streaming or the provider call's `stream` flag. **If this is a config
+key, the whole feature is a config change** and everything below is moot. It is the
+highest-value hour in this document precisely because it might end it.
+
+**(d) Only then**, size a code change — and see §4 for what "code change" costs here,
+which is much less than it would normally be.
+
+**None of (b) or (c) can be answered from this repository.** picoclaw's source is not
+vendored; `deploy/picoclaw-glob/` holds only two patches and a Dockerfile that clones
+upstream at build time. Answering them means reading `sipeed/picoclaw` at the `v0.3.1`
+tag. **Anything asserted about picoclaw's internals without that read is a guess, and this
+document does not contain one.**
+
+## 4. Delivery is already solved, and that changes the cost
+
+This is the second finding that matters, and it is easy to miss.
+
+**This stack already ships its own patched picoclaw.** `deploy/picoclaw-glob/` holds
+`dispatch-selector-glob.patch` and `vision-unsupported-glm.patch`; the
+`release-picoclaw-glob` workflow clones upstream at a pinned tag, applies them, runs
+upstream's Go tests, and publishes to GHCR; the deployed image is that output.
+
+So a picoclaw-side change is **a third patch in an existing, tested pipeline** — not a
+fork, not a vendored copy, not an upstream PR to wait on. The workflow's own comments
+already encode the discipline it needs: *"a patch that no longer applies cleanly is a
+signal"*, no build cache so the tests are real evidence every time, and a patch edit
+rebuilds against the bytes the patch was written for.
+
+That said, the ordering in §3 stands. A patch is cheap to *ship* and permanent to
+*maintain* — every upstream bump re-applies it — so a config key beats a patch, and an
+upstream-supported path beats both.
+
+## 5. What it would be worth
+
+Assuming (a)-(d) land somewhere useful:
+
+- **The silence goes away at the source.** Not filled with pings (`turn-stream-continuity`
+  Group A) — actually filled, with the answer. Every hop's idle timeout stops being
+  relevant, and Group C's re-attach loses most of its remaining reason to exist.
+- **The typewriter becomes real.** `turn-store.ts`'s reveal driver exists solely because
+  *"picoclaw does NOT stream: it returns the whole answer in one frame"*. With real
+  deltas, `REVEAL_MS_PER_WORD` / `REVEAL_TOTAL_MS` / `REVEAL_MAX_STEPS` and the whole
+  O(n²) re-render problem they were tuned around become a much smaller problem, or none.
+- **Perceived latency drops to first-token.** Today it is whole-answer. This is the single
+  largest available improvement to how the chat *feels*, and it is bigger than anything in
+  `turn-stream-continuity`.
+- **It does not fix cuts on its own.** A member on a genuinely broken connection still
+  loses the stream. Prevention plus recovery still earn their keep — this reduces how
+  often they are needed, it does not replace them.
+
+## 6. What it would cost, beyond the patch
+
+- **Maintenance on every upstream bump** (§4). Real, recurring.
+- **A steering-message interaction to re-check.** `picoclaw-as-library` §3.1: turns are
+  serialized per session key and a second message for an active session is folded in as a
+  *steering message*, not answered separately. Whether that interacts with a stream in
+  progress is unknown and would need reading.
+- **The proxy's completion heuristic gets harder, not easier.** `internal/pico/turn.go`
+  finalises on "real content has arrived AND typing has stopped" after a 500ms
+  `graceWindow`. More frames per turn means more chances for that window to be crossed at
+  a bad moment. This is the same race `picoclaw-as-library` §5 calls *"tuned rather than
+  solved"* — and it is an argument for reading that document before this one is turned
+  into a spec, because the library route removes the race entirely instead of stressing
+  it.
+- **Nothing in the webapp.** Deltas already render; that is §1.
+
+## 7. Verdict
+
+**The transport question is answered: no.** An HTTP connection between the proxy and
+picoclaw addresses the wrong hop and would improve nothing the member can perceive.
+
+**The framing question is open and worth an hour.** picoclaw exposes a streaming
+interface, the channel we use implements it, and the proxy already consumes deltas
+correctly — so the measured one-frame behaviour is unexplained, and the explanation might
+be a config key. §3(a)-(c) is the cheapest high-value work available anywhere near this
+problem, and it is cheap enough that it should happen regardless of what
+`turn-stream-continuity` does.
+
+**Sequencing:** after `turn-stream-continuity` Group A. Group A is smaller, needs no
+upstream knowledge, and reduces the harm this would remove — but this is the one that
+removes the cause. If §3(c) finds a config key, promote it immediately, ahead of
+everything else in either document.
+
+## Open questions
+
+**OQ-1 — Does the one-frame behaviour still hold on `0.3.1-glob`?** §3(a). Everything
+here rests on a measurement from 2026-07-28.
+
+**OQ-2 — Why does `BeginStream` not produce `message.update` frames on our path?** §3(b).
+The central unknown. Not answerable from this repository.
+
+**OQ-3 — Is streaming gated by configuration?** §3(c). If yes, this document is obsolete
+and the answer is a config change.
+
+**OQ-4 — Would incremental delivery destabilise the proxy's 500ms `graceWindow`?** §6.
+The failure mode is a turn finalised early, mid-answer — which would be a *worse* bug than
+the one being fixed, so this must be answered before any patch ships, not after.

--- a/.specs/features/steering-messages/investigation.md
+++ b/.specs/features/steering-messages/investigation.md
@@ -1,0 +1,115 @@
+# steering-messages — Feasibility Investigation
+
+**Status:** Investigation (pre-spec). No implementation, no commitment.
+**Date:** 2026-08-27.
+**Verdict on the immediate question:** **not part of `turn-stream-continuity` — next
+feature.** Reasons in §4. But it interacts with that feature's Group C in a way that must
+be written down *now*, and §5 is that note.
+
+## The question
+
+picoclaw can fold a message that arrives mid-turn into the turn already running, instead
+of answering it as a separate turn. Does this stack use it, and should
+`turn-stream-continuity` pick it up?
+
+## 1. picoclaw supports it. This stack cannot reach it.
+
+**Upstream (from `picoclaw-as-library/investigation.md` §3.1, read in `v0.3.1`):** turns
+are serialized per session key; a second message for an already-active session *"is not a
+second turn. It is enqueued as a steering message folded into the running turn"* —
+`enqueueSteeringMessage`, consumed at `turn_coord.go:115`.
+
+**This stack never sends one.** The webapp holds it in a client-side queue and does not
+POST it until the previous turn has fully finished:
+
+- `flushPending` (`turn-store.ts`) turns a burst into one entry on `queue` and calls
+  `drain`.
+- `drain` loops `await runTurn(...)` then `await awaitDrained(sid)` — the second wait is
+  for the *reveal* to finish, not merely for arrival, *"without this the next runTurn
+  resets `revealed`/`buffered` and the previous reply is wiped off the screen
+  mid-sentence"*.
+- `draining` is a synchronous flag precisely so two bursts cannot run concurrently.
+
+So the second message is POSTed strictly after the first turn's stream has ended. picoclaw
+sees two sequential turns and its steering path is **structurally unreachable** from
+zombie-crab. This is not an oversight — the queue was built to fix a real defect — but it
+does mean the capability is unused.
+
+The proxy imposes nothing here either: nothing in `sse.go` or `handlers.go` serializes per
+session. A concurrent POST would reach picoclaw and *would* be folded. Only the browser
+prevents it.
+
+## 2. What using it would buy
+
+The member types a correction ten seconds into a five-minute turn — "na verdade, só o Q3"
+— and the agent takes it into account instead of finishing the wrong answer and then
+starting a second five-minute turn. On long turns that is the difference between one wasted
+turn and none, and long turns are exactly this stack's problem case.
+
+## 3. What it would cost, and where it bites
+
+Three real interactions, none of them cosmetic.
+
+**3.1 — Two POSTs, one turn: the wire semantics are undefined.**
+A steering POST is a `chat/completions` request that will never get its own answer — its
+content lands in the *first* request's stream. Today's client assumes one POST → one
+stream → one reply. Something has to say what the second stream returns: an immediate
+`[DONE]` with no content, a distinct `x_crab_steering` acknowledgement, or a refusal. All
+three are defensible; none exists.
+
+**3.2 — The proxy's completion heuristic gets harder.**
+`internal/pico/turn.go` finalizes on "real plain content has arrived AND typing has
+stopped", after `graceWindow = 500ms`. A steering message injects more agent activity into
+a turn the proxy may already have armed to finalize. `picoclaw-as-library` §5 already calls
+this race *"tuned rather than solved"*; steering stresses it directly, and the failure mode
+is a turn finalized mid-answer — worse than the bug being fixed.
+
+**3.3 — The webapp's whole queue would need rethinking, not extending.**
+`drain`'s two awaits exist to protect the reveal buffer. Steering means a running turn's
+reveal receives content provoked by a message the member sent *after* it started. That is
+not a change to the queue; it is a change to what a "turn" is on screen.
+
+## 4. Why it is not part of `turn-stream-continuity`
+
+Different problem, different failure, different surface. `turn-stream-continuity` is about
+**bytes staying on the wire** — heartbeats, an inactivity bound, re-attach. Steering is
+about **what a message means when one is already running** — turn semantics, in picoclaw
+and in the proxy's completion machine.
+
+Folding it in would also break that feature's own discipline: its Non-goals protect
+`RunTurn`, the picoclaw processor and the completion heuristic, and §3.2 lands squarely on
+the last of those. A feature that prevents connection cuts should not also be the feature
+that renegotiates the turn boundary.
+
+**Sequencing:** after `turn-stream-continuity`, and read together with
+`picoclaw-incremental-streaming` — both are picoclaw-semantics work, both touch the
+`graceWindow` race, and doing them as one study is cheaper than twice.
+
+## 5. The forward-compatibility note that must not be lost
+
+**`turn-stream-continuity` Group C keys its frame log `memgraph.Scope → sessionID`, which
+assumes at most one turn in flight per conversation.** That assumption is true today
+*because of the webapp queue in §1*, not because anything enforces it. Steering makes a
+second POST arrive for a conversation that already has a live log.
+
+If Group C is built, its log must either key by turn rather than by conversation, or
+document the single-turn assumption explicitly so steering is a known migration and not a
+surprise. **This is cheap to get right up front and expensive to retrofit** — it is the one
+concrete reason this investigation was written before the feature it defers to.
+
+(`turnRegistry` itself is already fine: `Begin` is re-entrant and counts, and
+`background-turn-dock` DEC-4 made `since` first-seen, so a steering POST would correctly
+keep the original turn's start time rather than resetting it.)
+
+## Open questions
+
+**OQ-1 — What does the steering POST's own stream return?** §3.1. The first thing to
+decide; everything else follows from it.
+
+**OQ-2 — Does folding a steering message disturb the 500ms `graceWindow`?** §3.2. Must be
+answered before any implementation, not after.
+
+**OQ-3 — Is there an upstream signal that a message was folded rather than answered?**
+Not established. Without one the client cannot tell steering from a dropped message, and
+would have to infer it from the absence of a second reply. Needs a read of
+`turn_coord.go:115` and its surroundings in `v0.3.1`.

--- a/.specs/features/turn-stream-continuity/context.md
+++ b/.specs/features/turn-stream-continuity/context.md
@@ -1,0 +1,193 @@
+# turn-stream-continuity — Context
+
+What was established before this feature was written, and where each fact came from.
+None of it is re-derived in `spec.md` or `design.md`; it is recorded so nobody has to
+re-derive it either.
+
+## 1. Which of the existing answers are actually running
+
+This is the fact that decided the feature's shape, and it is the one most likely to go
+stale — re-check it before trusting the rest of this section.
+
+The live deploy pins `CHAT_WEBAPP_TAG=sha-d8f9aa7`
+(`zombie-crab-project-mkt/deploy/dokploy/.env.example:96`), which is the merge of
+`crab-exoskeleton-webapp#45`. Against that commit, in the webapp submodule:
+
+| Commit | Feature | In `sha-d8f9aa7`? |
+|---|---|---|
+| `d03aa2a` | recover a cut turn instead of losing it (`long-turn-resilience`) | **yes** |
+| `94387cd` | keep the "reply never arrived" banner long enough to read it | **yes** |
+| `696722f` | stop a running turn | **yes** |
+| `84359df` | a stop that raced the turn's own ending | **yes** |
+| `a46df19` | pick a running turn back up after a reload (`resume-turn-after-reload`) | **yes** |
+| `06beb19` | keep background turns visible in a dock (`background-turn-dock`) | **no** |
+| `c7a8d03` | any file type, paste and drag-and-drop | **no** |
+
+Reproduce with:
+
+```
+git -C crab/crab-exoskeleton-webapp merge-base --is-ancestor <commit> d8f9aa7
+```
+
+**AMENDED 2026-08-27 — the dock has since been deployed and its T-10 confirmed.** The
+table above is the state at the time this feature was specified, and it is kept because it
+is what shaped the feature. The current state is: the dock ships, `background-turn-dock` is
+finished, and P-0's deploy half is satisfied.
+
+**What survives the amendment — the finding that decided the feature's shape.**
+The member filing this complaint was on a build that **already had** transcript-growth
+recovery and reload resume. So the complaint was never "recovery was never built"; it is
+that recovery is not enough. That is what makes prevention (Group A) the deliverable rather
+than a re-implementation, and it is unaffected by the dock landing.
+
+**What the amendment retires.** The second consequence — that part of the complaint might
+have been the dock's absence rather than a cut — is no longer a live confound. It is also
+why P-0's *baseline* half still matters: the pre-heartbeat count must be taken on the
+dock-carrying build, which now exists, so the T-08 gate has something honest to compare
+against.
+
+**Stale in this file, deliberately not "fixed":** `deploy/dokploy/.env.example:96` still
+reads `CHAT_WEBAPP_TAG=sha-d8f9aa7`, which is *not* the deployed tag any more. The real
+value lives in Dokploy's own env, and `.env.example` has drifted from it. That drift is
+exactly the shape of `L-007` (`zombie-crab-project-mkt` commit `a6856e4`): Dokploy runs
+`docker compose up -d --build` **without** `--pull always`, so a deploy that trusts a stale
+example tag can put the host back on a cached older image. **Worth correcting in
+`.env.example` to whatever is actually deployed** — it is not corrected here because this
+file must not guess at a tag it has not read.
+
+## 2. picoclaw answers in one frame, and that is where the silence comes from
+
+`chat-responsiveness` spec, OQ-1, **answered by measurement** on 2026-07-28 — a temporary
+trace in `processor.handle` over two real turns:
+
+```
+01:43:55  typing.start
+          …51 seconds of complete silence…
+```
+
+then the reply, whole, in one `message.create`. The proxy's `internal/pico/turn.go`
+processor is built around this: it finalizes only once real content has arrived **and**
+typing has stopped, after a 500ms grace window, because picoclaw wraps every outbound
+message in its own typing pair.
+
+**Consequence for us:** the turn-store's reveal driver ("typewriter") is a simulation of
+streaming, not streaming — `turn-store.ts`'s own header says so. And the SSE between the
+proxy and the browser has nothing to carry for those 51 seconds, because there is nothing
+to carry.
+
+## 3. The proxy never writes on its own schedule
+
+`internal/httpapi/sse.go`. Every writer — `writeChunk`, `writeProgress`, `writeError` —
+is called from a `turn.Sink` callback, i.e. only when picoclaw emits. The one unprompted
+write is the initial role chunk, flushed before `EnsureRunning` so a cold start cannot
+trip the gateway (design D9). After that the stream is exactly as talkative as the agent.
+
+There is no ticker, no keep-alive, and no `event:` or comment frame anywhere in the file.
+
+**Consequence for us:** Group A is genuinely new behaviour in this file, not a knob.
+
+## 4. All writes today happen on one goroutine
+
+Same file. `streamTurn` runs on the request goroutine; `RunTurn` is called synchronously
+from it and invokes the sinks inline. So the `http.ResponseWriter` has exactly one writer
+and needs no lock — which is why there isn't one.
+
+**Consequence for us:** FR-5. A heartbeat ticker is a second goroutine writing the same
+`ResponseWriter`, and adding it without serializing is a data race, not a style question.
+
+## 5. The turn survives the client; the view does not
+
+`sse.go:109-117` (as cited by `long-turn-resilience/context.md`) runs the turn on
+`context.WithTimeout(context.Background(), turnTimeout)` — deliberately **not**
+`r.Context()` — with `turnTimeout = 10 * time.Minute`. The client context only decides
+whether to keep *writing*; every sink early-returns on `clientCtx.Err() != nil` while the
+turn keeps draining.
+
+The comment there names the bug that made it this way: tying the turn to the request
+cancelled the picoclaw WebSocket mid-turn on disconnect, and picoclaw persisted a
+truncated transcript.
+
+**Consequence for us:** this is what makes Group C possible at all. There is a live turn
+to re-attach *to*, for up to ten minutes after the socket died.
+
+## 6. `x_crab_error` and `x_crab_progress` set the extension convention
+
+Both ride as an extra **top-level** field on an otherwise-normal chunk with an **empty
+delta**, and `sse.go` explains why in a comment: a client that knows nothing about them
+reads `choices[0].delta.content`, finds nothing, and skips the frame. A named SSE event
+(`event: progress`) would instead be *dropped wholesale* by `data:`-only parsers.
+
+**Consequence for us:** DEC-3 deliberately does *not* follow this convention for the
+sequence number, and the difference is the point — `id:` is not an extension being
+smuggled through a payload, it is the SSE field designed for this, and the frames it
+labels are unchanged.
+
+## 7. `lastEventAt` is load-bearing for two separate readouts
+
+`background-turn-dock` DEC-12, verbatim on the intent: the band's "quiet for" and the
+dock's chip both derive from `lastEventAt`, so *"a chip and the band it corresponds to can
+never disagree"*. It is stamped in `runTurn`'s `onDelta` and `onProgress` callbacks
+(`turn-store.ts`), and nowhere else.
+
+`long-turn-resilience` FR-12 is what it serves: *"After the existing silence grace window,
+the band shows how long the turn has been running. A number that visibly advances is the
+strongest available signal that the chat is not stuck."*
+
+**Consequence for us:** FR-2 / DEC-6. A heartbeat that stamps `lastEventAt` pins that
+number at zero and silently deletes the feature. The comment-frame shape avoids it *by
+construction*, because `consumeStream` filters non-`data:` lines before any callback runs.
+
+## 8. The BFF is a byte pipe, with one unexamined default
+
+`app/api/chat/[instance]/route.ts` POSTs to mycelium through `fetchMycelium` and then
+returns `new Response(res.body)` — the upstream SSE bytes, unmodified. It sets
+`Content-Type`, `Cache-Control: no-cache` and `Connection: keep-alive`.
+
+`fetchMycelium` (`lib/mycelium.ts:79`) is `await fetch(url, init)` with no dispatcher and
+no options beyond what the caller passes. The runtime is `node:24-alpine`
+(webapp `Dockerfile`), Next `^15.5.21`, and `undici` is **not** a direct dependency.
+
+**Consequence for us:** whatever inactivity behaviour the runtime's default HTTP client
+has, the streaming route inherits it — including on a body that is legitimately silent for
+minutes. This spec does **not** assert what that default is (OQ-2); T-04 measures it. The
+same call is used by every other route, where an inactivity bound is a *feature*, which is
+FR-9.
+
+## 9. The edge, as far as it is known
+
+`zombie-crab-project-mkt/deploy/dokploy/docker-compose.yaml`: Traefik fronts the webapp
+(`traefik.http.services.zombie-chat.loadbalancer.server.port=3000`) and the landing.
+`crab-shell-proxy` is deliberately **not** behind Traefik — *"quem publica os agentes é o
+mycelium"* — so the browser's path is:
+
+```
+browser → Traefik → Next BFF (3000) → mycelium-gateway (8080) → crab-shell-proxy
+```
+
+No idle/read/write timeout is configured on any of these in the compose file. That is not
+the same as there being none: Traefik, the Go server, mycelium's client and the browser
+all have defaults, and the member's own network has no defaults at all. Group A is written
+to be indifferent to which one bites.
+
+## 10. Where the pieces already are
+
+**Proxy (`crab-shell-proxy`)**
+- `internal/httpapi/sse.go` — `streamTurn`, all four writers, `done()`, `turnTimeout`.
+- `internal/httpapi/turn_registry.go` — `Begin`/`Active`/`List`/`Current`, keyed
+  `memgraph.Scope → sessionID → {count, since}`. Registered at `handlers.go:657`,
+  `defer s.turns.Begin(scopeOf(key), req.SessionID)()`, before either branch.
+- `internal/httpapi/handlers.go:284,288` — `GET /v1/turns/active`, `GET /v1/turns/running`.
+  The pattern a re-attach route follows.
+- `internal/pico/turn.go` — the picoclaw WebSocket and the completion state machine.
+  **Group C does not touch it.**
+
+**Webapp (`crab-exoskeleton-webapp`)**
+- `app/chat/turn-store.ts` — module-scope state, the send ladder, the queue, the reveal
+  driver, `consumeStream`, `recover`, `resumeIfActive`, `RECOVERY_POLL_MS`,
+  `RECOVERY_BUDGET_MS`.
+- `app/chat/fragment.ts:252` — `historyQuery(workspace, sessionId, project)`, the query
+  builder `recover` already reuses.
+- `app/api/chat/[instance]/{route,active,running,history,cancel}.ts` — the BFF surface; a
+  re-attach route joins it.
+- `app/chat/turn-progress.tsx` — the pre-reply band, `SILENCE_GRACE_MS`, `useElapsed`.
+- `lib/i18n/chat.ts`, `lib/i18n/errors.ts` — both locales, with a parity test.

--- a/.specs/features/turn-stream-continuity/design.md
+++ b/.specs/features/turn-stream-continuity/design.md
@@ -1,0 +1,287 @@
+# turn-stream-continuity — Design
+
+Read `spec.md` and `context.md` first. This file is the how, per group, plus the test
+plan. It does not restate the why.
+
+## The path a turn's bytes take
+
+```mermaid
+sequenceDiagram
+    participant B as browser (turn-store)
+    participant T as Traefik
+    participant N as Next BFF (route.ts)
+    participant M as mycelium
+    participant P as crab-shell-proxy (sse.go)
+    participant K as picoclaw (WebSocket)
+
+    B->>N: POST /api/chat/{r}
+    N->>M: POST /{role}/v1/chat/completions
+    M->>P: (proxied)
+    P-->>B: 200 + role chunk (before EnsureRunning)
+    P->>K: RunTurn
+    K-->>P: typing.start
+    P-->>B: x_crab_progress
+    Note over P,B: TODAY: nothing at all, for up to<br/>51s measured — any hop may reclaim<br/>an idle connection here
+    Note over P,B: GROUP A: `: ping` every 10s
+    K-->>P: message.create (whole reply, one frame)
+    P-->>B: content chunk
+    P->>P: SyncDurable
+    P-->>B: finish_reason stop + [DONE]
+```
+
+Group A fills the `Note` window. Group B removes the BFF as a possible cutter of that
+same window. Group C is what happens when the arrow from `P` to `B` breaks anyway.
+
+---
+
+## Group A — heartbeat (`crab-shell-proxy/internal/httpapi/sse.go`)
+
+### Shape
+
+```
+: ping\n\n
+```
+
+An SSE comment. Nothing else on the wire changes.
+
+### Serializing the writers (FR-5)
+
+`streamTurn` gains a `sync.Mutex` that every writer takes. All five write sites —
+`writeChunk`, `writeProgress`, `writeError`, `done`, and the new heartbeat — become
+lock / write / flush / unlock. The lock is function-local; it protects one response, and
+two concurrent turns share nothing.
+
+The `clientCtx.Err()` guards stay where they are, in the sinks, unchanged. The heartbeat
+gets its own, for the same reason (FR-4).
+
+### Lifetime
+
+Start the ticker immediately after the initial role chunk is flushed — that is the moment
+the stream exists — and stop it before `done()`. A `context.WithCancel` derived from
+`turnCtx`, cancelled by a `defer`, is enough; the ticker goroutine selects on it and on
+`time.Ticker.C`.
+
+Ordering that matters: the ticker must be stopped **before** the terminal frames are
+written, not merely at function exit. A ping interleaved between `finish_reason: "stop"`
+and `data: [DONE]` is harmless to parse but is exactly the sort of thing a later reader
+of a packet capture will spend an hour on.
+
+### Interval
+
+`const heartbeatInterval = 10 * time.Second`, beside `turnTimeout`, with the reasoning
+from FR-3 as its comment. Not configurable: a knob here would be a knob nobody can set
+correctly without knowing the member's carrier.
+
+### What the webapp does about it
+
+Nothing. `consumeStream`'s `if (!line.startsWith("data:")) continue` already discards it
+before any callback. **Group A ships as a proxy-only release** — no submodule pointer bump,
+no webapp rebuild. That is a deliberate property (DEC-1), and T-03 is what proves it holds
+across the real path rather than in theory.
+
+---
+
+## Group B — the BFF (`crab-exoskeleton-webapp`)
+
+### Measure first (T-04)
+
+Before changing anything: hold a turn artificially quiet past the suspected bound and
+observe what ends the stream and where. The cheapest rig is a stub upstream — a tiny Go or
+Node server that answers the streaming path with SSE headers, one role chunk, then
+nothing for N minutes — pointed at by `MYCELIUM_INTERNAL_URL`, with the BFF route consumed
+by `curl`. What is being recorded:
+
+- whether the BFF's own read of `res.body` errors, and with what (`UND_ERR_BODY_TIMEOUT`
+  and `UND_ERR_HEADERS_TIMEOUT` are the names to watch for);
+- at what elapsed time;
+- what the browser-side response looks like when it happens — a clean end or an error.
+
+**Write the answer into `spec.md` OQ-2 whichever way it comes out.** A measured "there is
+no such bound on node:24" is a valuable result and closes FR-7 with no code.
+
+### If a bound exists
+
+Scope the fix to the streaming route (FR-9). Two candidate shapes, in preference order:
+
+1. **A per-call dispatcher** on the streaming `fetch` only. Requires `undici` as a direct
+   dependency (it is not one today — `context.md` §8) and requires confirming that a
+   separately-installed `undici`'s `Agent` is accepted by the runtime's built-in `fetch`
+   as a `dispatcher`. **Confirm before committing to this shape**; a mismatch here is the
+   kind of thing that fails silently by being ignored.
+2. **`node:http`/`node:https` directly** for this one route, piped into the `Response`.
+   More code, no new dependency, no ambiguity about which client's defaults apply. This is
+   the fallback if (1) does not hold up.
+
+Either way, `fetchMycelium` keeps its current behaviour for every other caller; the
+streaming route gets its own path through it (an options argument, or a sibling
+`fetchMyceliumStream`), and the comment says why the two differ.
+
+### `X-Accel-Buffering` (FR-8)
+
+One header on the returned `Response`, beside `Cache-Control`. Cheap, inert today, and it
+documents the requirement in the place someone would look.
+
+---
+
+## Group C — re-attach
+
+### Proxy side
+
+**A per-turn frame log, keyed like the registry.** `turnRegistry` already keys
+`memgraph.Scope → sessionID`, is already registered at the right moment
+(`handlers.go:657`, before either branch), and already carries a first-seen timestamp for
+the dock. A sibling structure — call it `turnStreams` — keys the same way and holds, per
+in-flight turn:
+
+- a slice of already-emitted frames, each with its sequence number;
+- the set of live subscribers;
+- whether the turn has reached its terminal frame, and when.
+
+`streamTurn`'s writers stop writing to `w` directly. They append to the log and fan out
+(FR-14); the HTTP handler for the POST becomes the *first subscriber*, not a privileged
+one. This is the change with the largest blast radius in the feature and it is why Group C
+is last in the build order.
+
+Heartbeats bypass this entirely (FR-6): they are written per-subscriber, on each
+subscriber's own schedule, and never enter the log.
+
+**Bounding (FR-17).** A cap on retained bytes per turn, not on frame count — one content
+frame can be the whole reply. On overflow, drop from the front and mark the log
+*truncated*; a re-attach asking for a sequence below the retained floor is refused with a
+distinct status so the client falls to the poll (FR-15) rather than replaying a hole.
+
+**Never blocking on a reader (FR-14a).** Each subscriber owns a bounded channel. `append`
+does a non-blocking send to every subscriber and, on a full channel, **closes and removes
+that subscriber** — it does not select with a timeout, and it does not wait. The log's own
+append is therefore O(subscribers) of non-blocking sends and cannot be slowed by anyone
+reading it. This is what keeps the change confined to the delivery path: the sink call that
+used to be a write+flush is now an append, and neither can be stalled by a client.
+
+**Retention (FR-11).** Two clocks, and conflating them is the mistake to avoid. *During*
+the turn the log is simply alive, bounded by `turnTimeout`. *After* the terminal frame it
+is held for **60 seconds** and then dropped — long enough for notice + reload + re-attach,
+and comfortably more than FR-16's ~30s re-attach budget, so a re-attach can never lose a
+race against expiry while it is still trying.
+
+**Endpoint (FR-12, FR-13).**
+
+```
+GET /v1/turns/stream?session_id=…&tenant_id=…&subs_acc_id=…
+Last-Event-ID: <seq>          # optional; absent means "from the start" (FR-18)
+```
+
+Answers `text/event-stream`, replays everything after `<seq>`, then continues live to the
+terminal marker. It goes through the same authorization as every other turn route and it
+does **not** call `turns.Begin` — it is a reader. A conversation with no live log is a
+plain, fast "nothing here", not a 500: it is the normal answer for a turn that finished
+while the client was away.
+
+Registered beside its siblings at `handlers.go`, next to `/v1/turns/active` and
+`/v1/turns/running`. It is a third question, with a third answer — the same argument
+`background-turn-dock` DEC-3 made for not overloading `/v1/turns/active`.
+
+**Sequencing (FR-10, DEC-3).** Each data frame is preceded by `id: <n>\n` in the same
+write. `n` is per-turn and starts at the role chunk.
+
+### Webapp side
+
+**`consumeStream` learns two things.** It parses `id:` lines and reports the last
+sequence seen, and it accepts a starting sequence so a re-attached stream continues the
+same accounting. Both are additive; the `data:`-only filter that makes Group A invisible
+stays exactly as it is.
+
+**`runTurn`'s cut handler gains a step.** Today:
+
+```
+if (!completed && !error && !stopped) await recover(sid, ctx)
+```
+
+becomes: try `reattach(sid, ctx, lastSeq)` first; if it returns having reached the
+terminal marker, the turn ends normally. If it returns without one, loop within the
+re-attach budget (FR-16). When the budget is spent — or the endpoint is unavailable, or
+the log was truncated — fall through to `recover(sid, ctx)` **exactly as it is written
+today** (DEC-4). `recover` is not modified by Group C.
+
+**The band.** A re-attached turn shows the ordinary working band, not the recovery line
+(FR-19): it *is* running and the member is being told about it again. The recovery line
+keeps its current copy and its current trigger, which is now specifically the poll path.
+
+**`resumeIfActive` (FR-18).** After a reload it currently confirms the turn with
+`/v1/turns/active` and enters `recover()`. With the log available it re-attaches from the
+start instead and rebuilds the partial reply and progress state. Keep the `active` probe:
+it is the cheap question, and it is what says whether to re-attach at all.
+
+**A new BFF route** mirroring `active/route.ts` — same instance guard, same session
+handling, same 401-clears-session behaviour — but streaming the body through like
+`route.ts` does, and forwarding `Last-Event-ID`.
+
+---
+
+## Group D — network awareness (`crab-exoskeleton-webapp`)
+
+A small module-scope helper in `turn-store.ts`, beside the existing timers: a set of
+"waiters" (a recovery poll or a re-attach backoff) that can be woken. `online` and
+`visibilitychange` listeners registered once, at module scope, resolve every waiter's
+current sleep immediately and reset any backoff.
+
+`recover`'s loop needs one change to benefit: its `await sleep(RECOVERY_POLL_MS)` becomes
+an interruptible sleep. The budget (`RECOVERY_BUDGET_MS`) is wall-clock and is unaffected —
+waking early takes samples sooner, it does not extend the wait.
+
+FR-22's offline copy reads `navigator.onLine` at render time in the band, with the
+`online`/`offline` events as the re-render trigger. `navigator.onLine` is famously
+optimistic (it reports a captive portal as online), which is fine for this use: it is used
+only to *soften* the message when it is definitely false, never to conclude that the
+network is fine.
+
+---
+
+## Test plan
+
+Numbers are referenced by `tasks.md`.
+
+**Proxy — Go, `go test -race` on every one of these.**
+
+1. `streamTurn` emits at least one `: ping` frame on a turn that takes longer than one
+   interval, and none on a turn that finishes inside it.
+2. No ping is written after `clientCtx` is cancelled (FR-4).
+3. No ping appears between `finish_reason: "stop"` and `[DONE]`.
+4. Concurrent writers do not interleave: a turn emitting content while the ticker fires,
+   under `-race`, produces only well-formed frames (FR-5).
+5. `turnStreams`: two subscribers to one turn both receive every frame, in order (FR-14).
+6. A subscriber that stops reading is **dropped**, and neither the turn nor the other
+   subscriber is delayed: with one reader never draining its channel, the turn still
+   reaches its terminal frame and the second reader still receives every frame (FR-14a).
+   Assert the drop, not just the absence of a hang — a test that only checks "it finished"
+   passes on a timeout-based implementation too.
+7. Re-attach from sequence `n` replays exactly the frames after `n`, then live ones.
+8. Re-attach with no `Last-Event-ID` replays from the start (FR-18).
+9. Re-attach below a truncated log's floor is refused distinguishably (FR-17).
+10. Re-attach does not register in `turnRegistry`: `Active` is unchanged across it (FR-13).
+11. The log is present 59s after the terminal frame and gone after 61s (FR-11), on an
+    injectable clock — the registry already takes `now func() time.Time` as a field
+    precisely so its tests can run `t.Parallel()`; do the same here rather than sleeping.
+
+**Webapp — vitest.**
+
+12. `consumeStream` ignores comment lines and does not invoke any callback for them —
+    the guard that keeps `lastEventAt` honest (FR-2, DEC-6). *This test is worth having
+    even though Group A needs no webapp change: it is the regression test for the
+    contract, and it belongs to the webapp because that is where it can be broken.*
+13. `consumeStream` reports the last `id:` seen, and reports none when there are no `id:`
+    lines (a pre-Group-C proxy).
+14. A cut with no terminal marker attempts re-attach before polling (FR-15).
+15. A re-attach that reaches the terminal marker finishes the turn through the existing
+    painter path — no second rendering path, per `long-turn-resilience` FR-7/DEC-3.
+16. A re-attach that fails every attempt falls through to `recover`, and `recover`'s own
+    behaviour is unchanged (the `long-turn-resilience` suite must still pass untouched).
+17. `online` wakes a sleeping recovery poll immediately (FR-20).
+18. i18n parity for every new string (FR-23).
+
+**Not coverable by either suite, and therefore operator-verified (T-11):**
+- that a comment frame survives Traefik → BFF → mycelium → browser (OQ-3);
+- that the heartbeat actually reduces observed cuts, which is the point of the whole
+  feature and cannot be asserted anywhere but production;
+- `visibilitychange` behaviour, which needs a real backgrounded mobile tab;
+- the band's rendering arms, for the same `environment: "node"` reason
+  `long-turn-resilience` records for itself.

--- a/.specs/features/turn-stream-continuity/design.md
+++ b/.specs/features/turn-stream-continuity/design.md
@@ -145,6 +145,13 @@ is last in the build order.
 Heartbeats bypass this entirely (FR-6): they are written per-subscriber, on each
 subscriber's own schedule, and never enter the log.
 
+**One turn per key — an assumption, not an invariant (spec OQ-4).** Keying the log like
+the registry is right for today, but "at most one turn in flight per conversation" holds
+because the webapp queues the second message, not because the proxy refuses it. A
+concurrent POST would already be folded by picoclaw as a steering message
+(`steering-messages/investigation.md`). **Decide at T-09 whether to key by turn instead** —
+it is a field and a lookup now, and a migration later.
+
 **Bounding (FR-17).** A cap on retained bytes per turn, not on frame count — one content
 frame can be the whole reply. On overflow, drop from the front and mark the log
 *truncated*; a re-attach asking for a sequence below the retained floor is refused with a

--- a/.specs/features/turn-stream-continuity/spec.md
+++ b/.specs/features/turn-stream-continuity/spec.md
@@ -86,6 +86,14 @@ for being idle — by any hop, including the ones we will never instrument.
 - **Not making picoclaw stream.** That is the right fix for the *silence* and the wrong
   scope for this spec. See `picoclaw-incremental-streaming/investigation.md`, written in
   parallel with this one, and DEC-8.
+- **Not using picoclaw's steering messages.** picoclaw folds a message that arrives
+  mid-turn into the running turn (`enqueueSteeringMessage`), and this stack never reaches
+  that path — the webapp queues the second message client-side and POSTs it only after the
+  first turn's reveal has drained. Worth having, and **not here**: this feature is about
+  bytes staying on the wire, steering is about what a message *means* when one is already
+  running, and it lands directly on the completion heuristic this spec's Non-goals protect.
+  See `steering-messages/investigation.md`, and OQ-4 below for the one part of it that
+  constrains Group C.
 - **Not making a failed turn survive a reload.** Still `turn-failure-visible`'s
   limitation; picoclaw does not persist errors. Inherited, not fixed.
 
@@ -368,6 +376,14 @@ which says how much was lost.
 FR-7 is written as a hypothesis for exactly this reason. `fetchMycelium` passes no
 dispatcher, so the answer is the runtime's default, and this spec does not assert what
 that default is on `node:24-alpine`. T-04 measures it before anything is changed.
+
+**OQ-4 — Should Group C's frame log be keyed by turn rather than by conversation?**
+FR-10/FR-11 key it `memgraph.Scope → sessionID`, like `turnRegistry`, which assumes at most
+one turn in flight per conversation. That is true today **only because the webapp queues a
+second message client-side** — nothing in the proxy enforces it, and a concurrent POST
+would already be folded by picoclaw as a steering message. If steering is ever adopted, a
+conversation-keyed log has two writers. Deciding this before T-09 is cheap; retrofitting it
+after is not. See `steering-messages/investigation.md` §5.
 
 **OQ-3 — Does every hop forward SSE comment lines untouched?**
 The SSE spec says they are legal and ignorable, and this repo already relies on that

--- a/.specs/features/turn-stream-continuity/spec.md
+++ b/.specs/features/turn-stream-continuity/spec.md
@@ -1,0 +1,379 @@
+# turn-stream-continuity — Spec
+
+**Status:** Specified. Not implemented.
+**Spans:** `crab-shell-proxy` (heartbeat, frame sequencing, re-attach endpoint) +
+`crab-exoskeleton-webapp` (BFF stream route, re-attach client, network-aware waiting).
+**Date:** 2026-08-27.
+**Successor to:** `long-turn-resilience` (webapp), `resume-turn-after-reload`,
+`background-turn-dock`. Read `context.md` before this file — it records which of those
+are actually deployed, and that is what decides this feature's shape.
+
+## Problem
+
+A member sends a message, the agent works for a few minutes, and the chat stops
+representing the work. They reload the page to find out whether anything happened.
+
+That complaint has been answered three times already, and all three answers are
+**recovery**: notice the stream is gone, then find the reply some other way.
+`long-turn-resilience` polls the durable transcript. `resume-turn-after-reload` asks the
+proxy on mount. `background-turn-dock` shows what is running elsewhere. Two of the three
+are running in production today (`context.md` §1), and the complaint is being filed
+against a build that has them.
+
+So recovery is not the missing half. **Nothing in this stack prevents the cut**, and both
+specs that noticed said so and declined:
+
+- `long-turn-resilience` → *"Alternatives not taken: keep-alive frames from the proxy …
+  It belongs in the proxy repo."*
+- `crab-shell-proxy/.specs/features/multi-harness-support/implementation-notes.md` §9 →
+  *"Anyone re-adding Hermes should treat this as the first problem to solve, not the
+  last."*
+
+This feature is that half, plus the reconnection the recovery path never had.
+
+## Why the stream goes quiet in the first place
+
+The chain is already in the repo; it had not been joined up.
+
+1. **picoclaw does not stream.** It returns the whole answer in one terminal frame —
+   measured, `chat-responsiveness` OQ-1: `typing.start`, **51 seconds of complete
+   silence**, then the reply.
+2. **`sse.go` emits nothing of its own.** Content, progress, error and attachment frames
+   are all reactions to picoclaw. Between picoclaw's frames the SSE is genuinely idle,
+   for as long as the agent thinks.
+3. **That idle stream crosses four hops** — browser ↔ Traefik ↔ the Next BFF ↔ mycelium
+   ↔ crab-shell-proxy — each with its own tolerance for a connection that carries no
+   bytes. The hop this feature cannot see or configure is the first one: mobile NAT, a
+   wifi handover, a VPN, a corporate proxy. That is the hop the member calls "the
+   internet fluctuating".
+
+This is deliberately **not** a claim that the gateway is the culprit. `context.md` of
+`long-turn-resilience` established that it is not (`gatewayTimeout=60s`, but *"awc timeout
+is headers-only"*), and nothing here contradicts it. FR-1 is written the way
+`long-turn-resilience` FR-1 was written: against a locally observable invariant, not
+against a theory of which hop is guilty. A stream that is never idle cannot be dropped
+for being idle — by any hop, including the ones we will never instrument.
+
+## Goals
+
+- A running turn's connection is never silent long enough for anything to reclaim it.
+- When a cut happens anyway, the client re-attaches to the *live* turn and keeps
+  receiving it, instead of waiting blind for a transcript to grow.
+- A member on a flaky connection is told which thing is wrong — their network, or ours —
+  and the interface reacts the moment their network comes back.
+
+## Non-goals
+
+- **Never re-POST a turn.** Unchanged from `long-turn-resilience`: once the stream is
+  open the turn is committed upstream, and re-sending would run a ten-minute turn twice.
+  Every mechanism here is a *read*.
+- **No change to how a turn is *produced*.** Not `RunTurn`, not the picoclaw processor,
+  not the completion heuristic, not the background `turnCtx` the turn runs on, not the
+  `clientCtx` guards that stop writing without stopping the turn. If a task starts editing
+  any of those, the task is wrong.
+
+  **This is narrower than `background-turn-dock` DEC-1's "this feature reads state; it does
+  not produce it", and deliberately so.** That sentence is inherited from the dock and is
+  **false for Group C**: re-attach changes the *response-write path* — the sinks stop
+  writing a `ResponseWriter` directly and write a fan-out log instead. Nothing about how
+  the turn is computed changes; how its bytes are delivered does. FR-14a is what keeps that
+  change off the turn's critical path.
+- **Not raising mycelium's `gatewayTimeout`.** Rejected in `multi-harness-support` §9 and
+  again in `long-turn-resilience`, for the same reason both times: it is global, so it
+  degrades failure detection for every other service to accommodate this one. It stays
+  rejected. (Note `deploy/standalone/config.standalone.toml:96` already sets 600 — that
+  is the single-tenant profile, and it did not make this problem go away.)
+- **Not making picoclaw stream.** That is the right fix for the *silence* and the wrong
+  scope for this spec. See `picoclaw-incremental-streaming/investigation.md`, written in
+  parallel with this one, and DEC-8.
+- **Not making a failed turn survive a reload.** Still `turn-failure-visible`'s
+  limitation; picoclaw does not persist errors. Inherited, not fixed.
+
+## Prerequisite
+
+**P-0 — SATISFIED for its deploy half (2026-08-27); one half remains.**
+
+*Why it existed:* the dock is the affordance that answers "what is running right now"
+without a reload. While the deployed build predated it, any before/after judgement of this
+feature would have measured the dock's absence as well as the cut.
+
+- **Deploy + verification — done.** `background-turn-dock` is deployed and its T-10 run
+  and confirmed by the maintainer. That feature is finished.
+- **Baseline — still open, and still needed before T-02 ships.** T-08 is a real gate: it
+  counts how often the recovery path fires *after* the heartbeat, and without a
+  pre-heartbeat count taken on the now-deployed build it produces one figure and nothing to
+  compare it against. `long-turn-resilience` OQ-1 already gives the instrument — a recovery
+  that fires is a cut that happened. See `tasks.md` P-0.
+
+This is a measurement, not code.
+
+## Requirements
+
+### Group A — the stream is never silent (crab-shell-proxy)
+
+**FR-1 — While a turn is in flight, the proxy writes a heartbeat at a fixed interval.**
+It starts once the stream is open and stops when the turn ends. Its purpose is to keep
+the connection carrying bytes, so no hop can reclaim it for being idle — whichever hop
+that would have been.
+
+**FR-2 — The heartbeat is an SSE comment, never a data frame.**
+`: ping\n\n`. This is not cosmetic and it is the requirement most likely to be
+"simplified" into a bug, so the reason is here rather than in the design:
+
+`background-turn-dock` DEC-12 made the band's elapsed readout and the dock's chips both
+derive from `lastEventAt`, precisely so *"a chip and the band it corresponds to can never
+disagree"*. `lastEventAt` is stamped in `runTurn`'s `onDelta` and `onProgress`
+(`turn-store.ts`). A heartbeat shaped as an empty-delta `x_crab_progress` chunk — the
+obvious shape, since that extension already exists — would stamp it every ten seconds,
+pinning "quiet for" at zero forever and destroying `long-turn-resilience` FR-11/FR-12
+outright. A comment line cannot: `consumeStream` does
+`if (!line.startsWith("data:")) continue` **before** any bookkeeping, so a comment is
+dropped ahead of every state change. **The webapp therefore needs no change for Group A
+at all**, and that is a property to preserve, not a coincidence to rely on silently.
+
+**FR-3 — The interval is chosen against the tightest plausible hop, not against the
+gateway.** Ten seconds. Mycelium's 60s is the *loosest* bound in the chain and the only
+one written down; mobile NAT and edge idle timeouts sit well below it, and the member's
+complaint is specifically about their connection, not ours.
+
+**FR-4 — The heartbeat obeys the same client-gone guard as every sink.**
+`clientCtx.Err() != nil` stops it writing, exactly as `Content`, `Progress`, `Error` and
+`Attachment` already early-return. The turn keeps draining regardless — that invariant is
+untouched.
+
+**FR-5 — Every write to the response is serialized.**
+Today all writes happen on the request goroutine, so `sse.go` needs no lock. A heartbeat
+is a second writer by construction. Without a mutex around `writeChunk` /
+`writeProgress` / `writeError` / `done` / the heartbeat this is a data race on an
+`http.ResponseWriter`, and interleaved output would corrupt a frame the client is
+mid-parse on. `go test -race` must be part of this task's gate.
+
+**FR-6 — Heartbeats are neither sequenced nor buffered.**
+They carry no state. Group C's sequence numbers and replay buffer are for frames that
+mean something; admitting heartbeats would fill the buffer with noise and make a
+re-attach replay ten minutes of pings.
+
+### Group B — the BFF stops cutting its own upstream (crab-exoskeleton-webapp)
+
+**FR-7 — The streaming route must not impose an inactivity bound shorter than the
+proxy's own turn bound.**
+`fetchMycelium` calls bare `fetch` with no dispatcher (`lib/mycelium.ts:79`), so the
+streaming POST inherits whatever the runtime's default inactivity behaviour is. If that
+default is shorter than `turnTimeout` (10 min, `sse.go:19`), then **our own BFF aborts the
+upstream body** on a long quiet turn and the member's "the internet dropped" was never
+the internet. **This is stated as a hypothesis to test, not a finding** (OQ-2): the first
+task is the measurement, and the fix is whatever the measurement points at. Group A alone
+may already make this unreachable — a stream that pings every ten seconds is never
+inactive — which is why the measurement matters more than the guess.
+
+**FR-8 — The streaming route declares itself unbuffered.**
+`X-Accel-Buffering: no` alongside the `Cache-Control: no-cache` it already sets. Traefik
+does not buffer responses by default, so this changes nothing today; it is a one-line
+guard against an nginx-shaped hop being introduced later and turning progressive delivery
+into a single blob at the end, which would present as this exact bug.
+
+**FR-9 — Whatever the fix for FR-7, it is scoped to the streaming route.**
+A global dispatcher change would remove the inactivity guard from every admin and history
+call as well, where it is the only thing that catches a hung upstream. One route has a
+ten-minute quiet period as normal behaviour; none of the others do.
+
+### Group C — re-attaching to a live turn (both repos)
+
+**FR-10 — Every data frame the proxy writes carries a monotonic sequence number.**
+As an SSE `id:` line, not a field inside the JSON payload — see DEC-3.
+
+**FR-11 — The proxy retains a turn's frames for the life of the turn, plus 60 seconds
+after its terminal frame.**
+During the turn the log is simply alive — that is the ten-minute case, and it is bounded by
+`turnTimeout`, not by this. The 60 seconds is a *different clock*: it covers only
+notice-plus-reload-plus-re-attach after the turn has already ended, which is tens of
+seconds, not minutes. It is deliberately **not** derived from `RECOVERY_BUDGET_MS` (11 min,
+sized to outlast `turnTimeout`); a turn that has written its terminal frame has nothing
+left to produce, and holding its bytes for eleven minutes would be retention for its own
+sake. The number is stated here rather than left to the implementation because T-09 needs a
+value and design test 11 needs a threshold — a guess made at build time would silently
+become the contract.
+
+**FR-12 — A re-attach endpoint resumes a running turn from a sequence number.**
+It replays the frames after that sequence, then continues live until the turn's terminal
+marker. Same frame shapes, same terminal marker: a re-attached client runs the same
+`consumeStream` it already has.
+
+**FR-13 — Re-attach is strictly a read.**
+It never starts a turn, never re-POSTs, and never registers a turn in `turnRegistry`. A
+re-attach to a conversation with no running turn is answered, not created.
+
+**FR-14 — A turn may have more than one reader.**
+The original POST stream and a re-attach can be live at once — the client cannot know its
+old socket is truly dead, only that it stopped delivering — so the proxy fans out rather
+than handing over.
+
+**FR-14a — Appending a frame never blocks on any subscriber, and a subscriber that cannot
+keep up is dropped.**
+This is the requirement that keeps FR-14 off the turn's critical path, and it is stated
+separately because "must not stall the turn" is otherwise an aspiration rather than
+something a test can assert. Each subscriber has its own bounded outbound queue. A full
+queue means that reader is gone or too slow: it is **dropped**, immediately and without
+being awaited. It is never waited on, and its slowness is never observable by the turn, by
+the log, or by any other subscriber. A dropped subscriber is not an error — it is a client
+that stopped reading, which is the case this whole feature exists for, and it can
+re-attach.
+
+**FR-15 — The client re-attaches before it polls; the poll stays as the floor.**
+On a cut with no terminal marker, the store tries re-attach first. On success the turn
+continues as though nothing broke: progress arrives, `lastEventAt` advances, the band goes
+back to being a working band. On failure — buffer expired, endpoint absent, an older proxy
+— it falls through to today's `recover()` polling, **unchanged**. The poll needs nothing
+from the proxy and is what keeps this feature from being a single point of failure.
+
+**FR-16 — Re-attach is bounded and backs off, and its budget is visibly smaller than
+FR-11's retention.**
+It is a reconnection, not a second retry ladder: a few attempts with backoff over roughly
+**30 seconds**, then the poll takes over. The relation to FR-11 is the point — 30s of
+trying against 60s of retention means a re-attach can never fail *because the log expired
+while it was still trying*, which would be the confusing failure. `MAX_SEND_ATTEMPTS` (10
+attempts, up to 30s apart) is deliberately not reused: that ladder exists for a turn that
+was never accepted, and this one is for a turn that certainly was.
+
+**FR-17 — Buffered frames are bounded per turn.**
+A long reply plus a tool-heavy turn is a lot of text, and it is held per in-flight turn
+per member. Overflow drops the oldest and the buffer says so, so a re-attach that cannot
+be served completely is refused and falls to the poll (FR-15) rather than replaying a
+transcript with a hole in it.
+
+**FR-18 — A client with no sequence re-attaches from the start of the turn.**
+After a reload the sequence is gone with the tab. Replaying from zero is correct and is
+what a reloaded client wants: it rebuilds the partial reply and the progress state it
+would otherwise have to invent. This is the path `resumeIfActive` takes today, and it
+currently lands in `recover()`, which patches `recoveringSince: Date.now()` and can only
+wait (`background-turn-dock` DEC-4 records how that lies about elapsed time).
+
+**FR-19 — Recovery copy distinguishes re-attached from waiting.**
+A re-attached turn is not "recovering" — it is running, and the member should see the
+working band, not the dropped-connection line. The recovery line stays for the poll path,
+where it remains the honest description.
+
+### Group D — reacting to the member's actual network (crab-exoskeleton-webapp)
+
+**FR-20 — A wait wakes immediately when the browser comes back online.**
+`recover()` polls blind every `RECOVERY_POLL_MS` and nothing listens to `online`. A member
+leaving a tunnel waits up to a full interval past the moment their connection returned,
+and a re-attach (FR-15) would have failed for the whole outage and be mid-backoff. The
+`online` event resets the backoff and fires an attempt at once.
+
+**FR-21 — And when a backgrounded tab becomes visible again.**
+`visibilitychange` → visible does the same. Mobile browsers throttle timers in background
+tabs, so the poll a member returns to may be minutes stale.
+
+**FR-22 — Offline is named as offline.**
+While `navigator.onLine` is false, the band says the device has no connection — not that
+we are reconnecting to the agent. They are different problems with different actions for
+the member, and today they read identically.
+
+**FR-23 — Both locales, no exceptions.**
+Every string added lands in `en` and `pt-BR` in `lib/i18n/chat.ts` (and
+`lib/i18n/errors.ts` for any new code). There is a parity test.
+
+## Decisions
+
+**DEC-1 — Prevention is the feature; the rest is contingency.**
+Group A is the only part that reduces how often the member is inconvenienced at all.
+Groups C and D make the inconvenience shorter and more honest. If only one group ever
+ships, it is A — and A is deliberately the one that needs no webapp change and no
+submodule pointer bump (FR-2), so it can ship on its own.
+
+**DEC-2 — Group C is in scope by maintainer decision, over the cheaper sequencing
+(user-directed).**
+Asked to choose, the maintainer chose to include the re-attach path now rather than hold
+it as a gated follow-up. The cheaper reading — that Group A prevents most cuts and Group C
+would then buy little — is not wrong, and this spec does not pretend otherwise. What it
+does instead is put the answer in the build order: **A → B → measure → C** (see
+`tasks.md`). The measurement between B and C is what tells us whether C earned its keep,
+and it is worth having on record either way.
+
+**DEC-3 — The sequence rides as an SSE `id:` line, not a field in the chunk.**
+`id:` is the native SSE mechanism and its counterpart, `Last-Event-ID`, is what a
+reconnection is supposed to send. A field inside the OpenAI chunk would work equally well
+for our own client and would be one more proprietary extension in a payload the proxy
+keeps deliberately generic — the same compatibility argument `sse.go` already makes for
+carrying progress as an extra top-level field rather than a named SSE event. The client
+does not use `EventSource` (it needs a POST), so it parses `id:` by hand; that is three
+lines in `consumeStream` beside the `data:` check that already exists.
+
+**DEC-4 — Re-attach precedes the poll and never replaces it.**
+The poll is the floor because it depends on nothing new: it reads the history endpoint
+that has existed since `chat-history`, and it works against a proxy that has never heard
+of Group C. Making re-attach the only path would tie a shipped, working recovery to a new
+endpoint's availability, and would mean a proxy/webapp version skew presents as the
+original bug.
+
+**DEC-5 — The frame buffer is in the proxy's memory, and losing it is correct.**
+Not Redis, not disk. A proxy restart loses the buffer, and a proxy restart also kills the
+turn (`turnCtx` dies with the process) — so there is nothing to re-attach to and nothing
+was lost that survived. Adding durable storage would buy re-attach to a turn that no
+longer exists.
+
+**DEC-6 — Heartbeats do not touch `lastEventAt`, and that is a contract, not an
+implementation detail.** Restated from FR-2 because it is the single thing most likely to
+be broken by a later well-meaning change (for instance, "let's give the heartbeat a
+timestamp so the client can measure drift"). Any frame the proxy invents on its own
+schedule must be invisible to the client's event bookkeeping.
+
+**DEC-7 — Group D is small, client-only, and shipped with B rather than held for C.**
+It needs nothing from the proxy and it is the part that most literally answers the
+complaint as it was filed ("sensível a flutuações na internet"). Holding it behind the
+expensive group would be sequencing by cost rather than by value.
+
+**DEC-8 — picoclaw's transport is not the problem; its framing is.**
+The question that started this feature included implementing an HTTP connection in
+picoclaw. Recorded here because the answer is useful and non-obvious: **that is the wrong
+hop.** proxy ↔ picoclaw is server-to-server inside the Docker network, over a WebSocket
+that neither the member's connection nor any edge proxy touches; changing its transport
+cannot affect a symptom that originates between the browser and the gateway. The
+legitimate picoclaw-side item is a different one, and it is upstream of everything above:
+picoclaw answers in **one terminal frame**, which is what creates the 51-second silence
+this whole feature works around. See
+`picoclaw-incremental-streaming/investigation.md`.
+
+## Alternatives not taken
+
+- **WebSocket between the browser and the BFF**, replacing SSE. It would carry native
+  ping/pong and make reconnection a solved problem. Rejected on cost and blast radius: the
+  proxy's OpenAI-compatible SSE shape is consumed by more than this client, the BFF would
+  become a stateful bridge instead of a byte pipe (`route.ts` is currently `return new
+  Response(res.body)`), and Group A gets the same idle-liveness for a ticker and a mutex.
+  Worth revisiting only if Groups A and C both prove insufficient.
+- **Long-polling instead of a stream.** Would trade one long connection for many short
+  ones, which does survive a flaky network — and would discard progressive delivery,
+  progress events, and the whole `chat-responsiveness` feature. The band exists because a
+  silent turn was the original complaint.
+- **A service worker holding the stream outside the page.** Real, and it survives a tab
+  close, not merely a reload. Out of proportion here, and `pwa-installability` is
+  deliberately unrelated (`background-turn-dock` non-goals, OQ-1).
+- **Raising `gatewayTimeout`.** See Non-goals. Rejected three times now.
+- **Keeping the turn on `r.Context()`** so a disconnect cancels it cleanly. Actively
+  harmful and already tried: `sse.go`'s own comment records that it truncated picoclaw's
+  transcript ("initial messages disappear after reload").
+
+## Open questions
+
+**OQ-1 — What actually cuts the stream is still not established.**
+Inherited from `long-turn-resilience` OQ-1, and this feature is again built not to need
+the answer. It does make it more observable in two new ways: after Group A, a cut on a
+stream that was pinging ten seconds ago is a much narrower event than a cut on a stream
+silent for a minute; and after Group C, a re-attach reports the sequence it resumed from,
+which says how much was lost.
+
+**OQ-2 — Does the BFF impose an inactivity bound on the upstream body at all?**
+FR-7 is written as a hypothesis for exactly this reason. `fetchMycelium` passes no
+dispatcher, so the answer is the runtime's default, and this spec does not assert what
+that default is on `node:24-alpine`. T-04 measures it before anything is changed.
+
+**OQ-3 — Does every hop forward SSE comment lines untouched?**
+The SSE spec says they are legal and ignorable, and this repo already relies on that
+convention in the other direction (`multi-harness-support` §10: *"only `data:` lines
+matter (`event:`/`id:`/comment lines are skipped)"*). But mycelium's proxying of the body
+has never been tested with one. T-03 verifies it end to end before Group A is called done
+— if a hop strips them, the fallback shape is a `data:` frame the client is taught to
+discard *before* the `lastEventAt` stamp, which costs the webapp change FR-2 was written
+to avoid.

--- a/.specs/features/turn-stream-continuity/tasks.md
+++ b/.specs/features/turn-stream-continuity/tasks.md
@@ -1,0 +1,261 @@
+# turn-stream-continuity — Tasks
+
+Read `spec.md`, `context.md` and `design.md` first.
+
+**Gate for every proxy task:** `go vet ./...`, `go test -race ./...` green.
+**Gate for every webapp task:** `yarn test` green, `yarn build` clean.
+
+## Build order, and why it is this one
+
+**P-0 → A → B+D → measure → C.**
+
+Group A ships alone, as a proxy-only release with no webapp change and no submodule
+pointer bump (spec DEC-1, design "What the webapp does about it"). It is the only group
+that reduces how often a member is inconvenienced at all, and it is the cheapest thing
+here. Nothing should be sequenced ahead of it.
+
+The measurement between B+D and C is deliberate and is the honest half of DEC-2: the
+maintainer chose to include the expensive re-attach path, and the cheap half may make it
+unnecessary. T-08 is where that gets decided with data instead of opinion, and it is
+worth recording either way.
+
+Commits: one per group. Group C is large enough that its proxy and webapp halves are
+separate commits in separate repos, which they must be anyway.
+
+---
+
+## P-0 — the dock, and the baseline (prerequisite, no code)
+
+**P-0a — deploy the dock and verify it. DONE (2026-08-27).**
+`background-turn-dock` is deployed and its T-10 run and confirmed by the maintainer; that
+feature is finished. Nothing further is required here.
+
+**P-0b — record the pre-heartbeat baseline. STILL OPEN, and it gates T-02.**
+- **What:** on the now-deployed, dock-carrying build, count how often the recovery path
+  fires before the heartbeat exists. `long-turn-resilience` OQ-1 already gives the
+  instrument — *"a recovery that fires is a cut that happened"* — so this is counting it
+  over a representative window (a week of ordinary use), not building one.
+- **Why it is part of P-0 and not part of T-08:** T-08 is the gate that decides whether
+  Group C gets built, and it counts the same thing *after* the heartbeat. Without a
+  pre-heartbeat number on the same build, T-08 produces one figure and nothing to compare
+  it against, and a real gate degrades back into a judgement call. Once T-02 ships, this
+  number can never be taken again.
+- **Done when:** the count and the window are written here.
+
+**P-0c — correct the drifted deploy tag. Small, and it is an L-007 trap.**
+- **What:** `zombie-crab-project-mkt/deploy/dokploy/.env.example:96` still reads
+  `CHAT_WEBAPP_TAG=sha-d8f9aa7`, which predates the dock and is no longer what is
+  deployed. Set it to the tag actually running.
+- **Why it matters:** L-007 — Dokploy runs `docker compose up -d --build` **without**
+  `--pull always`, so a deploy that trusts the stale example can put the host back on a
+  cached older image, and the symptom is "the fix stopped working". The example file is
+  the thing the next person reads.
+- **Blocked on:** knowing the real tag; this repo cannot read Dokploy's env.
+
+---
+
+## Group A — the stream is never silent (`crab-shell-proxy`)
+
+### T-01 — serialize the response writers
+- **What:** a function-local `sync.Mutex` in `streamTurn`; `writeChunk`, `writeProgress`,
+  `writeError` and `done` all take it around their write+flush.
+- **Where:** `internal/httpapi/sse.go`.
+- **Why before the ticker:** this is a no-op refactor while there is one writer, and it is
+  the thing that makes the next task safe. Landing it separately means a `-race` failure
+  in T-02 can only be about the ticker.
+- **Tests:** existing `sse_progress_test.go` unchanged and green under `-race`.
+- **Covers:** FR-5.
+
+### T-02 — the heartbeat
+- **What:** `const heartbeatInterval = 10 * time.Second` beside `turnTimeout`; a ticker
+  goroutine started after the initial role chunk flushes, cancelled before `done()`,
+  writing `: ping\n\n` under the T-01 mutex, skipped while `clientCtx.Err() != nil`.
+- **Where:** `internal/httpapi/sse.go`.
+- **Depends on:** T-01.
+- **Done when:** the ticker cannot outlive the turn and cannot write after the terminal
+  frames — `defer cancel()` alone is not enough; see design "Lifetime".
+- **Tests:** design 1, 2, 3, 4.
+- **Covers:** FR-1, FR-2, FR-3, FR-4, FR-6.
+
+### T-03 — verify a comment frame survives the whole path (operator, OQ-3)
+- **What:** with T-02 deployed, watch real long turns from the browser and confirm the
+  `: ping` frames arrive — devtools' EventStream pane, or `curl -N` against the BFF route
+  with a real session.
+- **Done when:** pings are observed on **at least three separate turns of more than 60
+  seconds each, from at least two different networks** (one of them mobile). Written out
+  because the cheap version of this check is one lucky observation, and a hop that strips
+  comments intermittently — or strips them only on one path — is exactly the failure this
+  task exists to catch.
+- **Why it cannot be a unit test:** the question is whether **mycelium and Traefik** pass
+  comment lines through, and neither is in any test harness here.
+- **If it fails:** the fallback is a `data:` frame the client discards *before* the
+  `lastEventAt` stamp — which costs the webapp change FR-2 exists to avoid, and turns
+  Group A into a two-repo release. Record the outcome in `spec.md` OQ-3 either way.
+- **Covers:** OQ-3, and closes Group A.
+
+---
+
+## Group B — the BFF stops cutting its own upstream (`crab-exoskeleton-webapp`)
+
+### T-04 — measure before changing anything (OQ-2)
+- **What:** the stub-upstream rig from design "Measure first" — SSE headers, one role
+  chunk, then silence — and record what ends the BFF's read of the body, and when.
+- **Where:** throwaway rig; the finding goes into `spec.md` OQ-2.
+- **Done when:** OQ-2 is answered with a number or with "no such bound", **in writing**.
+  A measured absence closes FR-7 with no code, and that is a good outcome, not a wasted
+  task.
+
+### T-05 — remove the bound, if there is one
+- **What:** whichever shape T-04 points at (per-call dispatcher, or `node:http` for this
+  route). Scoped to the streaming route only; every other `fetchMycelium` caller keeps
+  today's behaviour, with a comment saying why they differ.
+- **Where:** `app/api/chat/[instance]/route.ts`, `lib/mycelium.ts`.
+- **Depends on:** T-04.
+- **Skip if:** T-04 found no bound. Say so here rather than deleting the task.
+- **Covers:** FR-7, FR-9.
+
+### T-06 — `X-Accel-Buffering: no`
+- **What:** one header on the streaming response, beside `Cache-Control`, with a comment
+  naming what it guards against.
+- **Where:** `app/api/chat/[instance]/route.ts`.
+- **Covers:** FR-8.
+
+---
+
+## Group D — reacting to the member's actual network (`crab-exoskeleton-webapp`)
+
+Shipped with Group B (spec DEC-7): client-only, small, and the part that most directly
+answers the complaint as it was filed.
+
+### T-07 — wake on `online` and `visibilitychange`, and name offline as offline
+- **What:** an interruptible sleep in `recover`'s poll loop; module-scope `online` /
+  `visibilitychange` listeners that wake every waiter and reset any backoff; the band
+  reads `navigator.onLine` and says the device is offline while it is false.
+- **Where:** `app/chat/turn-store.ts`, `app/chat/turn-progress.tsx` (or the band arm in
+  `chat-view.tsx`), `lib/i18n/chat.ts` — **both locales**.
+- **Done when:** `RECOVERY_BUDGET_MS` is unchanged in effect — waking early takes samples
+  sooner, it must not extend the wait.
+- **Note:** `navigator.onLine` is used only to soften the message when it is definitely
+  false, never to conclude the network is fine (it reports a captive portal as online).
+- **Tests:** design 17, 18.
+- **Covers:** FR-20, FR-21, FR-22, FR-23.
+
+---
+
+## T-08 — measure, then decide about Group C (gate, no code)
+
+- **What:** with A, B and D in production for long enough to see real long turns, count
+  how often the recovery path still fires. `long-turn-resilience` OQ-1 already noted that
+  a recovery that fires **is** a cut that happened; that is the counter.
+- **Done when:** the finding is written into `spec.md` OQ-1, and Group C is either started
+  or stood down with a reason.
+- **This is a real gate.** DEC-2 committed to building C; it did not commit to building it
+  blind. If cuts have effectively stopped, the honest outcome is to record that and leave
+  C specified and unbuilt — which is a better state for this repo than an unmeasured
+  re-attach path.
+
+---
+
+## Group C — re-attaching to a live turn
+
+### Proxy (`crab-shell-proxy`)
+
+#### T-09 — the per-turn frame log
+- **What:** `turnStreams`, keyed like `turnRegistry` (`memgraph.Scope → sessionID`),
+  holding sequenced frames, live subscribers, and terminal state + terminal time. Byte cap
+  with front-drop and a `truncated` marker; **60s** retention after the terminal frame
+  (FR-11).
+- **Where:** `internal/httpapi/` — a new file beside `turn_registry.go`.
+- **Reuses:** `scopeOf(key)` and the registry's keying, deliberately, so the two structures
+  cannot disagree about what a turn is. Also its `now func() time.Time` field, for the
+  same reason: the retention test must not sleep.
+- **Done when:** `append` performs only non-blocking sends and drops a full subscriber
+  (FR-14a). If it selects with a timeout, or waits on anything, it is wrong — that is the
+  line between "the delivery path changed" and "the turn's execution changed", and the
+  spec's Non-goals now name it explicitly.
+- **Tests:** design 5, 6, 9, 11.
+- **Covers:** FR-10, FR-11, FR-14, FR-14a, FR-17.
+
+#### T-10 — route `streamTurn`'s writers through the log
+- **What:** the four writers append+fan-out instead of writing `w` directly; the POST
+  handler becomes the first subscriber. `id: <n>` precedes each data frame, in the same
+  write. Heartbeats keep writing per-subscriber and never enter the log.
+- **Where:** `internal/httpapi/sse.go`.
+- **Depends on:** T-02, T-09.
+- **Done when:** the existing SSE tests pass **unchanged** — the bytes one subscriber sees
+  are the bytes `streamTurn` used to write, plus `id:` lines.
+- **Tests:** design 4 (still), 5.
+- **Covers:** FR-10, FR-14, FR-6.
+- **Blast radius:** this is the largest edit in the feature, and it is the one place the
+  spec's Non-goals were deliberately narrowed to permit it. The *delivery* path changes;
+  the turn's *production* must not. If this task starts touching `RunTurn`, the picoclaw
+  processor, the completion heuristic, `turnCtx`, or the `clientCtx` guards, stop.
+  `background-turn-dock` DEC-1's "reads state, does not produce it" does **not** apply
+  here — see the amended Non-goal.
+
+#### T-11 — `GET /v1/turns/stream`
+- **What:** the re-attach endpoint. Same authorization as its siblings, `Last-Event-ID`
+  optional, replay-then-live, distinct refusal below a truncated floor, and a plain fast
+  answer when there is no live log. Does **not** call `turns.Begin`.
+- **Where:** `internal/httpapi/handlers.go` (registration beside `:284`/`:288`) and a
+  handler beside them.
+- **Depends on:** T-09, T-10.
+- **Tests:** design 7, 8, 9, 10.
+- **Covers:** FR-12, FR-13, FR-18.
+
+### Webapp (`crab-exoskeleton-webapp`)
+
+#### T-12 — `consumeStream` learns sequences
+- **What:** parse `id:` lines, report the last one seen, accept a starting sequence.
+  Additive only; the `data:`-only filter is untouched.
+- **Where:** `app/chat/turn-store.ts`.
+- **Tests:** design 12, 13. **Test 12 lands here even though Group A needed no webapp
+  change** — it is the regression test for DEC-6, and the webapp is where that contract
+  can be broken.
+- **Covers:** FR-10.
+
+#### T-13 — the re-attach BFF route
+- **What:** a streaming GET mirroring `active/route.ts`'s guards and `route.ts`'s body
+  passthrough, forwarding `Last-Event-ID`. Inherits T-05's dispatcher decision and T-06's
+  header — it is the same kind of stream.
+- **Where:** `app/api/chat/[instance]/stream/route.ts`.
+- **Depends on:** T-11.
+- **Covers:** FR-12.
+
+#### T-14 — try re-attach before polling
+- **What:** in `runTurn`, the cut branch tries `reattach(sid, ctx, lastSeq)` within a
+  bounded, backing-off budget of roughly 30s (FR-16 — visibly under FR-11's 60s retention,
+  so a re-attach cannot lose a race against expiry while still trying), then falls through
+  to `recover(sid, ctx)`. A re-attached turn shows the ordinary working band, not the
+  recovery line.
+- **Where:** `app/chat/turn-store.ts`, and the band arm in `app/chat/chat-view.tsx`.
+- **Depends on:** T-12, T-13.
+- **Done when:** `recover` itself is **unmodified** and the whole `long-turn-resilience`
+  suite still passes untouched (DEC-4 — the poll is the floor and must not be coupled to
+  this).
+- **Tests:** design 14, 15, 16.
+- **Covers:** FR-15, FR-16, FR-19.
+
+#### T-15 — re-attach on reload
+- **What:** `resumeIfActive` re-attaches from the start after confirming with
+  `/v1/turns/active`, instead of entering `recover()`. Keep the `active` probe — it is the
+  cheap question that says whether to re-attach at all.
+- **Where:** `app/chat/turn-store.ts`.
+- **Depends on:** T-14.
+- **Covers:** FR-18.
+
+---
+
+## T-16 — operator verification (the only end-to-end falsifier)
+
+Neither suite can reach these. Record the outcome here.
+
+- A real cut on a real long turn re-attaches and the reply continues, with no error and no
+  blanked conversation.
+- A reload mid-turn rebuilds the partial reply, not an empty band.
+- `visibilitychange` on a genuinely backgrounded mobile tab.
+- Whether the heartbeat reduced observed cuts — the T-08 counter, re-read after C.
+
+## Status
+
+Not started. P-0 first.

--- a/.specs/features/turn-stream-continuity/tasks.md
+++ b/.specs/features/turn-stream-continuity/tasks.md
@@ -169,6 +169,9 @@ answers the complaint as it was filed.
 - **Reuses:** `scopeOf(key)` and the registry's keying, deliberately, so the two structures
   cannot disagree about what a turn is. Also its `now func() time.Time` field, for the
   same reason: the retention test must not sleep.
+- **Decide first:** key by conversation (like the registry) or by turn? Spec OQ-4 — the
+  single-turn assumption holds only because the webapp queues, and steering would break it.
+  A field and a lookup now; a migration later.
 - **Done when:** `append` performs only non-blocking sends and drops a full subscriber
   (FR-14a). If it selects with a timeout, or waits on anything, it is wrong — that is the
   line between "the delivery path changed" and "the turn's execution changed", and the

--- a/.specs/project/ROADMAP.md
+++ b/.specs/project/ROADMAP.md
@@ -148,3 +148,26 @@ Telegram / MS Teams channels.
   conversation-tree-view; no proxy change). Feel-first prototype validated
   (Timeline chosen over Deck/Tree metaphors). See
   `.specs/features/canvas-timeline-view/`.
+- **turn-stream-continuity** (SPEC READY) — the *prevention* half of the cut-stream
+  problem, which `long-turn-resilience`, `resume-turn-after-reload` and
+  `background-turn-dock` all pointed at and all declined. Four groups: a 10s SSE
+  **heartbeat** from the proxy (an SSE *comment*, so it cannot stamp `lastEventAt` and
+  cannot break the band's elapsed readout — Group A therefore needs no webapp change and
+  ships as a proxy-only release); removing the BFF's own inactivity bound on the streaming
+  route (measure first, spec OQ-2); **re-attach to a live turn** via sequenced frames and
+  a `Last-Event-ID` endpoint, with today's transcript-growth poll kept underneath as the
+  floor; and waking a wait on `online`/`visibilitychange` instead of polling blind.
+  Prerequisite P-0: the dock deploy + T-10 half is **done** (2026-08-27); what remains is
+  the pre-heartbeat baseline, which gates T-02 and cannot be taken after it. Build order is
+  A → B+D → measure → C, with T-08 as a real gate. See
+  `.specs/features/turn-stream-continuity/` and STATE.md AD-017.
+- **picoclaw-incremental-streaming** (INVESTIGATION) — the cause, not the symptom.
+  picoclaw answers in one terminal frame (51s of measured silence), which is what makes the
+  SSE idle in the first place and what makes the webapp's typewriter a simulation. The
+  proxy **already** consumes deltas correctly (`internal/pico/turn.go:179` handles
+  `message.update` cumulatively), and picoclaw exposes `StreamingCapable`/`bus.Streamer`
+  which its pico channel implements — so the one-frame behaviour is unexplained and might
+  be a config key. Cheapest high-value hour near this problem. Delivery is already solved:
+  `deploy/picoclaw-glob/` + `release-picoclaw-glob` means a change is a third patch, not a
+  fork. Answers "should we implement an HTTP connection in picoclaw?" — **no**, wrong hop.
+  See `.specs/features/picoclaw-incremental-streaming/investigation.md`.

--- a/.specs/project/ROADMAP.md
+++ b/.specs/project/ROADMAP.md
@@ -171,3 +171,15 @@ Telegram / MS Teams channels.
   `deploy/picoclaw-glob/` + `release-picoclaw-glob` means a change is a third patch, not a
   fork. Answers "should we implement an HTTP connection in picoclaw?" — **no**, wrong hop.
   See `.specs/features/picoclaw-incremental-streaming/investigation.md`.
+- **steering-messages** (INVESTIGATION) — picoclaw folds a message that arrives mid-turn
+  into the running turn (`enqueueSteeringMessage`, `turn_coord.go:115`), and **this stack
+  never reaches that path**: the webapp queues the second message client-side and POSTs it
+  only after the first turn's reveal has drained (`turn-store.ts` `drain`/`awaitDrained`).
+  The proxy imposes nothing — only the browser prevents it. Worth having on long turns (a
+  correction ten seconds in, instead of a wasted five-minute answer), but it renegotiates
+  the turn boundary: two POSTs for one turn with undefined wire semantics, and it stresses
+  the proxy's 500ms `graceWindow` race directly. Deferred to after
+  `turn-stream-continuity`, read together with `picoclaw-incremental-streaming`. **One
+  thing it constrains now:** that feature's Group C frame log is keyed per conversation,
+  which is only safe while the webapp queue holds — see its OQ-4. See
+  `.specs/features/steering-messages/investigation.md`.

--- a/.specs/project/STATE.md
+++ b/.specs/project/STATE.md
@@ -38,6 +38,69 @@ still operator-gated (needs the backend stack). M4 (crab-shell-proxy) live-conta
 
 ## Recent Decisions (Last 60 days)
 
+### AD-017: the chat's cut-stream problem is answered by PREVENTION, not more recovery (2026-08-27)
+
+**Feature:** `.specs/features/turn-stream-continuity/` (spec + context + design + tasks).
+**Companion:** `.specs/features/picoclaw-incremental-streaming/investigation.md`.
+
+Three features already answer "the chat stops representing a running turn", and all three
+are recovery or visibility: `long-turn-resilience` (poll the durable transcript),
+`resume-turn-after-reload` (ask the proxy on mount), `background-turn-dock` (show what runs
+elsewhere). **Two of the three are deployed**, verified commit-by-commit against
+`CHAT_WEBAPP_TAG=sha-d8f9aa7` — so the complaint is being filed against a build that has
+them, and recovery is not the missing half.
+
+What nothing in this stack does is **prevent the cut**. Both specs that noticed said so and
+declined it as out-of-repo: `long-turn-resilience` ("keep-alive frames from the proxy… it
+belongs in the proxy repo") and `multi-harness-support/implementation-notes.md` §9 ("treat
+this as the first problem to solve, not the last"). Nobody built it.
+
+**The chain, joined up for the first time:** picoclaw answers in one terminal frame
+(measured: 51s of complete silence, `chat-responsiveness` OQ-1) → `sse.go` writes nothing
+of its own, so the SSE is genuinely idle for minutes → that idle stream crosses four hops,
+and the one we cannot see or configure is the member's own connection. A stream that is
+never idle cannot be dropped for being idle, by any hop.
+
+**Three findings worth keeping regardless of whether the feature ships:**
+
+1. **The heartbeat must be an SSE comment, not a data frame.** `background-turn-dock`
+   DEC-12 made the band's elapsed readout and the dock's chips both derive from
+   `lastEventAt`. A heartbeat shaped as an empty-delta `x_crab_progress` — the obvious
+   shape — would stamp it every 10s and silently delete `long-turn-resilience`
+   FR-11/FR-12. `consumeStream` filters non-`data:` lines *before* any callback, so a
+   comment cannot. **Group A therefore needs no webapp change at all.**
+2. **The BFF may be cutting its own upstream.** `fetchMycelium` calls bare `fetch` with no
+   dispatcher, so the streaming route inherits the runtime's default inactivity behaviour
+   on a body that is legitimately quiet for minutes. Stated as a hypothesis to measure
+   (spec OQ-2, T-04), not a finding.
+3. **The proxy is already a streaming consumer.** `internal/pico/turn.go:179` handles
+   `message.update` with cumulative-content bookkeeping and emits only the new suffix — so
+   if picoclaw sent deltas, they would already reach the browser with no code change
+   anywhere. picoclaw exposes `StreamingCapable`/`bus.Streamer` and its pico channel
+   implements it. The gap is unexplained and might be a config key.
+
+**Decisions taken with the maintainer:**
+- Scope includes the expensive re-attach path (resumable SSE, `Last-Event-ID`), over the
+  cheaper "hold it as a gated follow-up" reading. The disagreement is recorded honestly in
+  DEC-2 and resolved by build order: **A → B+D → measure (T-08) → C**.
+- Deploying `background-turn-dock` and running its never-run T-10 was a **prerequisite**
+  (P-0), because the build deployed at spec time predated the dock and any before/after
+  judgement taken then would have measured its absence too. **Satisfied 2026-08-27**: the
+  dock is deployed, T-10 confirmed by the maintainer, and that feature is **finished**.
+  What remains of P-0 is the *baseline* — the pre-heartbeat count of how often recovery
+  fires, which must be taken on the dock-carrying build and can never be taken again once
+  T-02 ships.
+- The picoclaw question ("implement an HTTP connection there") is answered **no** — wrong
+  hop, server-to-server inside the Docker network. The real picoclaw item is incremental
+  streaming, investigated in parallel.
+
+**Delivery note that lowers the picoclaw cost:** this stack already ships its own patched
+picoclaw (`deploy/picoclaw-glob/`, two patches, `release-picoclaw-glob` workflow,
+`0.3.1-glob` in production). A picoclaw-side change is a third patch in a tested pipeline,
+not a fork.
+
+Nothing implemented. P-0 first.
+
 ### AD-016: background-turn-dock specified; the premise it started from was wrong (2026-08-18)
 
 **Spec only, not implemented** — `.specs/features/background-turn-dock/`


### PR DESCRIPTION
## Why

Three features already answer "the chat stops representing a running turn", and all three are **recovery or visibility**: `long-turn-resilience` polls the durable transcript, `resume-turn-after-reload` asks the proxy on mount, `background-turn-dock` shows what runs elsewhere. Two of the three were already deployed when the complaint was filed — so recovery is not the missing half.

Nothing in this stack **prevents the cut**, and both specs that noticed said so and declined it as out-of-repo (`long-turn-resilience` "Alternatives not taken"; `multi-harness-support/implementation-notes.md` §9, *"the first problem to solve, not the last"*). `turn-stream-continuity` is that half.

**The chain, joined up for the first time:** picoclaw answers in one terminal frame (51s of measured silence, `chat-responsiveness` OQ-1) → `sse.go` writes nothing of its own, so the SSE is genuinely idle for minutes → that idle stream crosses four hops, and the one we cannot see or configure is the member's own connection.

## What is in here

**`turn-stream-continuity/`** — spec + context + design + tasks. Four groups, build order **A → B+D → measure → C** with T-08 as a real gate:

- **A** — a 10s SSE heartbeat from the proxy. It is an SSE **comment**, not a data frame, because `background-turn-dock` DEC-12 made the band's elapsed readout and the dock's chips both derive from `lastEventAt` — and `consumeStream` filters non-`data:` lines before any callback. So Group A needs no webapp change and ships as a proxy-only release.
- **B** — the BFF's own inactivity bound on the streaming route. Written as a hypothesis to measure (OQ-2), not a finding; a measured absence closes it with no code.
- **C** — re-attach to a live turn: sequenced frames, a `Last-Event-ID` endpoint, and today's transcript-growth poll kept underneath as the floor.
- **D** — wake a wait on `online`/`visibilitychange` instead of polling blind.

Group C's fan-out contradicts the "reads state, does not produce it" wording inherited from `background-turn-dock` DEC-1, so the non-goal is narrowed to name what is actually protected, and FR-14a makes "must not stall the turn" testable.

**`picoclaw-incremental-streaming/`** — answers the question that started this, and the answer is **no**: an HTTP connection between the proxy and picoclaw is the wrong hop, server-to-server inside the Docker network. The real picoclaw item is incremental streaming — the cause rather than the symptom. Two findings: the proxy is **already** a delta consumer (`internal/pico/turn.go:179` handles `message.update` cumulatively), and this stack already ships its own patched picoclaw, so a change is a third patch in a tested pipeline rather than a fork.

**`steering-messages/`** — picoclaw folds a mid-turn message into the running turn; this stack never sends one, because the webapp queues it client-side. Deferred, but it constrains Group C now: the frame log is keyed per conversation, which is only safe while that queue holds. Recorded as OQ-4 with a "decide first" on T-09.

**`background-turn-dock`** — marked **FINISHED**: T-10 was run and confirmed against the live stack. Four non-blocking improvements recorded at the end of its `tasks.md`, including that T-06's BFF route still has no test of its failure arms.

## Also

Submodule pointer moves to `crab-exoskeleton-webapp#48` (PNG brand assets), at its merge commit.

**Docs only — no code changes in this repo.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)