### PR TITLE
ci(picoclaw-glob): derive the image's patch list instead of spelling it out

### DIFF
--- a/.github/workflows/release-picoclaw-glob.yml
+++ b/.github/workflows/release-picoclaw-glob.yml
@@ -108,6 +108,28 @@ jobs:
           echo "tag=${TAG}"              >> "$GITHUB_OUTPUT"
           echo "image_tag=${TAG#v}-glob" >> "$GITHUB_OUTPUT"
 
+      # The image's description label names which patches are in the build, and it
+      # used to spell them out by hand -- so adding a third patch published an image
+      # whose own metadata still claimed there were two. Nothing failed; the label
+      # was just quietly wrong, which is the worst way for provenance to be wrong.
+      # Derived from the directory instead, so it cannot drift again.
+      - name: List applied patches
+        id: patches
+        run: |
+          set -euo pipefail
+          LIST="$(ls deploy/picoclaw-glob/*.patch \
+            | xargs -n1 basename \
+            | sed 's/\.patch$//' \
+            | sort \
+            | paste -sd'+' - \
+            | sed 's/+/ + /g')"
+          if [ -z "${LIST}" ]; then
+            echo "no patches found in deploy/picoclaw-glob/ -- this image is the whole reason they exist" >&2
+            exit 1
+          fi
+          echo "applied patches: ${LIST}"
+          echo "list=${LIST}" >> "$GITHUB_OUTPUT"
+
       - name: Decide tags
         id: tags
         env:
@@ -160,7 +182,7 @@ jobs:
           tags: ${{ steps.tags.outputs.list }}
           labels: |
             org.opencontainers.image.title=picoclaw (zombie-crab patches)
-            org.opencontainers.image.description=sipeed/picoclaw ${{ steps.ver.outputs.tag }} + dispatch-selector-glob + vision-unsupported-glm
+            org.opencontainers.image.description=sipeed/picoclaw ${{ steps.ver.outputs.tag }} + ${{ steps.patches.outputs.list }}
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
             org.opencontainers.image.version=${{ steps.ver.outputs.image_tag }}
 


### PR DESCRIPTION
## The drift I just caused

The published image carries

```
org.opencontainers.image.description = sipeed/picoclaw <tag> + dispatch-selector-glob + vision-unsupported-glm
```

with the patch names written by hand. #50 added a third patch, so the run that fired on its merge published `ghcr.io/lepistabioinformatics/picoclaw:0.3.1-glob@sha256:6772d00f…` — an image containing **three** patches, labelled as containing two.

Nothing failed. The label was quietly wrong, which is the worst way for provenance to be wrong: the one place you look to find out what is inside an image lies to you, and no build ever tells you.

## The change

Derive the list from `deploy/picoclaw-glob/*.patch` in a small step before the build, so it cannot drift again:

```
applied patches: context-routed-agent + dispatch-selector-glob + vision-unsupported-glm
```

An empty list **fails the step** rather than publishing an image labelled as if it were stock upstream — the same "a signal, not an inconvenience" posture the Dockerfile takes about a patch that no longer applies.

## Verification

The step's exact shell, run against the current directory, produces the line above. The workflow YAML parses. Nothing else in the file changes: tag selection, the `:latest` guard, and the build args are untouched.

## Note

The image published on #50's merge is *functionally* correct — the patch is in it, all three build gates ran (including the new one), and the fix is live. Only its description label is understated. The next publish relabels it; there is no need to rebuild for this alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)