### PR TITLE
ci: check submodule pointers instead of asking politely

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -3,35 +3,6 @@
 Monorepo-wide rules. Each submodule has its own `.claude/CLAUDE.md` for rules that
 only apply inside it; this file holds what applies across the stack.
 
-## Open this repo's PR only after its submodules' PRs are merged
-
-`crab/crab-shell-proxy` and `crab/crab-exoskeleton-webapp` are separate
-repositories with their own PRs. **Do not open — or even commit — a pointer bump
-here until the commit it points at is a merge on that submodule's `main`.**
-
-**Why.** A pointer recorded against a PR branch head is stale the moment that PR
-merges: the merge commit is a different sha, and the branch it named can be
-deleted. This repository then lands describing a proxy or a webapp that no branch
-points at any more, and the fix is a second PR that exists only to move a line.
-That happened on 2026-09-06 — #54 was opened with both pointers at branch heads
-and needed `08971f8` before it could merge, and the repo above this one merged a
-pointer at a PR-branch commit and needed a correction PR of its own.
-
-**While waiting:** open the submodule PRs, report the merge order, and commit
-nothing here. An unpushed commit that has to be amended is worse than no commit —
-a rebase or a branch switch can strand it.
-
-**Unless the maintainer asks otherwise.** "Open all of them now so I can review
-the whole chain" is a legitimate request. When it is made, the PR body must say
-which pointers are branch heads and what has to be advanced before it lands.
-
-**When they are merged:** `git -C crab/<name> checkout main && git pull
---ff-only`, then commit the bump naming the merge commits and their PR numbers.
-
-The repository ABOVE this one (`zombie-crab-project-mkt`, which carries this one
-as a submodule) has the same rule for the same reason, in its own
-`.claude/CLAUDE.md`. The chain is merged bottom-up, one level at a time.
-
 ## Calling mycelium
 
 **Always call mycelium over JSON-RPC. Never add a new call to its REST surface.**

--- a/.claude/rules/submodule-pointers.md
+++ b/.claude/rules/submodule-pointers.md
@@ -1,0 +1,26 @@
+---
+description: When a submodule pointer may be committed, and the check that enforces it
+---
+
+# Submodule pointers
+
+`crab/crab-shell-proxy` and `crab/crab-exoskeleton-webapp` are separate repositories
+with their own PRs.
+
+**A pointer may only name a commit reachable from that submodule's default branch.**
+Reachable, not equal: pointing at an older commit on `main` is ordinary and allowed.
+Pointing at a commit that exists only on a PR branch is not — that commit disappears
+when the branch does, and this repository is left describing a tree nothing points at.
+
+In practice: merge the submodule's PR first, then
+`git -C crab/<name> checkout main && git pull --ff-only`, then commit the bump naming
+the merge commit and its PR number.
+
+**This is enforced, not trusted.** `.github/workflows/submodule-pointers.yml` fails the
+PR when a pointer is off the child's default branch, so a stale pointer cannot be merged
+by anyone — agent or human — whatever any instruction file says. Read the workflow, not
+this file, if the two ever disagree.
+
+Opening the parent PR early is a judgement call, not a violation: the check is what
+holds, so "open all three so I can review the chain" is fine as long as the PR body says
+which pointers are branch heads.

