### PR TITLE
docs(specs): record Groups A, B and D as done, with what the measurements found

### DIFF
--- a/.specs/features/turn-stream-continuity/spec.md
+++ b/.specs/features/turn-stream-continuity/spec.md
@@ -164,7 +164,8 @@ re-attach replay ten minutes of pings.
 ### Group B — the BFF stops cutting its own upstream (crab-exoskeleton-webapp)
 
 **FR-7 — The streaming route must not impose an inactivity bound shorter than the
-proxy's own turn bound.**
+proxy's own turn bound. CONFIRMED BY MEASUREMENT — see OQ-2: 300s against the proxy's
+600s.**
 `fetchMycelium` calls bare `fetch` with no dispatcher (`lib/mycelium.ts:79`), so the
 streaming POST inherits whatever the runtime's default inactivity behaviour is. If that
 default is shorter than `turnTimeout` (10 min, `sse.go:19`), then **our own BFF aborts the
@@ -372,10 +373,29 @@ stream that was pinging ten seconds ago is a much narrower event than a cut on a
 silent for a minute; and after Group C, a re-attach reports the sequence it resumed from,
 which says how much was lost.
 
-**OQ-2 — Does the BFF impose an inactivity bound on the upstream body at all?**
-FR-7 is written as a hypothesis for exactly this reason. `fetchMycelium` passes no
-dispatcher, so the answer is the runtime's default, and this spec does not assert what
-that default is on `node:24-alpine`. T-04 measures it before anything is changed.
+**OQ-2 — ANSWERED (2026-08-27, measured): yes. 300 seconds, and it is ours.**
+
+Rig: a stub upstream that sends SSE headers plus one role chunk and then goes silent,
+read back through the runtime's global `fetch` — no Next, no auth, no mycelium, so the
+BFF's own read of `res.body` is the only thing under test. On **Node v24.18.0**, the
+version the runtime image pins:
+
+```
+[   0.0s] headers ok: 200
+[   0.0s] chunk: "data: {"choices":[{"delta":{"role":"assistant","content":""}}]}"
+[ 300.8s] THREW: TypeError / terminated / cause=UND_ERR_BODY_TIMEOUT
+```
+
+**The hypothesis in FR-7 was right, and the number matters:** undici's default
+`bodyTimeout` is 300s, while the proxy's `turnTimeout` is **600s**. So for the five
+minutes between them, a turn that is legitimately still running upstream has its body
+aborted **by our own BFF** — and the member's "the internet dropped" was never the
+internet. The abort surfaces to the client as a mid-stream failure, which
+`long-turn-resilience` correctly treats as a cut and recovers from; that is why this
+has been survivable and therefore invisible.
+
+This does not retire OQ-1. It explains one specific, reproducible cut — the long quiet
+turn — and says nothing about cuts on short turns or flaky connections.
 
 **OQ-4 — Should Group C's frame log be keyed by turn rather than by conversation?**
 FR-10/FR-11 key it `memgraph.Scope → sessionID`, like `turnRegistry`, which assumes at most

--- a/.specs/features/turn-stream-continuity/tasks.md
+++ b/.specs/features/turn-stream-continuity/tasks.md
@@ -66,6 +66,14 @@ feature is finished. Nothing further is required here.
 - **Tests:** existing `sse_progress_test.go` unchanged and green under `-race`.
 - **Covers:** FR-5.
 
