### PR TITLE
docs(standalone): correct two things the env example got wrong

### DIFF
--- a/deploy/standalone/.env.example
+++ b/deploy/standalone/.env.example
@@ -5,10 +5,13 @@
 # every service is built locally; host ports are published.
 # =============================================================================
 
+# NO IMAGE TAGS HERE, and that is not an omission. Standalone BUILDS every service
+# from the local checkout (`build:` in docker-compose.yaml, not `image:`), so
+# CRAB_SHELL_PROXY_TAG / CHAT_WEBAPP_TAG -- which the prod and dokploy modes pin --
+# do nothing in this mode. What you get is whatever is in your working tree, which is
+# the point of testing here first.
+
 # --- crab-shell-proxy -------------------------------------------------------
-# The picoclaw image the proxy spawns is NOT an env var: it comes from
-# `picoclawImage` in crab-shell-proxy's config.yaml. Only the variables below
-# are read from the environment (internal/config.Load).
 # Absolute HOST path of the data root; defaults to ${PWD}/data when compose runs
 # from the project root. Set explicitly if you run from elsewhere.
 #CRAB_HOST_DATA_ROOT=/absolute/path/to/zombie-crab-project/data
@@ -63,3 +66,13 @@ MYCELIUM_WEBAPP_PORT=8081
 CHAT_WEBAPP_DB_USER=chatwebapp
 CHAT_WEBAPP_DB_PASSWORD=change-me-db
 CHAT_WEBAPP_DB_NAME=chatwebapp
+
+# --- picoclaw image the proxy spawns ----------------------------------------
+# This file used to state that the spawned image is "NOT an env var: it comes from
+# `picoclawImage` in crab-shell-proxy's config.yaml". That is wrong -- see
+# docker-compose.yaml, which passes CRAB_PICOCLAW_IMAGE into the proxy's environment
+# with this same default. Left commented because the default is the one you want:
+# the locally built, patched image (agent-projects depends on its dispatch-selector
+# patch). Point it at docker.io/sipeed/picoclaw:latest to run stock picoclaw --
+# projects stop working, nothing else changes.
+#CRAB_PICOCLAW_IMAGE=zombie-crab/picoclaw:0.3.1-glob


### PR DESCRIPTION
Both found while setting the standalone mode up to test `turn-stream-continuity` locally.

**1. A factually wrong claim.** The file said *"The picoclaw image the proxy spawns is NOT an env var: it comes from `picoclawImage` in crab-shell-proxy's config.yaml."* It is an env var — `docker-compose.yaml:173` passes `CRAB_PICOCLAW_IMAGE` into the proxy's environment with a default of `zombie-crab/picoclaw:0.3.1-glob`. Anyone trying to run stock picoclaw would have gone looking in `config.yaml` on this file's say-so. Now documented and commented out, because the default is the one you want — agent-projects depends on the local image's `dispatch-selector` patch.

**2. A missing why.** Nothing said why this file has no image tags while the prod and dokploy examples pin them. Standalone **builds** every service from the local checkout (`build:`, not `image:`), so `CRAB_SHELL_PROXY_TAG` / `CHAT_WEBAPP_TAG` do nothing here. Worth stating now that [mkt#5](https://github.com/LepistaBioinformatics/zombie-crab-project-mkt/pull/5) has pinned them in the dokploy example — their absence here reads as an omission otherwise. And "you get whatever is in your working tree" is precisely the property that makes this the mode to test in first.

**No values changed.** `docker compose config` resolves clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)