--- a/.github/workflows/submodule-pointers.yml
+++ b/.github/workflows/submodule-pointers.yml
@@ -1,0 +1,59 @@
+# A submodule pointer must name a commit that exists on the child's default branch.
+#
+# Written after a chain of four PRs merged bottom-up by hand and one of them landed with
+# a pointer at a PR branch head, which needed a second PR to correct. The instruction
+# file that was supposed to prevent it said the right thing and was read by nobody at
+# the moment that mattered: the failure is at the MERGE button, and only a check is
+# there too.
+name: submodule pointers
+
+on:
+  pull_request:
+    paths:
+      - "crab/**"
+      - ".gitmodules"
+      - ".github/workflows/submodule-pointers.yml"
+
+jobs:
+  on-default-branch:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      # No `submodules:` — the pointers are read out of the tree and resolved through
+      # the API, so nothing has to be cloned and a private submodule would not need a
+      # token of its own.
+      - uses: actions/checkout@v4
+
+      - name: Every pointer is on its submodule's default branch
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -uo pipefail
+          owner="${GITHUB_REPOSITORY%%/*}"
+          status=0
+          while read -r _ path; do
+            sha="$(git rev-parse "HEAD:$path")"
+            # Same org, and the repo is the submodule directory's own name — true for
+            # every submodule in this chain, and a relative .gitmodules URL offers
+            # nothing better to go on.
+            repo="$(basename "$path")"
+            branch="$(gh api "repos/$owner/$repo" --jq .default_branch 2>/dev/null)" || branch=""
+            if [ -z "$branch" ]; then
+              echo "::error::$path — cannot read $owner/$repo through the API"
+              status=1
+              continue
+            fi
+            state="$(gh api "repos/$owner/$repo/compare/$branch...$sha" --jq .status 2>/dev/null)" || state="unreachable"
+            case "$state" in
+              # `behind` means the pointer is an ancestor of the branch tip, which is
+              # the ordinary case for a deliberate lag. `identical` is the tip itself.
+              identical|behind)
+                echo "ok       $path -> ${sha:0:7} (on $branch)" ;;
+              *)
+                echo "::error::$path -> ${sha:0:7} is NOT on $owner/$repo@$branch (compare says: $state)."
+                echo "::error::Merge the submodule's PR first, then advance this pointer to the merge commit."
+                status=1 ;;
+            esac
+          done < <(git config --file .gitmodules --get-regexp '^submodule\..*\.path$')
+          exit $status


### PR DESCRIPTION
Replaces #55's prose with a check, and keeps ten lines of *why* in `.claude/rules/`.

## Why #55 was not enough

I wrote that rule and then evaluated it honestly at the maintainer's request. It addresses the wrong step. The pointer that went wrong in the parent repo was **written correctly** — the PR body said which pointers were branch heads and what to advance first — and it was **merged anyway**. The failure is at the merge button, and an instruction file is not there: it binds an agent that reads it, and nothing else.

## The check

Every submodule pointer must name a commit **reachable from the child's default branch**.

*Reachable*, not *equal to the tip*: pointing at an older commit on `main` is deliberate and ordinary. Pointing at a commit that exists only on a PR branch is the failure — that commit disappears when the branch does, and this repository is left describing a tree nothing points at.

Both submodules are public and in the same org, so the default `GITHUB_TOKEN` resolves them through the API. Nothing is cloned; `.gitmodules` is read for paths and the pointer comes out of the tree.

## Verified both ways

```
ok       crab/crab-shell-proxy -> cd35d0d (on main)
ok       crab/crab-exoskeleton-webapp -> 3837092 (on main)
exit=0
```

and, against a throwaway commit pushed to a branch and deleted afterwards:

```
::error::crab/crab-exoskeleton-webapp -> 461fb3e is NOT on …@main (compare says: ahead).
::error::Merge the submodule's PR first, then advance this pointer to the merge commit.
exit=1
```

## What moves where

- `.claude/CLAUDE.md` loses the block #55 added.
- `.claude/rules/submodule-pointers.md` (a directory Claude Code loads automatically alongside CLAUDE.md) keeps the *why* and says plainly: read the workflow, not this file, if the two disagree.
- Opening the parent PR early stops being a violation and becomes a judgement call — the check is what holds, so "open all three so I can review the chain" is fine as long as the body says which pointers are branch heads.

## Also reviewed, and deliberately left alone

- **The patch apply order in `deploy/picoclaw-glob/`** is already enforced: `git apply` runs without fuzz, so a patch that no longer applies fails the image build. A rule would restate a check that exists.
- **The mycelium JSON-RPC rule** stays here as the stack-wide policy. Its enforceable half belongs in `crab-exoskeleton-webapp`, where every call is actually made — that is a separate PR, and it found something (see it for details).

🤖 Generated with [Claude Code](https://claude.com/claude-code)