### PR TITLE
docs(deploy): say why `latest` silently does nothing on Dokploy

### DIFF
--- a/deploy/dokploy/.env.example
+++ b/deploy/dokploy/.env.example
@@ -51,6 +51,22 @@ CHAT_WEBAPP_DB_NAME=chatwebapp
 # Pin RELEASED tags for reproducible deploys instead of :latest. Keep mycelium on
 # the same release standalone builds from source (MYCELIUM_GIT_REF in
 # deploy/standalone/.env.example).
+#
+# ON DOKPLOY, `latest` IS NOT MERELY UNREPRODUCIBLE -- IT SILENTLY DOES NOTHING.
+# Dokploy runs `docker compose up -d --build` WITHOUT `--pull always`, and for a
+# service declared with `image:` Compose only pulls when the image is absent from the
+# local cache. So republishing `:latest` and hitting redeploy leaves the host serving
+# the OLD image, and the symptom is "the fix didn't work" -- which sends you looking
+# at the fix instead of at the deploy. Changing the tag is what forces the pull,
+# because that tag is not in cache yet.
+#
+# This is recorded as L-007 and it has now cost time twice: once on the webapp, and
+# again on crab-shell-proxy, where the pin was never applied and the SSE heartbeat
+# (turn-stream-continuity Group A) would have been redeployed as a no-op.
+#
+# Both workflows publish `sha-<7>`, `main`, `latest` and the semver tags
+# (`type=sha` in docker/metadata-action). Use a `sha-` tag from a build you have
+# verified as `success`, not a tag you remember.
 MYCELIUM_IMAGE_TAG=9.0.0-rc.13
 CRAB_SHELL_PROXY_TAG=latest
 CHAT_WEBAPP_TAG=latest


### PR DESCRIPTION
The block already said *"pin RELEASED tags for reproducible deploys instead of :latest"* and then shipped `latest` for both images, without saying what actually goes wrong.

What goes wrong is not unreproducibility — **it is a no-op.** Dokploy runs `docker compose up -d --build` **without** `--pull always`, and for a service declared with `image:` Compose pulls only when the image is absent from the local cache. So republishing `:latest` and hitting redeploy leaves the host serving the **old** image, and the symptom is *"the fix didn't work"* — which sends you looking at the fix rather than at the deploy.

This is L-007, and it has now cost time **twice**: once on the webapp, and again on `crab-shell-proxy`, where the pin was never applied. That second one nearly mattered: `turn-stream-continuity` Group A is a **proxy** change, so with `CRAB_SHELL_PROXY_TAG=latest` the heartbeat would have been redeployed as a no-op — and T-03, the operator check that the pings reach the browser, would have silently verified a build that did not contain them.

**No values changed here.** This file is the generic template, and a specific sha is meaningless to someone deploying the product themselves; what was missing was the reason. The concrete pins belong in the deployment's own env and in `zombie-crab-project-mkt`'s copy of this file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)