### PR TITLE
chore(submodule): advance crab-shell-proxy to the context_manager pin, record AD-020

### DIFF
--- a/.specs/features/project-chat-context-loss/investigation.md
+++ b/.specs/features/project-chat-context-loss/investigation.md
@@ -155,6 +155,13 @@ always **written** correctly into the project workspace — the defect is read-o
 fixing the read makes existing transcripts visible again on the next turn. B starts those
 chats from zero, because `bootstrapSession` replays only the default agent's sessions.
 
+**That exclusivity is now enforced, not merely documented.** Because the choice between
+the two silently discards a workspace's context — the stores are separate and nothing
+migrates — leaving it settable from an admin config editor meant one text field could
+inflict the very bug this document is about, across every instance of an agent in a
+subscription. A shipped, so the key is pinned to `"legacy"`. See §5B's status note and
+AD-020.
+
 ### A — Third local patch in `deploy/picoclaw-glob/` (recommended) — **IMPLEMENTED**
 
 Shipped as `deploy/picoclaw-glob/context-routed-agent.patch`, wired into the Dockerfile
@@ -205,7 +212,16 @@ zombie-crab content — and is the only option that also restores summarization 
 chats. It is a bigger patch than the two already there (it crosses the interface), so it
 needs a re-read on every `PICOCLAW_TAG` bump.
 
-### B — `agents.defaults.context_manager: "seahorse"` (no patch)
+### B — `agents.defaults.context_manager: "seahorse"` (no patch) — **CLOSED, see AD-020**
+
+**Status (2026-08-28, after A shipped): no longer reachable as a config change.** The proxy
+now pins `agents.defaults.context_manager` to `"legacy"` on every materialization
+(`internal/docker/materialize.go`, `PinnedContextManager`), and the path is in
+`ManagedConfigPaths` — so both admin config editors refuse it and a template or hand edit
+is overwritten. Adopting seahorse is now a code change to that constant, plus a plan for
+the transcripts it orphans. The analysis below is kept because it is the reasoning that
+decided the pin's value, not because the option is open. AD-020 in `STATE.md` carries the
+decision.
 
 The seahorse manager keeps one SQLite engine keyed by session key
 (`context_seahorse.go`), ingests through `turnState.ingestMessage` with the routed

--- a/.specs/project/STATE.md
+++ b/.specs/project/STATE.md
@@ -9,6 +9,8 @@ turn after the first. Shipped as a third local patch,
 `deploy/picoclaw-glob/context-routed-agent.patch` (+239/−7 across 8 files), with three
 tests gated in the image build. Operator-verified: the previously amnesiac conversation
 got its memory back after the container picked up the new image.
+Followed by AD-020: the key that selects the context manager is now pinned, so the same
+context loss cannot be inflicted from an admin config editor.
 **Two follow-ups are open, neither blocking:** `ContextManager.Clear` is deliberately out
 of the patch (interface break — `/clear` in a project chat still clears the main agent's
 store), and the defect is unreported upstream. See
@@ -51,6 +53,42 @@ still operator-gated (needs the backend stack). M4 (crab-shell-proxy) live-conta
 
 ## Recent Decisions (Last 60 days)
 