+**Status: done** — `crab-shell-proxy#34`, `ccb215b`.
+
+Note for anyone reading the design: its literal wording ("all five write sites take
+the mutex") **deadlocks**. `done()` calls `writeChunk` and Go mutexes are not
+reentrant. Shipped as `emit*` (unlocked bodies) + `write*` (locking wrappers), with
+`done()` taking the lock once across both terminal frames — which is also what keeps
+a ping from landing between them.
+
 ### T-02 — the heartbeat
 - **What:** `const heartbeatInterval = 10 * time.Second` beside `turnTimeout`; a ticker
   goroutine started after the initial role chunk flushes, cancelled before `done()`,
@@ -76,6 +84,31 @@ feature is finished. Nothing further is required here.
   frames — `defer cancel()` alone is not enough; see design "Lifetime".
 - **Tests:** design 1, 2, 3, 4.
 - **Covers:** FR-1, FR-2, FR-3, FR-4, FR-6.
+
+**Status: done** — `crab-shell-proxy#34`, `ccb215b`.
+
+`stopHeartbeat()` **waits** for the goroutine to exit rather than only cancelling:
+signalling without waiting would let a ping be written after `streamTurn` returns, to
+a `ResponseWriter` that is no longer valid. The design said "a `context.WithCancel`
+derived from `turnCtx`, cancelled by a `defer`, is enough" — it is not.
+
+The cadence seam is an unexported `Server.heartbeatEvery`, a field rather than a
+package var for the same reason `turnRegistry.now` is one: the tests run
+`t.Parallel()`.
+
+**Two tests were inert on the first pass and are recorded because the pattern
+recurs.** The comment-shape test searched for the word "ping", so reshaping the
+heartbeat made it fail with "nothing to assert on" — it detected the mutation while
+misidentifying it; it now counts data frames instead. And the recorder locked its own
+`Write`, which *substitutes* for `writeMu` rather than isolating it (every frame is
+one `Write` call), so removing the mutex produced no race and no failure; the
+recorder is now deliberately unsynchronized and that mutation reports `DATA RACE`.
+
+**One property is not covered, by construction.** "No ping between `finish_reason`
+and `[DONE]`" cannot be provoked from outside: the window is microseconds, and
+widening it with a blocking `Write` does not help because the sleep runs while
+`writeMu` is held. Removing both guards still passed five runs of five. The guarantee
+is structural and visible in `sse.go`; the test is a smoke test over it.
 
 ### T-03 — verify a comment frame survives the whole path (operator, OQ-3)
 - **What:** with T-02 deployed, watch real long turns from the browser and confirm the
@@ -105,6 +138,16 @@ feature is finished. Nothing further is required here.
   A measured absence closes FR-7 with no code, and that is a good outcome, not a wasted
   task.
 
+**Status: done** — **300.8s, `UND_ERR_BODY_TIMEOUT`, on Node v24.18.0.** Full output in
+`spec.md` OQ-2. undici's default `bodyTimeout` is 300s; the proxy's `turnTimeout` is
+600s. For the five minutes between them our own BFF was aborting turns that were still
+running upstream.
+
+Rig: `scratchpad/t04-rig.mjs` — a stub upstream sending SSE headers plus a role chunk
+and then nothing, read back through the global `fetch`. Deliberately no Next, no auth,
+no mycelium: the BFF's own read of `res.body` is the question, everything else is
+noise.
+
 ### T-05 — remove the bound, if there is one
 - **What:** whichever shape T-04 points at (per-call dispatcher, or `node:http` for this
   route). Scoped to the streaming route only; every other `fetchMycelium` caller keeps
@@ -114,11 +157,33 @@ feature is finished. Nothing further is required here.
 - **Skip if:** T-04 found no bound. Say so here rather than deleting the task.
 - **Covers:** FR-7, FR-9.
 
+**Status: done** — `crab-exoskeleton-webapp#49`, `567650e`. `lib/mycelium-stream.ts`,
+undici's own `fetch` with `Agent{bodyTimeout: 0, headersTimeout: 0}`.
+
+**Both shapes were measured, as design.md asked, rather than picked.** undici's fetch
+and `node:http` with `setTimeout(0)` both ran clean at 310s against the silent stub.
+undici wins because it returns a standard `Response`, leaving the route's auth and
+error paths untouched; `node:http` would have meant rewriting them by hand. Recorded
+because a reviewer objecting to the dependency has a validated alternative here.
+
+**It lives in its own module, and that is not tidiness.** Putting it in
+`lib/mycelium.ts` first pulled undici into the BROWSER bundle — that file is imported
+by 52 files including `"use client"` components (`app/admin/user-models-panel.tsx`) —
+and the build failed with a wall of `UnhandledSchemeError: Reading from "node:assert"`.
+
+**And the control run says it is currently belt-and-braces:** the same rig with a 10s
+heartbeat ran the full 330s and ended cleanly, so Group A already makes this bound
+unreachable. It ships because the heartbeat MASKS the bound rather than removing it —
+a cadence change or a proxy predating the heartbeat brings the 300s cut straight back,
+silently, five minutes into a turn nobody is watching.
+
 ### T-06 — `X-Accel-Buffering: no`
 - **What:** one header on the streaming response, beside `Cache-Control`, with a comment
   naming what it guards against.
 - **Where:** `app/api/chat/[instance]/route.ts`.
 - **Covers:** FR-8.
+
+**Status: done** — `crab-exoskeleton-webapp`, `a0c232b`.
 
 ---
 
@@ -139,6 +204,17 @@ answers the complaint as it was filed.
   false, never to conclude the network is fine (it reports a captive portal as online).
 - **Tests:** design 17, 18.
 - **Covers:** FR-20, FR-21, FR-22, FR-23.
+
+**Status: done** — `crab-exoskeleton-webapp`, `a0c232b`.
+
+The tests live in their own file with an `@vitest-environment jsdom` pragma, and that
+is load-bearing rather than tidiness: the listeners register at module scope behind
+`typeof window !== "undefined"`, which is **false at import time** under the suite's
+default `node` environment. `vi.stubGlobal("window", …)` cannot stand in — it runs
+long after the import — so under `node` the wiring would not exist and the tests
+would pass against nothing.
+
+Mutation-checked: reverting the poll to the blind `sleep` fails both wake tests.
 
 ---
 
@@ -261,4 +337,15 @@ Neither suite can reach these. Record the outcome here.
 
 ## Status
 
-Not started. P-0 first.
+**Group A: done** (T-01, T-02) — `crab-shell-proxy#34`. Ships proxy-only, as designed.
+**T-03 (operator): not run.** It is what closes Group A.
+**Group B: done** (T-04, T-05, T-06) — `crab-exoskeleton-webapp#49`. T-04 found a real
+bound and it was ours: **300.8s, `UND_ERR_BODY_TIMEOUT`**, against the proxy's 600s.
+**Group D: done** (T-07).
+**Group C: not started, and correctly so** — T-08 gates it, and P-0b's baseline has
+not been taken.
+
+The one thing that is now urgent and is not code: **P-0b**. Once T-02 reaches
+production the pre-heartbeat count can never be taken again, and without it T-08 —
+the gate that decides whether Group C is built at all — produces one figure and
+nothing to compare it against.

--- a/.specs/project/STATE.md
+++ b/.specs/project/STATE.md
@@ -69,10 +69,15 @@ never idle cannot be dropped for being idle, by any hop.
    shape — would stamp it every 10s and silently delete `long-turn-resilience`
    FR-11/FR-12. `consumeStream` filters non-`data:` lines *before* any callback, so a
    comment cannot. **Group A therefore needs no webapp change at all.**
-2. **The BFF may be cutting its own upstream.** `fetchMycelium` calls bare `fetch` with no
-   dispatcher, so the streaming route inherits the runtime's default inactivity behaviour
-   on a body that is legitimately quiet for minutes. Stated as a hypothesis to measure
-   (spec OQ-2, T-04), not a finding.
+2. **The BFF WAS cutting its own upstream — measured 2026-08-27, and the hypothesis was
+   right.** `fetchMycelium` called bare `fetch` with no dispatcher, so the streaming route
+   inherited undici's default `bodyTimeout` of **300s** on a body that is legitimately
+   quiet for minutes, against the proxy's `turnTimeout` of **600s**. For the five minutes
+   between them our own BFF aborted turns that were still running upstream, and the member
+   read it as their internet dropping. `long-turn-resilience` recovered the reply, which is
+   why it was survivable and therefore invisible. Rig and output in the feature's
+   `spec.md` OQ-2. **It does not close OQ-1** — it explains the long quiet turn and nothing
+   else.
 3. **The proxy is already a streaming consumer.** `internal/pico/turn.go:179` handles
    `message.update` with cumulative-content bookkeeping and emits only the new suffix — so
    if picoclaw sent deltas, they would already reach the browser with no code change
@@ -99,7 +104,26 @@ picoclaw (`deploy/picoclaw-glob/`, two patches, `release-picoclaw-glob` workflow
 `0.3.1-glob` in production). A picoclaw-side change is a third patch in a tested pipeline,
 not a fork.
 
-Nothing implemented. P-0 first.
+**Implemented 2026-08-27: Groups A, B and D.** `crab-shell-proxy#34` (heartbeat),
+`crab-exoskeleton-webapp#49` (BFF bound, `X-Accel-Buffering`, network-aware waiting).
+Group C is deliberately NOT started: T-08 gates it and P-0b's baseline has not been
+taken.
+
+**Two things learned in the doing, both worth more than the code:**
+
+- **The design's literal wording for T-01 deadlocks.** "All five write sites take the
+  mutex" cannot work — `done()` calls `writeChunk` and Go mutexes are not reentrant.
+  Shipped as unlocked `emit*` bodies plus locking `write*` wrappers, with `done()`
+  holding the lock once across both terminal frames.
+- **Two tests were inert on the first pass, in the same way twice:** an assertion that
+  looked for a specific shape ("ping") and a harness that synchronized what it was
+  supposed to observe (a locked recorder standing in for `writeMu`). Both were caught by
+  deliberately mutating the implementation rather than by reading the tests. The habit is
+  the finding.
+
+**Now urgent and not code: P-0b.** Once the heartbeat is deployed the pre-heartbeat
+recovery-rate count can never be taken again, and without it T-08 — the gate that decides
+whether Group C is built at all — produces one figure and nothing to compare it against.
 
 ### AD-016: background-turn-dock specified; the premise it started from was wrong (2026-08-18)
 


### PR DESCRIPTION
`turn-stream-continuity` is implemented except **Group C**, which is correctly gated on T-08.

Shipped: [crab-shell-proxy#34](https://github.com/LepistaBioinformatics/crab-shell-proxy/pull/34) (Group A — heartbeat) and [crab-exoskeleton-webapp#49](https://github.com/LepistaBioinformatics/crab-exoskeleton-webapp/pull/49) (Groups B and D).

## The measurement that turned a hypothesis into a finding

T-04 / OQ-2: the BFF's own inactivity bound is **300s** (undici's default `bodyTimeout`) against the proxy's **600s** `turnTimeout`. For the five minutes between them we were aborting turns that were still running upstream, and the member read it as their internet dropping.

**It does not close OQ-1** — it explains the long quiet turn and says nothing about short turns or flaky connections.

The control run is recorded beside it: the same rig **with** a 10s heartbeat ran the full 330s and ended cleanly, so Group A already makes that bound unreachable. T-05 shipped anyway, because the heartbeat *masks* the bound rather than removing it.

## Two things learned in the doing, recorded because they will recur

- **The design's literal wording for T-01 deadlocks.** "All five write sites take the mutex" cannot work — `done()` calls `writeChunk`, and Go mutexes are not reentrant.
- **Two tests were inert on the first pass, in the same way twice:** an assertion keyed to a specific shape (searching for the word `ping`), and a harness that synchronized the very thing it was meant to observe (a locked recorder standing in for `writeMu`). Both were caught by deliberately mutating the implementation, not by re-reading the tests.

## Still open, and one of them is time-sensitive

- **P-0b — the pre-heartbeat baseline. Urgent.** Once the heartbeat reaches production the pre-heartbeat recovery-rate count can never be taken again, and without it **T-08** — the gate that decides whether Group C is built at all — produces one figure and nothing to compare it against.
- **T-03** — operator verification that `: ping` frames survive Traefik → BFF → mycelium → browser (OQ-3). Done when observed on ≥3 turns of >60s, from ≥2 networks, one mobile.
- **P-0c** — `deploy/dokploy/.env.example:96` still reads `CHAT_WEBAPP_TAG=sha-d8f9aa7`, which is not what is deployed. An L-007 trap.

Submodule pointer moves to `crab-exoskeleton-webapp#49`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)