+### AD-020: `agents.defaults.context_manager` is pinned, not admin-editable (2026-08-28)
+
+**Decision:** the proxy writes `agents.defaults.context_manager = "legacy"` into every
+workspace on every materialization (`internal/docker/materialize.go`,
+`PinnedContextManager`) and lists the path in `ManagedConfigPaths`. Both admin config
+editors therefore refuse it, and a template or hand edit in the volume is overwritten too.
+
+**Why.** The key selects which ContextManager assembles a turn's history, and picoclaw
+activates exactly one per process. `legacy` reads the agent's session JSONL; `seahorse`
+reads its own SQLite. **They share no store, so switching migrates nothing** — it silently
+starts every conversation in the workspace over, and switching back strands whatever
+accumulated in between. No error, no warning, and for the member it is indistinguishable
+from the agent having forgotten them. That is AD-019's bug, reachable from a text field.
+
+**What made it urgent rather than a note.** The bulk config editor applies one key across
+*every instance of an agent in a subscription* — N workspaces belonging to other people,
+in one request.
+
+**Why pinned rather than gated.** `ManagedConfigPaths` is authoritative *because the proxy
+rewrites those paths* ("not a diff, not a whitelist"). Giving the key a writer and listing
+it reuses that end to end: the bulk editor refuses with `ErrManagedConfigPath` before
+touching disk, the single-instance editor's reapply takes an edit back, and the admin UI
+already renders managed paths read-only from the list it is served. A per-key deny concept
+would have meant a new API field and a webapp change for the same result.
+
+**`"legacy"` changes nothing.** It is what picoclaw resolves to when the key is absent, so
+the pin removes only the ability to change it.
+
+**Accepted cost, stated so it is not discovered later:** this is stronger than "admins
+cannot edit it" — the pin re-imposes on every materialization, so the template stops being
+an escape hatch. **AD-019's Option B is closed by this.** Adopting seahorse is now a
+reviewed change to one constant plus a plan for the transcripts it orphans, which is the
+weight that decision deserves.
+
+---
+
 ### AD-019: patch picoclaw's context manager to read the ROUTED agent's sessions, rather than adopt `seahorse` (2026-08-28)
 
 **Decision:** ship `deploy/picoclaw-glob/context-routed-agent.patch` — a third local
@@ -70,7 +108,9 @@ project sessions were also never summarized.
 every project its own agent. Main-agent chats were never affected — for the default agent
 the guess is correct.
 
-**Why not `seahorse` (the zero-patch option).** It keeps one SQLite engine keyed by
+**Why not `seahorse` (the zero-patch option).** *Since AD-020 this option is not merely
+unchosen but closed: the key is pinned and no longer settable from a config editor, a
+template, or the volume.* It keeps one SQLite engine keyed by
 session key, so it is agent-agnostic by accident of shape and would have fixed this with a
 config change. Rejected on three counts: its DB lives in the *default* agent's workspace
 (project content leaves the project boundary); `bootstrapSession` replays only the default


### PR DESCRIPTION
Advances `crab/crab-shell-proxy` from `0cc3f9c` to `c5aa7ad`, picking up LepistaBioinformatics/crab-shell-proxy#36, and amends the two documents that were about to be read as live advice.

## What the pointer picks up

The proxy now writes `agents.defaults.context_manager = "legacy"` into every workspace on every materialization and lists the path in `ManagedConfigPaths`, so **neither admin config editor can set it** — the bulk editor refuses it with `ErrManagedConfigPath` before touching disk, and the single-instance editor's reapply takes an edit back.

That key selects which `ContextManager` assembles a turn's history, and the two implementations share no store: `legacy` reads the agent's session JSONL, `seahorse` reads its own SQLite. Switching migrates nothing — it silently starts every conversation in the workspace over, with no error and nothing for the member to see but an agent that has forgotten them. The bulk editor made that reachable across *every instance of an agent in a subscription* in one request. It is #50's bug, inflictable from a text field.

`"legacy"` is what picoclaw already resolves to when the key is absent, so the pin changes no behaviour — it only removes the ability to change it.

## Why the docs change too

AD-019 recommended seahorse as the zero-patch **Option B**. After the pin, that option is not merely unchosen — it is **unreachable** without a code change. Leaving the recommendation standing would be the same failure mode as the stale `internal/history` comment corrected in #51: a document that is confidently wrong at the exact moment someone reads it to make a decision.

So:

- **AD-019** gets the correction inline, where the recommendation is, rather than only in a newer entry someone might not reach.
- **§5B** of the investigation gets a status note; the analysis stays, because it is the reasoning that decided the pin's *value*, not a live option.
- **§5's "A and B are mutually exclusive"** paragraph now records that the exclusivity is **enforced** rather than merely documented, and why it had to be.
- **AD-020** carries the decision itself.

## The cost, recorded rather than discovered later

The pin is stronger than "admins cannot edit it": it re-imposes on every materialization, so a template edit or a hand edit in the volume is overwritten too. The template stops being an escape hatch. Adopting seahorse becomes a reviewed change to one constant plus a plan for the transcripts it will orphan — which is the weight that decision deserves. AD-020 states this as an accepted cost, not a side effect.

## Next

`zombie-crab-project-mkt` advances once after this merges, closing the chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)