### PR TITLE
docs(specs): plan harness-sphere adoption and its zombie-crab-only turn

### DIFF
--- a/.specs/features/harness-sphere-integration/design.md
+++ b/.specs/features/harness-sphere-integration/design.md
@@ -1,0 +1,201 @@
+# harness-sphere-integration — Design
+
+**Status:** DESIGN. Settles OQ-5, which `spec.md` left open as the only F1 requirement
+whose shape was genuinely undecided. Everything else here is the shape the requirements
+already imply.
+**Date:** 2026-09-07.
+
+## Topology
+
+```mermaid
+flowchart LR
+    subgraph host["host (hospedeiro)"]
+        subgraph net["zombie_net"]
+            HS["harness-sphere<br/>non-root, no socket"]
+            MG["mycelium-gateway<br/>:8080"]
+            PX["crab-shell-proxy<br/>:8080 · root · docker.sock"]
+            WA["chat-webapp<br/>:3000"]
+            PC1["crabshell-alpha-&lt;hash&gt;<br/>:18790"]
+            PC2["crabshell-beta-&lt;hash&gt;<br/>:18790"]
+        end
+        DR[("data root<br/>tenants/…/sessions")]
+        SOCK[("/var/run/docker.sock")]
+    end
+    OTLP(["OTLP endpoint<br/>(stdout in F1)"])
+
+    HS -. "TCP probe" .-> MG
+    HS -. "TCP probe" .-> PX
+    HS -. "TCP probe" .-> WA
+    HS -- "read-only bind" --> DR
+    HS -- "metrics" --> OTLP
+    PX -- "creates / inspects" --> SOCK
+    SOCK -.-> PC1
+    SOCK -.-> PC2
+    PX -. "GET /v1/instances<br/>(shipped in F1, consumed in F2)" .-> HS
+
+    style HS stroke-width:3px
+    style PC1 stroke-dasharray: 4 4
+    style PC2 stroke-dasharray: 4 4
+```
+
+Dashed picoclaw boxes are **not observed in F1** (spec Non-goals). They are drawn because
+the whole point of the placement decision is that they are *reachable* from where
+harness-sphere sits — which is what F2 will use.
+
+## DEC-15 — `GET /v1/instances` gets its own read-only credential (settles OQ-5)
+
+**The rejected option first, because it is the one that looks obvious.** Reusing
+`resolveAgent` would mean handing harness-sphere an agent's `ResolvedToken`. That token is
+not a read scope — it is the credential that gates *every* authenticated route on the
+proxy, including `POST /v1/chat/completions`.
+
+And it is load-bearing in a way that is easy to miss. The caller's identity arrives in
+`x-mycelium-profile`, and the proxy **does not verify it**:
+`SDKResolver.Resolve` calls `mycelium.DecodeAndDecompressProfileFromBase64`
+(`internal/identity/identity.go:67`) — base64 → zstd → JSON, a transport encoding with no
+signature check. The header is unauthenticated data that the proxy trusts *because
+mycelium injected it*, and `resolveAgent`'s bearer-token check
+(`internal/httpapi/handlers.go:500`) is what makes that trust safe: it is the thing that
+stops a caller who reached the proxy directly on `zombie_net` from asserting whatever
+`accId` they like.
+
+So an agent token in the watcher's environment does not widen a read surface. It hands a
+telemetry component the one secret that gates chat as any user in any tenant. **A
+monitoring service must not be able to send a message as a member.**
+
+**The second reason the reuse does not fit**, and the one that surfaced first: the endpoint
+is inherently cross-agent — it lists every workspace of every agent — while `resolveAgent`
+resolves exactly one agent from `x-mycelium-service-name` and validates that agent's token.
+There is no principled answer to "which agent's token authorizes a list spanning all
+agents". This is where the `background-turn-dock` FR-P2 precedent stops applying: that
+endpoint reproduces `resolveAgent` verbatim *because it is scoped to one agent*.
+
+**Decision.** A distinct credential, configured on the proxy and given only to
+harness-sphere, authorizes `GET /v1/instances` and nothing else. Concretely:
+
+- A new config value with a `CRAB_*` env override, absent by default.
+- **When it is unset, the route is not registered at all.** Not "registered and always
+  401" — absent. A deployment that has not opted in has no new surface, and a
+  misconfiguration cannot leave an unauthenticated topology dump reachable.
+- It authorizes only this route. It is never accepted by `resolveAgent` and never
+  substitutes for an agent token.
+- Constant-time comparison, matching how the agent token is already compared in spirit;
+  the value is a secret and a timing oracle on a topology endpoint is free to exploit from
+  inside `zombie_net`.
+
+**Accepted cost, stated plainly:** this is the first credential on the proxy that is not an
+agent's, so it is a new thing to provision and rotate, and the stack has no rotation
+automation (`PROJECT.md` lists it as explicitly out of scope). That is a real cost and it
+is smaller than the alternative, which is a watcher that can impersonate members.
+
+**Rejected for a different reason: mounting the socket read-only on harness-sphere.**
+There is no read-only Docker socket. The API is one endpoint with full authority; a
+`:ro` bind stops the *file* being written, not `POST /containers/create`. It would have
+made this decision moot by making the watcher root-equivalent, which is precisely what
+spec DEC-3 refused.
+
+## DEC-16 — The endpoint reports the union of two surfaces, computed on the proxy
+
+FR-P5 requires that a provisioned-but-never-started workspace be reported explicitly rather
+than omitted. The proxy is the only place that can compute that union cheaply, because it
+already does both halves for its own boot reconciliation:
+
+- `docker.List(crab-shell.managed=true)` → live containers, tuple from the six labels
+  (`internal/docker/manager.go:21-28`).
+- `existingWorkspaces`, which globs
+  `tenants/*/subscriptions/*/agents/<role>/users/*` → provisioned workspaces
+  (`internal/docker/reconcile.go`).
+
+Each entry therefore carries a state drawn from a closed set — running, stopped,
+provisioned-without-container, container-without-directory — rather than a raw Docker
+status string passed through. A closed set is what lets a consumer treat the fourth case
+as the anomaly FR-D4 will require, instead of pattern-matching engine strings.
+
+**This is a read-out over existing machinery, not new machinery.** If an implementation
+task finds itself adding a registry, a cache, or a background scan to serve this endpoint,
+the task has misread the design: both halves are already computed on demand elsewhere in
+the same package.
+
+## DEC-17 — The Dockerfile is a two-stage static build, and it lives upstream
+
+The image is built in `harness-sphere`, not here (spec FR-C6), so that `release.yml` and
+this stack's compose consume the same artifact definition.
+
+- Builder stage on the channel `rust-toolchain.toml` names, which is `stable` — **not a
+  pin**. It was exercised at 1.96.0 during FR-V1's experiment, and a reproducible release
+  image should name an explicit version in the Dockerfile rather than inherit whatever
+  `stable` resolves to on build day.
+- `--features otlp`; `ingest` and `prometheus` off (FR-C6).
+- Runtime stage: a minimal base, a non-root user (FR-C2), the binary and nothing else.
+- The release profile is already tuned for this (`opt-level = "z"`, `lto`, `strip`), and
+  `panic = "unwind"` is kept **deliberately** — the workspace `Cargo.toml` says so, because
+  the resilience contract depends on `catch_unwind`. **A task that sets `panic = "abort"`
+  to shrink the binary breaks the Critical/Optional isolation the whole design rests on.**
+
+## DEC-18 — Compose wiring, and the two things that must not be added
+
+```
+harness-sphere:
+  build: ./crab/harness-sphere
+  networks: [zombie_net]
+  restart: unless-stopped
+  user: <non-root>
+  volumes:
+    - ${CRAB_HOST_DATA_ROOT:-...}:/data:ro
+  environment:
+    HARNESSSPHERE_EXPORTER: ${HARNESS_SPHERE_EXPORTER:-stdout}
+```
+
+No `ports`. No `depends_on`. No `/var/run/docker.sock`. No `/proc` or `/sys`.
+
+`depends_on` is absent by design, not by omission (FR-C5): `EndpointProbeCollector::probe()`
+never touches the network — it returns `Ready` when the target list is non-empty
+(`crates/collectors/src/probe.rs:44`) — and reachability is decided per tick inside
+`collect()`, which emits `up = 0` and returns `Ok`. Ordering the watcher behind the health
+of the things it watches would suppress exactly the signal it exists to produce.
+
+The data-root bind is `:ro` and is the same host path the proxy already uses. Note the
+asymmetry that makes this safe: the proxy writes that tree as root; harness-sphere reads it
+as a non-root user and never writes.
+
+## DEC-19 — Config precedence: TOML committed, secrets by env
+
+`config.zombie-crab.toml` is committed in the submodule and holds intervals, probe targets
+and the session path. The exporter endpoint and the FR-P credential arrive by environment
+(`HARNESSSPHERE_EXPORTER` already exists upstream as an override). No secret is written
+into a tracked TOML — the upstream `config.example.toml` already states this rule for the
+Prometheus token, and it is kept even though that field is being configured empty here.
+
+## Sequence: what one tick looks like
+
+```mermaid
+sequenceDiagram
+    participant T as ticker
+    participant H as HostCollector
+    participant P as EndpointProbeCollector
+    participant S as SessionCollector
+    participant X as exporter
+
+    T->>H: collect()
+    H->>X: system.cpu.utilization, system.memory.*, system.paging.*
+    T->>P: collect()
+    loop each target
+        P->>P: TCP connect (2s timeout)
+        P->>X: endpoint.up (1 or 0), endpoint.probe.duration
+    end
+    T->>S: collect()
+    S->>S: read_dir + read_to_string per *.jsonl
+    S->>X: harness.messages by role, tool.calls, harness.sessions
+```
+
+The `SessionCollector` box is drawn with its full re-read on purpose: it is what FR-V3
+measures, and it is the shape F2's DEC-13.4 replaces.
+
+## What this design deliberately does not decide
+
+- **Where per-container CPU/memory comes from** (spec OQ-2 / F2 OQ-6). Untouched here.
+- **The backend** (spec OQ-1). `stdout` in F1.
+- **Response field names and the OpenAPI entry for `/v1/instances`.** Ordinary
+  implementation detail, settled in the proxy PR against its own conventions — the proxy
+  serves `/doc/openapi.json` for mycelium's tool discovery, and the new route needs to
+  appear there consistently with the rest.

--- a/.specs/features/harness-sphere-integration/spec.md
+++ b/.specs/features/harness-sphere-integration/spec.md
@@ -1,0 +1,481 @@
+# harness-sphere-integration — Spec
+
+**Status:** SPEC. Not implemented. One verification item, FR-V1, is already DISCHARGED —
+it was settled by experiment during specification rather than deferred to deployment.
+**Spans:** `zombie-crab-project` (compose service, submodule pointer) +
+`crab/crab-shell-proxy` (one new read endpoint) + `harness-sphere` (configuration and
+project documents only — **no Rust code changes in this feature**, see DEC-5).
+**Date:** 2026-09-07.
+**Successor:** `harness-sphere-zombie-crab-scope` (F2), which prunes the tool's scope and
+teaches it dynamic instances. **This feature exists to answer F2's empirical questions**,
+and its verification section is therefore the point of it, not a formality.
+**Upstream:** https://github.com/LepistaBioinformatics/harness-sphere @ `main` (v0.2.0).
+
+## Problem
+
+**This stack emits no telemetry at all.** Not "not enough" — none. A strict grep for
+`prometheus|opentelemetry|go\.opentelemetry|otelhttp|promhttp|\botel\b` across every file
+type in this repository and both submodules returns **zero hits**; `go.mod` carries no
+telemetry dependency and `crab-exoskeleton-webapp/package.json` has neither
+`@opentelemetry/*` nor `prom-client`.
+
+What exists instead:
+
+- Three health endpoints: `GET /healthz` on the proxy (`internal/httpapi/handlers.go:419`),
+  `GET /health` on mycelium, `GET /health` on each picoclaw (`:18790`, recorded surface is
+  `/health`, `/ready`, `/reload` only).
+- Unstructured printf logs. `main.go` builds
+  `log.New(os.Stdout, "crab-shell-proxy ", log.LstdFlags|log.Lmsgprefix)` and threads it
+  everywhere as `logf func(format string, args ...any)`. **No levels, no JSON, no
+  request/correlation id.** One access-log line per request from `withLogging`
+  (`handlers.go:462`), which records method, path, status, rounded duration and the
+  service name — and deliberately skips `/healthz`.
+- No metrics endpoint, no traces, no aggregation, no dashboard, no alerting, and no
+  monitoring service anywhere in `docker-compose.yaml` or `docker-compose.prod.yaml`.
+
+The gap this leaves is specific to what this stack *is*. `crab-shell-proxy` spawns one
+picoclaw container **per (tenant, subscription, agent, user)** — containers that are not
+in compose, that outlive `docker compose up`, and that nothing counts. Today nobody can
+answer:
+
+- How many agent containers are running right now, and for whom?
+- Which tenant is consuming the host's memory?
+- Did a cold start miss its 35s `startupDeadline`, and how often?
+- Is a workspace's container up but its harness wedged?
+- Is the host itself about to run out of RAM before any of this degrades?
+
+Every one of those is invisible, and the stack's answer to all of them today is to read
+`docker ps` by hand and correlate it against a stdout log with no request ids.
+
+## Goals
+
+- `harness-sphere` is a submodule of `zombie-crab-project` and runs as a service in the
+  stack, exporting OTLP.
+- The host, the watcher itself, the gateway, the proxy and the webapp are observable with
+  no code change to any of them.
+- **The questions F2 depends on are answered by measurement, not by reasoning.** One
+  (FR-V1) was settled at the desk during specification; the rest need a live deployment.
+  See "Verification".
+
+## Non-goals
+
+- **No metric pruning and no scope reduction.** The tool lands as it is. Deleting
+  `prometheus.rs` / `ingest`, remapping `Layer`, and cutting the metric set are all F2.
+- **No dynamic instance discovery.** F1 observes what static TOML can name: the host, the
+  watcher, and the fixed compose services. Per-user picoclaw containers are **out of scope
+  for F1** and are the whole point of F2.
+- **No changes to picoclaw.** The four patches in `deploy/picoclaw-glob/` add no
+  instrumentation and this feature adds none. Picoclaw stays a black box observed from
+  outside.
+- No changes to `crab-exoskeleton-webapp`.
+- No alerting, no SLOs, no on-call routing.
+- No renaming of the `harness-sphere` repository, its binary, or its crates. See DEC-7.
+
+## Decisions
+
+### DEC-1 — The upstream repository is repurposed in place, not forked (user-directed)
+
+Asked directly, the maintainer chose to modify `LepistaBioinformatics/harness-sphere`
+itself rather than fork it and leave a generic tool upstream.
+
+**What made this cheap, checked rather than assumed:** the repository has **0 stars, 0
+forks, 0 watchers, 0 open issues**, and `harnesssphere` **does not exist on crates.io**
+(the `publish-crates` workflow is manual and was only ever dry-run — its own STATE.md
+says "real publish not yet run"). The only published artifacts are GitHub binary releases
+through v0.2.0. **There is no external consumer to break.**
+
+**The cost, stated so it is not discovered later:** the generic seven-layer vision in
+`harness-sphere/.specs/project/PROJECT.md` — "every layer of a host running the
+Claw/Harness ecosystem" — stops being true the moment F2 lands. A future need for a
+generic watcher means forking *back out*, from a tree that has had a third of its
+collectors deleted. That is accepted knowingly.
+
+### DEC-2 — It runs as a compose service on `zombie_net`, not as a host binary
+
+This contradicts harness-sphere's own first design principle ("single binary, static and
+portable", which reads as a systemd unit on the host), and it is not a preference.
+
+**The picoclaw instances publish no host ports.** `manager.go`'s `CreateSpec` sets no
+port bindings, and `18790` is reachable only on `zombie_net`. The proxy's `18080` is
+loopback-only and explicitly marked TEMPORARY in `docker-compose.yaml` —
+`docker-compose.prod.yaml` drops it with `ports: !reset []`. So a binary running on the
+host cannot probe the agent layer at all, and in production cannot probe the proxy either.
+A watcher that cannot see the layer it exists for is not a watcher.
+
+**The host layer survives the move, which is the objection this would otherwise raise.**
+`HostCollector` reads through `sysinfo::System` (`crates/collectors/src/host.rs:10,26`),
+which reads `/proc/meminfo` and `/proc/stat` — and in Docker those files are **not
+namespaced**: a container reads the host's values. So "hospedeiro" works from inside the
+container **with no `/proc` or `/sys` bind at all**. This is **not** an inference from the
+collector's source — it was measured before this spec was finished, against a container
+capped at 512 MB that reported the host's 33 GB anyway. See FR-V1, which is discharged.
+
+### DEC-3 — Instance identity comes from the proxy, not from a second Docker socket (user-directed)
+
+The container name is `crabshell-<role>-<sha256(tenant::subs::user)[:16]>`
+(`manager.go:139-149`). The hash is one-way, and the code says so in its own comment:
+*"tenant/subscription/user are recovered from the container labels and the
+.crab-owner.json marker, not the name."* So anything wanting per-tenant attribution of a
+running container needs either the Docker API or someone who already has it.
+
+`crab-shell-proxy` already has it. It mounts `/var/run/docker.sock` and runs as root — it
+is the most privileged service in the stack. Giving **harness-sphere its own socket mount
+would create a second one**, doubling the blast radius of the stack's worst-case
+compromise to gain a mapping the proxy already holds in memory.
+
+Asked to choose, the maintainer took the read-only inventory endpoint. Harness-sphere
+stays the collector; the proxy answers one question it is uniquely able to answer.
+
+**What this does not buy:** the inventory names containers; it does not carry cgroup
+counters. F2 must still get per-container CPU/memory from somewhere, and DEC-3
+deliberately leaves that open rather than pre-deciding it — see OQ-2.
+
+### DEC-4 — Attribution is the full tuple; `session_id` is never a metric attribute (user-directed)
+
+Every instance-scoped metric carries `crab.tenant`, `crab.subscription`, `crab.agent`,
+`crab.user`. That is one series per container, which is exactly the granularity the stack
+already creates, and it is the only granularity that answers "which user is burning the
+host" in a multi-tenant deployment.
+
+**`session_id` is excluded by rule, not by omission.** Conversations grow without bound
+and **nothing prunes them** — the repository already records this defect against the
+in-memory registry (`background-turn-dock/spec.md:446`, OQ-3). A conversation-keyed metric
+would inherit an unbounded key space from a component that is known not to reap it.
+
+The `crab.user` label is the mycelium **account UUID**, never the email. The proxy already
+draws this line: the email is kept only in `.crab-owner.json` for operator traceability,
+and identity resolution yields `Profile.accId`.
+
+### DEC-5 — F1 changes no Rust in harness-sphere, and that is what makes it falsifiable
+
+It would be faster to prune and rewire in one pass. It would also mean the first run
+against the stack tests a tree that no longer resembles the one whose behaviour is
+documented, so a failure would have two candidate causes.
+
+F1 ships **configuration only** into harness-sphere: a `config.zombie-crab.toml`, a
+`Dockerfile`, and project-document edits. Everything that stops working is then either a
+deployment fact or a genuine upstream limitation — and both are exactly what F2 needs to
+know.
+
+### DEC-6 — The vendored SigNoz stack is not brought into this repository
+
+`harness-sphere/deploy/signoz/` vendors a full SigNoz deployment (ClickHouse, collector,
+dashboards) and was verified end-to-end upstream. It stays inside the submodule, unused by
+`docker-compose.yaml`. This stack's compose gains **one** service.
+
+**Where the signals go in F1 is deliberately left to the operator** via
+`HARNESSSPHERE_EXPORTER` / `otlp_endpoint` — `stdout` proves the pipeline with no backend
+at all, and pointing it at the vendored SigNoz is one env var. Choosing and hardening a
+backend is neither F1 nor F2.
+
+### DEC-7 — crates.io publishing is disabled; the name and binary are kept
+
+`publish-crates.yml` is removed and the workspace `version` fields lose their
+"publishable" justification. Five generically-named crates (`harnesssphere-domain`,
+`-collectors`, `-runtime`, `-export`, `-ingest`) on a public registry contradict a tool
+that is exclusive to one stack, and the registry is the one publication that cannot be
+withdrawn cleanly.
+
+Binary releases (`release-pr.yml` / `release.yml`) are **kept** — they are how the image
+gets a pinned artifact.
+
+The repository, the binary and the crates keep their names. Renaming is outward-facing,
+breaks the release pipeline, and can be done later at the same cost; doing it now would
+mix a rename into the one change whose failures must stay legible.
+
+## Requirements
+
+### Submodule and repository (FR-M)
+
+**FR-M1** `harness-sphere` is added as a submodule of `zombie-crab-project` at
+`crab/harness-sphere`, alongside `crab/crab-shell-proxy` and
+`crab/crab-exoskeleton-webapp`.
+
+**FR-M2** The `.gitmodules` entry uses the **absolute HTTPS** form
+(`https://github.com/LepistaBioinformatics/harness-sphere.git`), matching the two existing
+entries in this repository. The relative form (`../name.git`) is the *parent* marketing
+repository's convention and must not be copied down.
+
+**FR-M3** The pointer names a commit reachable from `harness-sphere`'s default branch, per
+`.claude/rules/submodule-pointers.md`. On first add this is trivially satisfied
+(`main` @ v0.2.0). It is enforced by `.github/workflows/submodule-pointers.yml`, so a
+violation cannot merge regardless of what any instruction file says.
+
+**FR-M4** `harness-sphere/.specs/project/PROJECT.md` states the exclusivity: the vision,
+the "Target stack" and the non-goals name `zombie-crab` and stop claiming a generic
+Claw/Harness ecosystem. `README.md` gains a banner to the same effect.
+
+**FR-M5** `.github/workflows/publish-crates.yml` is deleted (DEC-7). `release-pr.yml`,
+`release.yml` and `audit.yml` are untouched.
+
+**FR-M6** This repository's `.claude/CLAUDE.md` records the third submodule and the chain
+it introduces, so the merge order stays discoverable from the file that already documents
+the other two.
+
+**FR-M7** **The merge chain is four repositories deep and has two independent child
+merges gating one parent PR.** Spelled out because `.claude/rules/submodule-pointers.md`
+describes a chain with one child at a time, and this feature is the first to have two:
+
+1. `harness-sphere` PR → its `main` (config, Dockerfile, project documents, FR-M5's
+   workflow deletion).
+2. `crab-shell-proxy` PR → its `main` (FR-P). **Independent of step 1** — neither blocks
+   the other, and they can be in review simultaneously.
+3. **One** `zombie-crab-project` PR that adds the new submodule at a `main` commit of
+   harness-sphere, bumps the `crab-shell-proxy` pointer to its merge commit, and adds the
+   compose service.
+4. `zombie-crab-project-mkt` pointer bump.
+
+Steps 1 and 2 must both be merged before step 3 can pass
+`.github/workflows/submodule-pointers.yml`. Opening step 3 early for review is explicitly
+allowed by the rules file, provided the PR body says which pointers are branch heads.
+
+### Deployment (FR-C)
+
+**FR-C1** One new compose service, `harness-sphere`, built from `./crab/harness-sphere`,
+joined to `zombie_net`. It publishes **no host ports**.
+
+**FR-C2** It runs as a **non-root** user and mounts **no Docker socket** (DEC-3). If an
+implementation task adds `/var/run/docker.sock` to this service, the task is wrong.
+
+**FR-C3** It mounts **no `/proc` and no `/sys`** bind for host metrics (DEC-2 — the
+container's own `/proc` is already the host's). A bind may only be added if FR-V1
+falsifies this, and then the spec is amended rather than the deployment quietly widened.
+
+**FR-C4** It mounts the proxy's data root **read-only** at a fixed path, for the session
+collector. The source is the same host path `CRAB_DATA_ROOT` names for the proxy.
+
+**FR-C5** **No `depends_on` ordering is required, and adding
+`condition: service_healthy` would be wrong.** Boot ordering was investigated as a risk —
+the runtime probes each source once at startup — and the risk does not exist for the
+collectors F1 runs. `EndpointProbeCollector::probe()` (`crates/collectors/src/probe.rs:44`)
+**never touches the network**: it returns `Ready` when the target list is non-empty and
+`NotApplicable` when it is empty. Reachability is decided per tick inside `collect()`,
+which emits `harnesssphere.endpoint.up = 0` for a target that is down and returns `Ok`. So
+a gateway that is not yet listening produces an honest `up = 0`, not a dead collector, and
+starts reporting `up = 1` on the tick after it comes up.
+
+Ordering `depends_on: service_healthy` would instead delay the watcher until the things it
+watches are healthy — which is precisely backwards for a component whose job includes
+recording that they were not.
+
+`restart: unless-stopped`, matching the stack's other long-lived services.
+
+**FR-C5a** **`ProbeResult::NotApplicable` permanently drops a source**
+(`crates/runtime/src/lib.rs:198-201` — it logs and `return`s from the task). `Unavailable`
+does not: it trips the circuit breaker (`trip_open()`) and the collect loop keeps running
+under backoff that saturates at 60s, so an `Unavailable` source recovers on its own.
+
+This distinction is recorded here because it is invisible at the call site and it is a
+loaded gun for F2: a per-instance source that answers `NotApplicable` is gone for the
+process lifetime, which for a dynamically discovered instance means *never watched again
+until harness-sphere restarts*. F1 must not introduce a collector that can return
+`NotApplicable` for a recoverable condition.
+
+**FR-C6** The image is built from a Dockerfile added to the `harness-sphere` repository,
+producing a static binary with the `otlp` feature. `ingest` and `prometheus` features stay
+**off** — nothing in this stack pushes OTLP or exposes a Prometheus endpoint.
+
+**FR-C7** `docker-compose.prod.yaml` swaps the build for a pinned
+`ghcr.io/lepistabioinformatics/harness-sphere:${HARNESS_SPHERE_TAG}` image, matching how
+the other three services are overridden there.
+
+**FR-C8** Every new setting follows the stack's actual env convention, which is **not**
+"add it to `.env`": `.env` is gitignored and untracked, so a requirement written against it
+cannot be committed. The convention is an inline compose default —
+`${HARNESS_SPHERE_TAG:-...}`, as `docker-compose.yaml` already does in 28 places — plus an
+entry in the tracked `deploy/standalone/.env.example` and `deploy/prod/.env.example`.
+
+### Proxy inventory endpoint (FR-P)
+
+**FR-P1** `GET /v1/instances` on `crab-shell-proxy` returns every managed workspace: the
+tuple (`tenant_id`, `subs_acc_id`, `agent`, `user_acc_id`), the container name, its mode
+(`continuous` / `scale-to-zero`), and its Docker state.
+
+**FR-P2** It is **read-only and has no container side effects**. It must not call
+`EnsureRunning`, `provision`, `resolveAndMaterialize`, or anything that can create, start,
+stop or remove a container. A telemetry read that can cold-start an agent is a defect, not
+a feature. This mirrors FR-P7 of `background-turn-dock`, which drew the same line for the
+same reason.
+
+**FR-P3** It derives its answer from `docker.List(crab-shell.managed=true)` and the six
+labels (`manager.go:21-28`) — the same source `Reconcile` already trusts. It does not
+re-derive the tuple from the container name, which is impossible (DEC-3).
+
+**FR-P4** The endpoint is authenticated. It is **not** added to the unauthenticated set —
+`/healthz` and `/doc/openapi.json` are unauthenticated for specific documented reasons
+(mycelium's health dispatcher and its tool discovery), and neither applies here. This
+endpoint discloses the full tenant/subscription/user topology of the deployment.
+
+**Which credential is an open design question, not a detail (OQ-5), because the obvious
+answer does not fit.** Every authenticated route on this proxy goes through
+`resolveAgent`, which resolves **one** agent from `x-mycelium-service-name` and validates
+*that agent's* `ResolvedToken`. `GET /v1/instances` is inherently **cross-agent** — it
+lists every workspace of every agent — so "reuse the existing check" does not answer the
+question of which agent's token authorizes a list spanning all of them.
+
+This is exactly where the `background-turn-dock` precedent stops applying. Its FR-P2
+reproduces `resolveAgent` verbatim *because that endpoint is scoped to a single agent*.
+This one is not, and copying the pattern without noticing the difference would produce a
+route whose authorization is meaningless. Two candidate shapes, to be settled in
+`design.md`:
+
+- **Per-agent scoping.** The endpoint stays single-agent and harness-sphere calls it once
+  per agent key, which it can read from its own config. Reuses `resolveAgent` honestly,
+  costs one request per agent, and needs no new credential.
+- **A distinct operator credential.** One call, one answer, but a new secret to provision,
+  rotate and scope — and it would be the first credential in the proxy that is not an
+  agent's.
+
+**FR-P5** A workspace that exists on disk but has no container is reported with an
+explicit absent state, not omitted. "Provisioned but never started" is a real and
+interesting condition — `POST /v1/accounts` scaffolds directories and creates no container
+— and silence cannot distinguish it from "the proxy failed to answer".
+
+**FR-P6** The response is a stable JSON envelope with an empty list, never `null`, when
+nothing is running.
+
+**FR-P7** No existing route, and no behaviour of `EnsureRunning`, `Reconcile`,
+`turnRegistry` or `BounceScope`, changes.
+
+**FR-P8** F1 **defines and ships** this endpoint but harness-sphere does not yet consume
+it — consumption is F2's dynamic discovery. Shipping it in F1 is deliberate: it is the
+only part of F2 that lives in another repository and therefore has the longest merge
+chain, and having it on `main` early removes that chain from F2's critical path.
+
+### Harness-sphere configuration (FR-H)
+
+**FR-H1** A `config.zombie-crab.toml` in the submodule configures, using only fields that
+exist today: `host` and `self` (Critical, always on), `probe_targets` for the fixed
+services, and `session_dir`.
+
+**FR-H2** `probe_targets` names the compose services by their **compose names on
+`zombie_net`** — `mycelium-gateway:8080`, `crab-shell-proxy:8080`, `chat-webapp:3000`.
+Note that `chat-webapp` is the compose service name for the repository called
+`crab-exoskeleton-webapp`; a spec or config using the repository name will not resolve.
+
+**FR-H3** `container_cgroup`, `container_id`, `prometheus_scrape_url` and
+`watch_processes` are left empty. Each is single-valued and boot-resolved, which is
+precisely why F2 exists; setting one to an arbitrary instance in F1 would produce a metric
+that silently describes one tenant and looks like it describes the stack.
+
+**FR-H4** `session_dir` **ships empty and is set at deploy time**, pointed at one known
+workspace's `sessions/` directory for FR-V3's measurement **only**, with an inline comment
+saying it is a probe and not a deployment posture.
+
+It cannot ship populated: a development checkout has no `tenants/` tree (the local `data/`
+holds only `templates/`), so any committed path would be a guess that resolves nowhere.
+This is why FR-V3 is operator-gated rather than part of the merge gate — Group C can pass
+`docker compose config` with this unset, and FR-H4 is only genuinely discharged at T-14.
+
+**FR-H5** No `harnesssphere-*` crate source file is modified (DEC-5).
+
+## Verification
+
+These are the point of the feature. Each is a question F2's design depends on. FR-V1 has
+been discharged by experiment; the rest are still answered by inference and need a live
+deployment.
+
+**FR-V1 — Does the host layer survive containerization? — DISCHARGED 2026-09-07, before
+implementation. It does.**
+
+Measured rather than reasoned, because a wrong answer changes the deployment shape and it
+was cheap to settle at the desk. `cargo build --bin harnesssphere` inside `rust:1.96-slim`
+against the upstream tree, then run **in a container capped at `-m 512m`** with
+`exporter = "stdout"` and only the two Critical sources enabled:
+
+```
+METRIC UpDownCounter system.memory.usage = 10055008256 By [("system.memory.state","used")]
+METRIC UpDownCounter system.memory.usage = 23262818304 By [("system.memory.state","available")]
+METRIC Gauge       system.memory.utilization = 0.3017906416522267
+```
+
+The host, sampled seconds earlier: `MemTotal 33317826560`, used `10037673984`, available
+`23280152576`. The values agree, and `0.3018 ≈ 10.055e9 / 33.32e9` confirms the
+denominator is the host's total. **The 512 MB cgroup limit was ignored entirely** —
+`sysinfo` 0.39.3 reads `/proc/meminfo`, which Docker does not namespace.
+
+DEC-2 and FR-C3 hold: **no `/proc` or `/sys` bind is required for host metrics.**
+
+**The converse, recorded so it is not mistaken for a defect later:** harness-sphere
+therefore *cannot* see its own container's limit through `HostCollector`. If the watcher's
+own cgroup ceiling ever needs watching, that is `ContainerCollector`'s job and a separate
+mount, not a fix to this collector. Nothing in F1 needs it.
+
+Two side observations from the same run, worth keeping: the binary boots with
+`sources=2 receivers=0 exporter=stdout` — Critical `host` and `self`, no ingest — and the
+`self` collector's `process.*` metrics describe the watcher process correctly from inside
+the container.
+
+**FR-V2 — Are the compose services probeable from inside `zombie_net`?**
+`harnesssphere.endpoint.up` is 1 for all three FR-H2 targets. A failure here is a network
+or naming fault, and it is cheaper to find now than inside F2's discovery loop.
+
+**FR-V3 — Does `SessionCollector` actually parse this stack's transcripts?** This is the
+richest zero-instrumentation signal available and the one most likely to need real work.
+
+The shape is already known to be compatible, from the proxy's own parser rather than from
+assumption: `internal/history/history.go:73-86` reads picoclaw's JSONL as
+`{role, content, created_at, tool_calls[], reasoning_content}`, and `SessionCollector`
+reads exactly `role` and `tool_calls`.
+
+**Three specific distortions are predicted here, and the measurement must report on each
+by name — a bare "it parsed" does not discharge FR-V3:**
+
+1. **`durable/` must be excluded.** The proxy maintains its own append-only transcripts at
+   `sessions/durable/<sessionKey>.jsonl` (`history.go`, `durableDir`). `SessionCollector`
+   uses a non-recursive `read_dir`, so it should skip them already — confirm it does,
+   because if it ever recurses, every message is counted twice.
+2. **Cron sessions inflate the count.** `harnesssphere.harness.sessions` counts `*.jsonl`
+   files. **Every scheduled-task run gets its own session file** (`history.go`,
+   `cronSessionPrefix = "agent:cron-"`), so a workspace with two daily tasks accrues files
+   forever and the metric stops meaning "conversations". The paired `.meta.json` carries
+   the `key` that distinguishes them.
+3. **Every transcript is re-read in full, every interval.** `collect()` calls
+   `read_to_string` on each file on every tick. Record the measured cost against a real
+   workspace — this is the number that decides whether F2 needs incremental reads or can
+   defer them.
+
+**FR-V4 — What does the tuple actually cost?** With FR-P1 live, record the real count of
+workspaces and containers in the target deployment. DEC-4's cardinality budget is
+currently justified by an argument ("bounded by real users"); this replaces it with a
+number, and it is the input to F2's decision on collection cadence.
+
+**FR-V5 — Non-root and no socket, confirmed at runtime.** The service's effective user is
+not root and `/var/run/docker.sock` is absent from its mounts (FR-C2). Asserted against
+the running container, not read back off the compose file.
+
+## Open questions
+
+**OQ-1 — Where do the signals land in a real deployment?** DEC-6 defers this. `stdout`
+proves F1. A durable backend (the vendored SigNoz, or an existing collector) is a separate
+decision with retention, storage and access-control consequences, and it should be made
+with FR-V4's cardinality number in hand rather than before it.
+
+**OQ-2 — Where do per-container CPU/memory come from in F2?** DEC-3 removes the Docker
+socket, which is also how `ContainerCollector` would learn a container's cgroup path.
+Candidates, none yet chosen: the proxy reporting the cgroup path alongside FR-P1's
+inventory; harness-sphere deriving it from a read-only `/sys/fs/cgroup` bind plus a
+container id from the inventory; or accepting that F2 ships without per-container resource
+counters and covers the agent layer with probes and session metrics only. **This is F2's
+first design question and F1 must not pre-empt it.**
+
+**OQ-3 — Does the exclusivity turn stop at documents?** DEC-1 repurposes the repository,
+but F1 only changes prose. If the maintainer later wants the *name* to say it too, the
+rename is cheap and independent — deliberately left undone so F1's failures stay legible
+(DEC-7).
+
+**OQ-5 — Which credential authorizes `GET /v1/instances`?** Raised in FR-P4 and repeated
+here so it is not lost in a requirement: the endpoint is cross-agent and every existing
+authenticated route on this proxy is single-agent, so `resolveAgent` does not answer it.
+Per-agent scoping (harness-sphere calls once per agent key) versus a distinct operator
+credential. **This must be settled in `design.md` before FR-P is implemented** — it is the
+only F1 requirement whose shape is genuinely undecided, and it changes both the route and
+the caller.
+
+**OQ-4 — Nothing reaps abandoned workspaces.** There is no reaper and no GC: containers
+are stopped on idle only in `scale-to-zero` mode, and both agents ship as `continuous`, so
+in practice nothing is ever stopped or removed except on drift-recreate. An abandoned
+user's directory and container persist indefinitely and will be counted forever. This is a
+pre-existing stack property, not something F1 introduces — but F1's metrics are the first
+thing that will make it *visible*, and it is recorded here so the first sight of it is
+recognized rather than diagnosed.

--- a/.specs/features/harness-sphere-integration/tasks.md
+++ b/.specs/features/harness-sphere-integration/tasks.md
@@ -2,6 +2,20 @@
 
 Read `spec.md` and `design.md` first. Nothing here restates their reasoning.
 
+## Status (2026-09-07)
+
+**Groups A and B are implemented and open as draft PRs.** They are independent and were
+built in parallel, as the build order below intends.
+
+| Group | Repo | PR | State |
+|---|---|---|---|
+| A | `harness-sphere` | [#21](https://github.com/LepistaBioinformatics/harness-sphere/pull/21) `feat/zombie-crab-exclusive` | draft — T-01…T-05 done |
+| B | `crab-shell-proxy` | [#38](https://github.com/LepistaBioinformatics/crab-shell-proxy/pull/38) `feat/instance-inventory` | draft — T-06…T-08 done |
+| — | `zombie-crab-project` | [#58](https://github.com/LepistaBioinformatics/zombie-crab-project/pull/58) `docs/harness-sphere-specs` | draft — these documents |
+
+**Not started:** Group C (blocked on A and B merging), Group D (needs a live stack),
+Group E. One deviation is recorded, at T-08.
+
 **Gate for every `harness-sphere` task:** `cargo build`, `cargo test`, `cargo clippy`
 and `cargo fmt --check` clean, plus `cargo audit` (the repo already runs it in CI).
 **Gate for every `crab-shell-proxy` task:** `go build ./...`, `go vet ./...`,
@@ -36,7 +50,7 @@ three separate PRs in three repositories by construction.
 
 ## Group A — `harness-sphere` becomes this stack's tool (upstream repo)
 
-### T-01 — state the exclusivity in the project documents
+### T-01 — state the exclusivity in the project documents. DONE (2026-09-07).
 - **What:** rewrite `.specs/project/PROJECT.md`'s Vision, "Target stack" and Non-goals to
   name zombie-crab; add a banner to `README.md`. Record the adoption in the repo's own
   `STATE.md`, cross-referencing this stack's AD-022.
@@ -47,7 +61,7 @@ three separate PRs in three repositories by construction.
   FR-R7, after the layers actually change. Prose only.
 - **Satisfies:** FR-M4.
 
-### T-02 — delete the crates.io publishing workflow
+### T-02 — delete the crates.io publishing workflow. DONE (2026-09-07).
 - **What:** remove `.github/workflows/publish-crates.yml`. Leave `release-pr.yml`,
   `release.yml` and `audit.yml` untouched. Drop the "so the crates are publishable to
   crates.io" justification comment on the workspace `version` fields; **keep the fields**
@@ -56,7 +70,7 @@ three separate PRs in three repositories by construction.
   tool, and the registry is the one publication that cannot be cleanly withdrawn.
 - **Satisfies:** FR-M5.
 
-### T-03 — add the Dockerfile
+### T-03 — add the Dockerfile. DONE (2026-09-07).
 - **What:** two-stage build per design DEC-17 — builder on the pinned toolchain,
   `--features otlp` (no `ingest`, no `prometheus`), runtime stage minimal with a
   **non-root** user, binary only.
@@ -64,11 +78,17 @@ three separate PRs in three repositories by construction.
   `Cargo.toml` keeps `panic = "unwind"` deliberately, because FR-RES-03's `catch_unwind`
   containment depends on it. Shrinking the binary by breaking the resilience contract is
   the one tempting mistake here.
-- **Done when:** the image builds and `docker run <image> --help` (or an equivalent
-  no-config invocation) exits cleanly as a non-root uid.
+- **Done:** 131MB image; `id` inside it is `uid=10001(harnesssphere) gid=10001`; it boots
+  `sources=3 receivers=0 exporter=stdout` and reports the host's memory
+  (`system.memory.usage{used} = 10369028096`).
+- **Incidental confirmation of FR-C5, worth keeping:** the run also emitted
+  `harnesssphere.endpoint.up = 0` for `mycelium-gateway:8080` — unreachable, because the
+  test container was not on `zombie_net`. An unreachable target therefore yields an honest
+  zero rather than a dead collector, which is FR-C5's argument demonstrated instead of
+  reasoned.
 - **Satisfies:** FR-C6, FR-C2 (image half).
 
-### T-04 — add `config.zombie-crab.toml`
+### T-04 — add `config.zombie-crab.toml`. DONE (2026-09-07).
 - **What:** `host` and `self` intervals; `probe_targets` = `mycelium-gateway:8080`,
   `crab-shell-proxy:8080`, `chat-webapp:3000`. `container_cgroup`, `container_id`,
   `prometheus_scrape_url` and `watch_processes` left empty.
@@ -85,7 +105,7 @@ three separate PRs in three repositories by construction.
 - **Depends on:** nothing.
 - **Satisfies:** FR-H1–FR-H4, FR-C5 (no ordering needed).
 
-### T-05 — confirm no Rust changed
+### T-05 — confirm no Rust changed. DONE (2026-09-07) — `git diff --stat` over `crates/**` and `harnesssphere/src/**` is empty.
 - **What:** `git diff --stat` on the group's branch shows no file under `crates/` or
   `harnesssphere/src/`.
 - **Why it is a task and not an assumption:** DEC-5 is the property that makes Group D's
@@ -97,7 +117,7 @@ three separate PRs in three repositories by construction.
 
 ## Group B — `GET /v1/instances` (`crab-shell-proxy`, independent of Group A)
 
-### T-06 — the operator credential
+### T-06 — the operator credential. DONE (2026-09-07).
 - **What:** a new config value with a `CRAB_*` env override, absent by default;
   constant-time comparison. **When unset, the route is not registered** (design DEC-15) —
   not registered-and-401.
@@ -109,7 +129,7 @@ three separate PRs in three repositories by construction.
   credential 401s and the right one succeeds; an **agent** token does not authorize it.
 - **Satisfies:** FR-P4.
 
-### T-07 — the handler
+### T-07 — the handler. DONE (2026-09-07).
 - **What:** `GET /v1/instances` returning the union of `docker.List(crab-shell.managed=true)`
   and the on-disk workspace glob, each entry carrying the tuple, container name, mode and a
   state from a **closed set** (running / stopped / provisioned-without-container /
@@ -122,12 +142,28 @@ three separate PRs in three repositories by construction.
 - **Depends on:** T-06.
 - **Satisfies:** FR-P1, FR-P2, FR-P3, FR-P5, FR-P6.
 
-### T-08 — tests and the OpenAPI entry
-- **What:** table tests over the four states using the existing `Docker` fake (the
-  interface is declared at the consumer precisely so tests can supply one); a test asserting
-  no lifecycle method is invoked; the route added to `/doc/openapi.json` consistently with
-  the rest.
-- **Done when:** `go test -race ./...` green and the existing suite unchanged.
+### T-08 — tests, and the OpenAPI entry that was NOT added. DONE (2026-09-07).
+- **What:** tests over the four states using the existing `Docker` fake (the interface is
+  declared at the consumer precisely so tests can supply one), plus assertions that no
+  lifecycle method is invoked.
+- **Done:** 10 tests — 6 in `internal/httpapi` (including "an agent token must not open
+  this route" and the no-side-effects check) and 4 in `internal/docker` (the union across
+  both surfaces; the tuple coming from labels rather than the name). `go build`, `go vet`
+  and `gofmt` clean on every file touched.
+- **SPEC_DEVIATION — the route was deliberately NOT added to `/doc/openapi.json`.**
+  That document is served **unauthenticated** and exists for mycelium tool discovery — its
+  own description says the operations in it are exposed "as a discoverable tool". This
+  route does not go through mycelium (harness-sphere calls the proxy directly on
+  `zombie_net` with its own credential) and is not a member tool, so listing it there
+  would publish the existence of a topology endpoint for free, to anyone who can fetch the
+  document. Adding it would have contradicted DEC-15's whole reason for existing. Flagged
+  on the PR as reversible if the maintainer disagrees.
+- **Pre-existing failures, confirmed unrelated:** five tests in `internal/docker`
+  (`TestScaleToZeroIdleStop`, `TestContinuousDoesNotArmIdle`,
+  `TestReconcileEnsuresContinuousWorkspaces`, `TestEnsureRunningRecreatesOnPersonaDrift`,
+  `TestEnsureRunningRecreatesOnImageDrift`) fail with `lchown: operation not permitted` —
+  they need root. **Reproduced identically on a pristine clone of `main`** before being
+  called pre-existing.
 - **Satisfies:** FR-P7 (by demonstration).
 
 ---

--- a/.specs/features/harness-sphere-integration/tasks.md
+++ b/.specs/features/harness-sphere-integration/tasks.md
@@ -1,0 +1,215 @@
+# harness-sphere-integration — Tasks
+
+Read `spec.md` and `design.md` first. Nothing here restates their reasoning.
+
+**Gate for every `harness-sphere` task:** `cargo build`, `cargo test`, `cargo clippy`
+and `cargo fmt --check` clean, plus `cargo audit` (the repo already runs it in CI).
+**Gate for every `crab-shell-proxy` task:** `go build ./...`, `go vet ./...`,
+`go test -race ./...` green.
+**Gate for every `zombie-crab-project` task:** `docker compose config` parses, and
+`.github/workflows/submodule-pointers.yml` passes on the PR.
+
+## Build order, and why it is this one
+
+**A ∥ B → C → D → E.**
+
+Groups A and B are **independent and can be in review at the same time** — they live in
+different repositories and neither imports the other. That is the whole reason the proxy
+endpoint is in F1 rather than F2 (spec FR-P8): it has the longest merge chain, so starting
+it early takes it off the critical path.
+
+Group C cannot open for merge until both A and B are on their default branches
+(spec FR-M7). Opening it early *for review* is allowed by
+`.claude/rules/submodule-pointers.md`, provided the PR body says which pointers are branch
+heads — the CI check is what holds, not the convention.
+
+Group D is operator-gated and needs a live deployment. It is not optional: spec FR-V2–V5
+are the reason this feature exists in the shape it does, and shipping C without D leaves
+F2 designing against inference — the exact failure DEC-5 was written to prevent.
+
+**FR-V1 is already discharged** (`spec.md`, measured 2026-09-07); no task covers it.
+
+Commits: one per task where the task stands alone, one per group otherwise. A, B and C are
+three separate PRs in three repositories by construction.
+
+---
+
+## Group A — `harness-sphere` becomes this stack's tool (upstream repo)
+
+### T-01 — state the exclusivity in the project documents
+- **What:** rewrite `.specs/project/PROJECT.md`'s Vision, "Target stack" and Non-goals to
+  name zombie-crab; add a banner to `README.md`. Record the adoption in the repo's own
+  `STATE.md`, cross-referencing this stack's AD-022.
+- **Why first:** every later task in this group is easier to review against a document
+  that already says what the tool is for. It is also the cheapest place to discover that
+  the maintainer meant something narrower than what was specified.
+- **Note:** F1 does **not** delete the seven-layer tables from the README — that is F2's
+  FR-R7, after the layers actually change. Prose only.
+- **Satisfies:** FR-M4.
+
+### T-02 — delete the crates.io publishing workflow
+- **What:** remove `.github/workflows/publish-crates.yml`. Leave `release-pr.yml`,
+  `release.yml` and `audit.yml` untouched. Drop the "so the crates are publishable to
+  crates.io" justification comment on the workspace `version` fields; **keep the fields**
+  — `cargo set-version` and the release flow use them.
+- **Why:** DEC-7. Five generic crate names on a public registry contradict an exclusive
+  tool, and the registry is the one publication that cannot be cleanly withdrawn.
+- **Satisfies:** FR-M5.
+
+### T-03 — add the Dockerfile
+- **What:** two-stage build per design DEC-17 — builder on the pinned toolchain,
+  `--features otlp` (no `ingest`, no `prometheus`), runtime stage minimal with a
+  **non-root** user, binary only.
+- **Watch for:** do **not** set `panic = "abort"` to shrink the image. The workspace
+  `Cargo.toml` keeps `panic = "unwind"` deliberately, because FR-RES-03's `catch_unwind`
+  containment depends on it. Shrinking the binary by breaking the resilience contract is
+  the one tempting mistake here.
+- **Done when:** the image builds and `docker run <image> --help` (or an equivalent
+  no-config invocation) exits cleanly as a non-root uid.
+- **Satisfies:** FR-C6, FR-C2 (image half).
+
+### T-04 — add `config.zombie-crab.toml`
+- **What:** `host` and `self` intervals; `probe_targets` = `mycelium-gateway:8080`,
+  `crab-shell-proxy:8080`, `chat-webapp:3000`. `container_cgroup`, `container_id`,
+  `prometheus_scrape_url` and `watch_processes` left empty.
+- **`session_dir` ships EMPTY.** It is set at deploy time by the operator, for T-14 only,
+  with an inline comment saying it is a probe and not a deployment posture. A development
+  checkout has no `tenants/` tree — local `data/` holds only `templates/` — so a committed
+  path would resolve nowhere. **This is the seam where Group C's gate and FR-H4 part
+  company:** `docker compose config` parses with the value unset, so nothing in the merge
+  gate notices FR-H4 is unmet. It is discharged at T-14 and nowhere earlier.
+- **Watch for:** `chat-webapp` is the **compose service name**; the repository is called
+  `crab-exoskeleton-webapp` and that name does not resolve on `zombie_net`. This is the
+  single most likely typo in the whole feature.
+- **No secret goes in this file** (design DEC-19).
+- **Depends on:** nothing.
+- **Satisfies:** FR-H1–FR-H4, FR-C5 (no ordering needed).
+
+### T-05 — confirm no Rust changed
+- **What:** `git diff --stat` on the group's branch shows no file under `crates/` or
+  `harnesssphere/src/`.
+- **Why it is a task and not an assumption:** DEC-5 is the property that makes Group D's
+  results interpretable. A stray "while I was in there" edit costs the feature its
+  falsifiability, and it is invisible unless someone looks.
+- **Satisfies:** FR-H5.
+
+---
+
+## Group B — `GET /v1/instances` (`crab-shell-proxy`, independent of Group A)
+
+### T-06 — the operator credential
+- **What:** a new config value with a `CRAB_*` env override, absent by default;
+  constant-time comparison. **When unset, the route is not registered** (design DEC-15) —
+  not registered-and-401.
+- **Why this and not `resolveAgent`:** design DEC-15. The short version: the profile
+  header is decoded, never verified (`identity.go:67`), so an agent token is the sole gate
+  on chatting as any member — a telemetry component must not hold one. And the endpoint is
+  cross-agent while `resolveAgent` is single-agent, so there is no principled token to pick.
+- **Done when:** with the value unset, the route 404s (absent); with it set, a wrong
+  credential 401s and the right one succeeds; an **agent** token does not authorize it.
+- **Satisfies:** FR-P4.
+
+### T-07 — the handler
+- **What:** `GET /v1/instances` returning the union of `docker.List(crab-shell.managed=true)`
+  and the on-disk workspace glob, each entry carrying the tuple, container name, mode and a
+  state from a **closed set** (running / stopped / provisioned-without-container /
+  container-without-directory). Stable envelope, empty list never `null`.
+- **Watch for — the requirement most likely to be violated by accident:** no container side
+  effects. Do not call `EnsureRunning`, `provision`, `resolveAndMaterialize`, or anything
+  reachable from them. A telemetry read that cold-starts an agent is a defect. If serving
+  this needs a new registry, cache or background scan, the design has been misread — both
+  halves already exist for `Reconcile`.
+- **Depends on:** T-06.
+- **Satisfies:** FR-P1, FR-P2, FR-P3, FR-P5, FR-P6.
+
+### T-08 — tests and the OpenAPI entry
+- **What:** table tests over the four states using the existing `Docker` fake (the
+  interface is declared at the consumer precisely so tests can supply one); a test asserting
+  no lifecycle method is invoked; the route added to `/doc/openapi.json` consistently with
+  the rest.
+- **Done when:** `go test -race ./...` green and the existing suite unchanged.
+- **Satisfies:** FR-P7 (by demonstration).
+
+---
+
+## Group C — wire it into the stack (`zombie-crab-project`)
+
+**Blocked on A and B both merged to their default branches** (FR-M7). CI enforces it.
+
+### T-09 — add the submodule
+- **What:** `crab/harness-sphere`, `.gitmodules` entry in the **absolute HTTPS** form.
+- **Watch for:** the relative form (`../name.git`) is the *marketing* repo's convention.
+  Both existing entries here are absolute HTTPS; copy those.
+- **Satisfies:** FR-M1, FR-M2, FR-M3.
+
+### T-10 — the compose service
+- **What:** per design DEC-18 — `zombie_net`, `restart: unless-stopped`, non-root user,
+  data root bound `:ro`, exporter by env. **No `ports`, no `depends_on`, no
+  `/var/run/docker.sock`, no `/proc`, no `/sys`.**
+- **Also:** `docker-compose.prod.yaml` override to the pinned
+  `ghcr.io/lepistabioinformatics/harness-sphere:${HARNESS_SPHERE_TAG}` image.
+- **Satisfies:** FR-C1–FR-C3, FR-C5, FR-C7.
+
+### T-11 — env plumbing
+- **What:** inline `${VAR:-default}` in compose plus entries in the **tracked**
+  `deploy/standalone/.env.example` and `deploy/prod/.env.example`.
+- **Watch for:** `.env` is gitignored and untracked here — a requirement written against it
+  cannot be committed. The examples are the tracked surface.
+- **Satisfies:** FR-C8.
+
+### T-12 — bump the proxy pointer and record the chain
+- **What:** advance `crab/crab-shell-proxy` to Group B's merge commit; add the third
+  submodule and its merge order to `.claude/CLAUDE.md`.
+- **Satisfies:** FR-M6, FR-M7 step 3.
+
+---
+
+## Group D — verification (operator-gated, needs a live stack)
+
+This group cannot run from a development checkout: the local `data/` tree holds only
+`templates/` and no `tenants/`, so there is no workspace to measure.
+
+### T-13 — FR-V2, probes from inside the network
+- **What:** `harnesssphere.endpoint.up` = 1 for all three targets.
+- **Also run the restart case:** `docker compose restart harness-sphere` alone, with the
+  targets already up. Both orderings should give the same answer given design DEC-18's
+  reasoning; a disagreement falsifies it.
+
+### T-14 — FR-V3, does `SessionCollector` parse this stack's transcripts
+- **Depends on:** T-04 (which ships `session_dir` empty) and a live stack with at least one
+  provisioned workspace. This task is where FR-H4 is actually discharged.
+- **What:** set `session_dir` to a real workspace and report on **each of the three
+  predicted distortions by name** — `durable/` exclusion, cron-run inflation, and the
+  measured cost of the full re-read. A bare "it parsed" does not discharge this.
+- **Why it is the most valuable task in the group:** it is the input to F2's DEC-13, which
+  is the largest single piece of work in the whole effort.
+
+### T-15 — FR-V4, the real cardinality
+- **What:** with T-07 live, record the actual count of workspaces and containers.
+- **Feeds:** F2 OQ-7 (discovery interval) and spec OQ-1 (backend choice).
+
+### T-16 — FR-V5, privilege, asserted at runtime
+- **What:** against the **running** container, confirm the effective user is not root and
+  `/var/run/docker.sock` is absent from its mounts. Read off the container, not off the
+  compose file — the compose file is the claim, not the evidence.
+
+---
+
+## Group E — `zombie-crab-project-mkt`
+
+### T-17 — pointer bump
+- **What:** advance `modules/zombie-crab-project` to Group C's merge commit.
+- **Blocked on:** C merged. Its own `submodule-pointers.yml` enforces this.
+
+---
+
+## Not in this feature
+
+Recorded so they are not picked up by mistake:
+
+- Metric pruning, `Layer` remapping, deleting `prometheus.rs` / `ingest` — **F2**.
+- Dynamic instance discovery and per-instance collection — **F2**.
+- Harness-sphere *consuming* `GET /v1/instances` — **F2**. F1 ships the endpoint unused,
+  deliberately (FR-P8).
+- Choosing an OTLP backend — spec OQ-1, deferred until T-15 produces a cardinality number.
+- Renaming the repository or binary — spec OQ-3.

--- a/.specs/features/harness-sphere-integration/tasks.md
+++ b/.specs/features/harness-sphere-integration/tasks.md
@@ -4,17 +4,31 @@ Read `spec.md` and `design.md` first. Nothing here restates their reasoning.
 
 ## Status (2026-09-07)
 
-**Groups A and B are implemented and open as draft PRs.** They are independent and were
-built in parallel, as the build order below intends.
+**Groups A, B and C are implemented.** A and B are **merged**; C is open as a draft.
 
 | Group | Repo | PR | State |
 |---|---|---|---|
-| A | `harness-sphere` | [#21](https://github.com/LepistaBioinformatics/harness-sphere/pull/21) `feat/zombie-crab-exclusive` | draft — T-01…T-05 done |
-| B | `crab-shell-proxy` | [#38](https://github.com/LepistaBioinformatics/crab-shell-proxy/pull/38) `feat/instance-inventory` | draft — T-06…T-08 done |
-| — | `zombie-crab-project` | [#58](https://github.com/LepistaBioinformatics/zombie-crab-project/pull/58) `docs/harness-sphere-specs` | draft — these documents |
+| A | `harness-sphere` | [#21](https://github.com/LepistaBioinformatics/harness-sphere/pull/21) | **merged** — T-01…T-05 |
+| B | `crab-shell-proxy` | [#38](https://github.com/LepistaBioinformatics/crab-shell-proxy/pull/38) | **merged** — T-06…T-08 |
+| C | `zombie-crab-project` | [#60](https://github.com/LepistaBioinformatics/zombie-crab-project/pull/60) | draft — T-09…T-12 |
+| — | `zombie-crab-project` | [#58](https://github.com/LepistaBioinformatics/zombie-crab-project/pull/58) | draft — these documents |
 
-**Not started:** Group C (blocked on A and B merging), Group D (needs a live stack),
-Group E. One deviation is recorded, at T-08.
+**Both decisions the specs flagged for the maintainer were confirmed (2026-09-07):**
+DEC-15 stands ("configurável e previsível"), and DEC-8 proceeds as proposed. DEC-15 is
+already on `main` via #38; DEC-8 is F2 and unbuilt.
+
+**Not started:** Group D (needs a live stack), Group E (follows C).
+
+**Two things carried forward that are not task failures but will bite if forgotten:**
+
+1. **One deviation, at T-08** — `/v1/instances` was kept out of `openapi.json`.
+2. **`ghcr.io/lepistabioinformatics/harness-sphere` does not exist.** Group C's prod
+   override names it, but `harness-sphere` publishes **binary releases only** — it has no
+   `release-image.yml` and the package 404s. Prod must omit the service or build from
+   source until an image workflow is added there. Recorded in the compose file and both
+   `.env.example`s, not just here, because the failure would otherwise surface as an image
+   pull error mid-deploy. **This is the next small piece of work**, and it belongs to the
+   `harness-sphere` repo, mirroring `crab-shell-proxy`'s `release-image.yml`.
 
 **Gate for every `harness-sphere` task:** `cargo build`, `cargo test`, `cargo clippy`
 and `cargo fmt --check` clean, plus `cargo audit` (the repo already runs it in CI).
@@ -172,13 +186,13 @@ three separate PRs in three repositories by construction.
 
 **Blocked on A and B both merged to their default branches** (FR-M7). CI enforces it.
 
-### T-09 — add the submodule
+### T-09 — add the submodule. DONE (2026-09-07) — pointer `768fcc6`, absolute HTTPS URL.
 - **What:** `crab/harness-sphere`, `.gitmodules` entry in the **absolute HTTPS** form.
 - **Watch for:** the relative form (`../name.git`) is the *marketing* repo's convention.
   Both existing entries here are absolute HTTPS; copy those.
 - **Satisfies:** FR-M1, FR-M2, FR-M3.
 
-### T-10 — the compose service
+### T-10 — the compose service. DONE (2026-09-07).
 - **What:** per design DEC-18 — `zombie_net`, `restart: unless-stopped`, non-root user,
   data root bound `:ro`, exporter by env. **No `ports`, no `depends_on`, no
   `/var/run/docker.sock`, no `/proc`, no `/sys`.**
@@ -186,14 +200,14 @@ three separate PRs in three repositories by construction.
   `ghcr.io/lepistabioinformatics/harness-sphere:${HARNESS_SPHERE_TAG}` image.
 - **Satisfies:** FR-C1–FR-C3, FR-C5, FR-C7.
 
-### T-11 — env plumbing
+### T-11 — env plumbing. DONE (2026-09-07).
 - **What:** inline `${VAR:-default}` in compose plus entries in the **tracked**
   `deploy/standalone/.env.example` and `deploy/prod/.env.example`.
 - **Watch for:** `.env` is gitignored and untracked here — a requirement written against it
   cannot be committed. The examples are the tracked surface.
 - **Satisfies:** FR-C8.
 
-### T-12 — bump the proxy pointer and record the chain
+### T-12 — bump the proxy pointer and record the chain. DONE (2026-09-07) — pointer `473b726`.
 - **What:** advance `crab/crab-shell-proxy` to Group B's merge commit; add the third
   submodule and its merge order to `.claude/CLAUDE.md`.
 - **Satisfies:** FR-M6, FR-M7 step 3.

--- a/.specs/features/harness-sphere-zombie-crab-scope/spec.md
+++ b/.specs/features/harness-sphere-zombie-crab-scope/spec.md
@@ -1,0 +1,355 @@
+# harness-sphere-zombie-crab-scope — Spec
+
+**Status:** SPEC. Not implemented. **Blocked on `harness-sphere-integration` (F1)** — not
+by ceremony, but because four of its decisions (DEC-9, DEC-11, DEC-12, F1 OQ-2) are written
+against measurements F1 takes and this spec does not have.
+**Spans:** `harness-sphere` (the substantial change — reduction and dynamic discovery) +
+`zombie-crab-project` (compose, submodule pointer). `crab-shell-proxy` is **not** touched:
+F1 already shipped the endpoint this feature consumes (F1 FR-P8).
+**Date:** 2026-09-07.
+**Predecessor:** `harness-sphere-integration`. Read it first — its DEC-1 through DEC-4 are
+this feature's premises and are not restated here.
+
+## Problem
+
+F1 lands a watcher that works and watches the wrong shape of world.
+
+**HarnessSphere was designed for one host running one harness.** Every optional collector
+is configured by a single-valued, boot-resolved TOML field: `container_cgroup` names *one*
+cgroup, `container_id` *one* id, `session_dir` *one* directory, `prometheus_scrape_url`
+*one* endpoint. `SourceDescriptor.name` is `&'static str`. `SignalSource::probe()` runs
+**once, at boot**, and the runtime supervisor spawns one task per source at startup and
+never revises the set.
+
+**zombie-crab is the opposite of that.** `crab-shell-proxy` creates a picoclaw container
+per `(tenant, subscription, agent, user)` on the first turn that needs it
+(`EnsureRunning`, `manager.go:188`), destroys and recreates it on persona/project/image
+drift, and adopts whatever it finds at boot by listing
+`docker.List(crab-shell.managed=true)`. **Docker is the registry — there is no instance
+table.** The set of things worth watching is discovered at runtime and changes while the
+watcher runs.
+
+So the tool that F1 installs can see the host, itself, and the three fixed compose
+services, and is structurally blind to the layer the project exists to run.
+
+**And roughly a third of it has no source in this stack.** `prometheus.rs` (770 LOC)
+scrapes a Prometheus exposition endpoint; nothing here exposes one. The `ingest` crate
+(574 LOC) receives pushed OTLP; nothing here pushes any. `Layer::Api` and `Layer::Tools`
+have no collector that fills them from a zombie-crab source. Carrying that is not neutral:
+it is surface that has to keep compiling, keep passing `cargo audit`, and keep being read
+by anyone changing the parts that do work.
+
+## Goals
+
+- Every picoclaw instance the proxy creates is observed, attributed to its tenant,
+  subscription, agent and user, without harness-sphere holding a Docker socket.
+- An instance that appears is watched within one discovery interval; one that disappears
+  stops reporting, and does so visibly rather than by leaving a series frozen at its last
+  value.
+- The metric set is exactly the six domains this stack has: **mycelium-gateway, proxy,
+  exoskeleton, picoclaw, hospedeiro, self.** Nothing that no zombie-crab component can
+  produce survives.
+- The tool's own documents say what it now is.
+
+## Non-goals
+
+- **No instrumentation added to any zombie-crab component.** Not picoclaw, not the webapp,
+  not mycelium, and not the proxy beyond F1's inventory endpoint. Everything is observed
+  from outside or derived from disk.
+- **No Docker socket for harness-sphere**, ever. F1 DEC-3 is a premise, not a
+  reconsideration.
+- **No `session_id` in any metric attribute.** F1 DEC-4, likewise.
+- No alerting, no SLOs, no dashboards beyond what the submodule already vendors.
+- No repository, binary or crate rename (F1 DEC-7 / OQ-3).
+- Not fixing the stack's missing reaper. F2 makes abandoned workspaces *visible*
+  (F1 OQ-4); reaping them is the stack's problem, not the watcher's.
+
+## Decisions
+
+### DEC-8 — Six layers, and they are the user's six words
+
+`Layer` today is `Host, Watcher, Container, Gateway, Harness, Tools, Api`. It becomes
+exactly:
+
+| Layer | What it is | Component |
+|---|---|---|
+| `Host` | the machine underneath | *hospedeiro* |
+| `Watcher` | harness-sphere observing itself | *self* |
+| `Gateway` | the authenticated front door | `mycelium-gateway` |
+| `Proxy` | the orchestrator | `crab-shell-proxy` |
+| `Webapp` | the member-facing UI | `chat-webapp` (repo: `crab-exoskeleton-webapp`) |
+| `Harness` | the per-user agent containers | `picoclaw` |
+
+`Api` and `Tools` are **deleted**: no zombie-crab source fills either.
+
+**`Container` is deleted as a layer and kept as a dimension**, which is the one
+non-obvious move here. Everything in this stack that runs, runs in a container — the
+gateway, the proxy, the webapp and every picoclaw. "Container" was never a peer of
+"Gateway"; it was the *mechanism* by which a gateway's resource use is measured. So cgroup
+counters are emitted **on the layer of whatever the container is**, and a picoclaw
+container's memory is a `Harness` signal, not a `Container` one. This is what makes
+"metrics of the proxy" and "metrics of picoclaw" answerable as written, instead of
+requiring a join between two layers to ask one question.
+
+**`tool.calls` survives the deletion of `Tools`.** It has a real source here — picoclaw's
+session JSONL, which the proxy's own parser confirms carries `tool_calls[]`
+(`internal/history/history.go:73-86`). It moves under `Harness`. Deleting the layer must
+not delete the signal; they are separate facts and it would be easy to conflate them.
+
+### DEC-9 — `prometheus.rs` and the `ingest` crate are deleted, and the second one is a consequence of a choice
+
+`prometheus.rs` (770 LOC) scrapes an OpenClaw diagnostics endpoint. **Nothing in this
+stack exposes Prometheus text**: zero grep hits stack-wide, and picoclaw's recorded HTTP
+surface is `/health`, `/ready`, `/reload` plus per-channel webhooks. It is dead code
+against a component this stack does not run.
+
+`ingest` (574 LOC) is a working OTLP receiver for metrics, traces, logs and histograms,
+verified upstream against SigNoz. **It is dead here for a different reason, and the
+difference matters:** it is dead *because F1 DEC-3 chose the pull-based inventory endpoint
+over instrumenting the proxy to push OTLP*. Had that gone the other way, `ingest` would
+have become the primary intake and this deletion would be exactly wrong.
+
+Recorded that way deliberately: if the proxy is ever instrumented, the thing to do is
+restore this crate from history, not rebuild it. Its `gen_ai.*` semconv mapping and its
+resource-identity merge are the parts worth not rewriting.
+
+**What is lost, stated plainly:** `gen_ai.client.token.usage` — token cost — leaves with
+`prometheus.rs`, and this stack has no other path to it. Picoclaw does not write tokens to
+disk (harness-sphere's own STATE.md establishes this: *"tokens are NOT derivable —
+PicoClaw doesn't write token cost to disk"*). Token accounting is **not available and this
+feature does not make it available**; it would need instrumentation inside picoclaw, which
+is a non-goal. Anyone who reads "AI observability" and expects a token bill should read
+this paragraph first.
+
+### DEC-10 — Discovery reconciles two surfaces, and they are allowed to disagree
+
+A picoclaw instance is visible two ways, and neither alone is right:
+
+1. **F1's `GET /v1/instances`** — the live containers, with the tuple recovered from the
+   six `crab-shell.*` labels. Authoritative for *running*, and the only source of the
+   container name, because the name hashes the tuple one-way (`manager.go:139-149`).
+2. **The on-disk tenant tree** — `tenants/*/subscriptions/*/agents/<role>/users/*`, which
+   the proxy's own `existingWorkspaces` globs. **The path itself encodes the full tuple**,
+   so session metrics can be attributed with no proxy call at all. Authoritative for
+   *provisioned*, including workspaces whose container has never existed.
+
+The reconciliation is the feature, not a detail. A workspace on disk with no container is
+**provisioned-not-running** and is reported as such — it is exactly what `POST
+/v1/accounts` produces, since it scaffolds directories and creates no container. A
+container with no directory is a stack fault and must surface as one, not be silently
+dropped.
+
+**The disk surface is the fallback, and this is a resilience property, not an
+optimization:** if the proxy is down or its endpoint fails, session metrics keep flowing
+with full attribution and only the liveness/resource signals degrade. A watcher whose
+telemetry disappears when the thing it watches breaks is worthless at the moment it
+matters.
+
+### DEC-11 — Sources become dynamic: owned names, per-instance probe, a mutable supervisor
+
+Three concrete changes, all forced by DEC-10 and all easy to under-scope:
+
+- `SourceDescriptor.name` becomes an owned `String`. `&'static str` cannot name
+  `session:<tenant>/<subs>/<agent>/<user>`.
+- `probe()` stops being a boot gate and becomes **per-instance, at discovery**. Its
+  `ProbeResult::Fatal` variant stays reachable only for Critical sources (`Host`,
+  `Watcher`); a per-instance probe failing is `Unavailable`, which degrades that instance
+  and nothing else. The existing criticality policy already expresses this — it just never
+  had a caller that ran after boot.
+- The runtime supervisor gains **add-source and remove-source at runtime**. Today it
+  spawns one task per source at startup and the set is fixed for the process lifetime.
+
+Removal must actually stop the task and drop the source. A supervisor that only ever adds
+turns every recreated container — and drift-recreate is a routine event in this stack —
+into a permanent extra task and a permanently stale series.
+
+### DEC-12 — A retired instance goes absent, not silent
+
+When an instance disappears, its series must not simply stop being written. A gauge that
+stops updating reads as "unchanged" on every dashboard and in every alert rule, so a
+container that died at 92% memory looks like a container sitting calmly at 92% forever.
+
+The last write for a retired instance is an explicit terminal signal, so the difference
+between *gone* and *quiet* is in the data rather than in the reader's assumption. The exact
+shape is a design question (a zeroed `up` gauge is the cheap answer); the requirement is
+that the distinction exists.
+
+### DEC-13 — The session collector is rewritten, not re-pathed
+
+F1 FR-V3 measures this; the rewrite is expected regardless of the measurement's detail,
+because four things are wrong at once and only the first is a path:
+
+1. **One directory → N.** One `SessionCollector` per workspace, or one that fans out; either
+   way `session_dir` as a scalar is gone.
+2. **`durable/` excluded.** The proxy keeps its own append-only transcripts at
+   `sessions/durable/<sessionKey>.jsonl`. Today's non-recursive `read_dir` already skips
+   them; the exclusion becomes explicit and tested, because the cost of a future recursive
+   walk is silently double-counting every message.
+3. **Cron runs excluded.** `harness.sessions` counts `*.jsonl` files, and **every scheduled-task
+   run writes its own session file** (`history.go`, `cronSessionPrefix = "agent:cron-"`).
+   A workspace with two daily tasks accrues files forever, so uncorrected the metric drifts
+   from "conversations" to "conversations plus every cron run since provisioning". The
+   paired `.meta.json` `key` is what distinguishes them — the same discriminator the proxy
+   uses, for the same reason.
+4. **Incremental reads.** `collect()` calls `read_to_string` on every transcript on every
+   tick. At one workspace that is a rounding error; at N workspaces × M conversations ×
+   a year of history it is unbounded IO on a fixed interval, and it grows with the
+   stack's success. Track per-file offset and read the tail. **Caveat that must be
+   handled, not assumed away:** picoclaw's older in-memory store *rewrote* its live file,
+   so a file can shrink. A shrunk file means re-read from zero, not a negative delta.
+   (v0.3.1 runs the JSONL store, which appends — but `PICOCLAW_TAG` is a variable and the
+   store choice is upstream's, not this stack's.)
+
+### DEC-14 — The probe collector learns which layer it is probing
+
+`EndpointProbeCollector` already takes `Vec<String>` of targets, so multi-target is not the
+change. It stamps `Layer::Gateway` on **every** target
+(`crates/collectors/src/probe.rs:29`). Under DEC-8 that would file the proxy, the webapp
+and every picoclaw instance under "gateway", which makes five of the six layers
+unanswerable. Targets become `(address, layer, attributes)`.
+
+This is also how per-instance liveness works with no Docker socket: the inventory gives the
+container name, the name resolves on `zombie_net`, and `crabshell-<role>-<hash>:18790` is
+probeable directly.
+
+## Requirements
+
+### Scope reduction (FR-R)
+
+**FR-R1** `crates/collectors/src/prometheus.rs` is deleted, with its `prometheus` feature,
+its `Cargo.toml` entry, its fixture (`tests/fixtures/openclaw_prometheus.txt`), its
+composition-root wiring, and its four config fields (`prometheus_scrape_url`,
+`prometheus_token_file`, `prometheus_harness_name`, `prometheus_interval_secs`).
+
+**FR-R2** The `ingest` crate is deleted: workspace member, dependency entries, the
+`ingest` feature, the `Receiver` port if nothing else implements it, and the
+`ingest_enabled` / `ingest_endpoint` config fields.
+
+**FR-R3** `Layer` is exactly `Host, Watcher, Gateway, Proxy, Webapp, Harness` (DEC-8).
+`as_str()` and every match are exhaustive with no fallback arm — the compiler finding
+every site is the point.
+
+**FR-R4** Every retained metric belongs to one of the six layers and has a live source in
+this stack. Any metric whose only producer was deleted goes with it. `gen_ai.*` and
+`harnesssphere.openclaw.*` are gone (DEC-9).
+
+**FR-R5** `harnesssphere.tool.calls` is retained under `Harness` (DEC-8).
+
+**FR-R6** `config.example.toml` describes only fields that still exist, and
+`config.zombie-crab.toml` from F1 is updated to match.
+
+**FR-R7** `harness-sphere`'s own `.specs/project/PROJECT.md`, `STATE.md` and `README.md`
+describe six layers and one stack. The README's layer tables lose the deleted rows rather
+than marking them unsupported — a table row that says "not available here" is a promise
+this feature is deciding not to make.
+
+**FR-R8** `cargo build`, `cargo test` and `cargo audit` pass with no reference to a
+deleted module, feature or field.
+
+### Dynamic discovery (FR-D)
+
+**FR-D1** A discovery source reconciles F1's `GET /v1/instances` against the on-disk tenant
+tree (DEC-10) on a configurable interval, and yields the set of instances to watch.
+
+**FR-D2** Each instance carries the full tuple as attributes — `crab.tenant`,
+`crab.subscription`, `crab.agent`, `crab.user` — with the user as the mycelium account
+UUID, never the email (F1 DEC-4).
+
+**FR-D3** An instance present on disk but absent from the inventory is watched for session
+metrics and reported as provisioned-not-running. It is not dropped.
+
+**FR-D4** An instance in the inventory with no directory is surfaced as an anomaly, not
+dropped.
+
+**FR-D5** If the inventory endpoint is unreachable, session metrics continue from the disk
+surface alone, and the failure is itself a `Watcher`-layer signal (DEC-10). Harness-sphere
+must not exit, degrade its Critical sources, or stop discovering.
+
+**FR-D6** A newly discovered instance is being collected within one discovery interval,
+with no restart.
+
+**FR-D7** A retired instance's task is stopped and its source dropped (DEC-11), and its
+final emission distinguishes *gone* from *quiet* (DEC-12).
+
+**FR-D8** `SourceDescriptor.name` is an owned `String` and is unique per instance
+(DEC-11).
+
+**FR-D9** `probe()` runs per instance at discovery. A failing per-instance probe yields
+`Unavailable` and degrades only that instance; `Fatal` remains reachable only from
+`Host` and `Watcher` (DEC-11).
+
+**FR-D10** The runtime supervisor supports add and remove at runtime, and removal actually
+terminates the task (DEC-11).
+
+**FR-D11** Per-instance liveness comes from probing `<container-name>:18790` on
+`zombie_net`, using the name the inventory reports (DEC-14). Harness-sphere never computes
+the name hash itself — that would duplicate a preimage the proxy owns, and silently
+diverge the day the prefix or the hash changes.
+
+**FR-D12** `EndpointProbeCollector` targets carry their own layer and attributes (DEC-14).
+
+**FR-D13** Discovery is bounded and cheap: it is a list operation and a directory glob, not
+a walk of every transcript. Session *content* is read by the session collector on its own
+cadence, which is slower.
+
+### Session collection (FR-S)
+
+**FR-S1** One logical session source per workspace, attributed by FR-D2's tuple (DEC-13.1).
+
+**FR-S2** `sessions/durable/` is excluded, explicitly and with a test (DEC-13.2).
+
+**FR-S3** Cron-originated sessions are excluded from `harness.sessions` via the paired
+`.meta.json` `key` prefix `agent:cron-` (DEC-13.3).
+
+**FR-S4** Transcripts are read incrementally by tracking a per-file offset. **A file that
+shrank is re-read from zero, not treated as a negative delta** (DEC-13.4).
+
+**FR-S5** Per-project workspaces are covered. Sessions live under sibling workspace
+directories as well as the main one, and their ids are prefixed `p.<project>.` — a
+collector that globs only `workspace/sessions` silently omits every project conversation.
+
+**FR-S6** No transcript *content* is emitted — only counts. Message bodies are member data
+and metrics are not the place for them. (Harness-sphere's upstream backlog carries a
+GenAI content redaction item, GA-05, for the opt-in content path; this feature has no
+content path at all, which is the stronger position.)
+
+### Deployment (FR-C)
+
+**FR-C9** Compose gains whatever mount FR-D's resource collection settles on
+(F1 OQ-2) — and nothing more. F1 FR-C2's "no Docker socket, non-root" survives this feature
+unchanged.
+
+**FR-C10** New configuration keys follow the existing `.env` convention with documented
+defaults.
+
+**FR-C11** The submodule pointer bump obeys `.claude/rules/submodule-pointers.md`:
+harness-sphere's PR merges to its `main` first, then this repository's pointer names the
+merge commit, then the marketing repository's.
+
+## Open questions
+
+**OQ-6 — Where do per-container resource counters come from?** Inherited unresolved from
+F1 OQ-2, and it is this feature's first design question. The current preference, to be
+confirmed against F1's measurements rather than adopted now: the proxy reports each
+container's id or cgroup path alongside the inventory, and harness-sphere reads a
+**read-only `/sys/fs/cgroup` bind**. That is a far weaker grant than a Docker socket — it
+reads counters and cannot start, stop or inspect anything — and it reuses
+`ContainerCollector` as it stands. The alternative worth pricing is shipping without
+per-container CPU/memory and covering the harness layer with probes and session metrics
+alone, which is genuinely less useful but needs no new mount at all.
+
+**OQ-7 — What is the discovery interval, and what does it cost at real scale?** Depends on
+F1 FR-V4's workspace count. Too slow and a short-lived container is never seen; too fast
+and every tick is an authenticated HTTP call plus a glob. No number is defensible before
+the measurement.
+
+**OQ-8 — Is `harness.sessions` still the right metric once cron is excluded?** Excluding
+cron makes it mean "conversations". But cron runs are real agent activity, and dropping
+them entirely trades one distortion for a blind spot. A separate cron-run counter may be
+the honest answer; deferred rather than guessed.
+
+**OQ-9 — Does anything upstream still want the generic tool?** F1 DEC-1 accepted that this
+feature ends harness-sphere's generic life. FR-R1/FR-R2 are the point of no return —
+after them, re-generalizing means reverting a large deletion. Worth one explicit
+confirmation at the moment those tasks are picked up, not because the decision is in doubt
+but because it is the last cheap moment to change it.

--- a/.specs/project/ROADMAP.md
+++ b/.specs/project/ROADMAP.md
@@ -119,6 +119,51 @@ Telegram / MS Teams channels.
 
 ---
 
+## M5 (planned): Observability — harness-sphere
+
+**Goal:** the stack stops being unobservable. Today it emits **nothing** — a strict grep
+for `prometheus|opentelemetry|otel` across this repo and both submodules returns zero
+hits, and the entire observability surface is three health endpoints plus unstructured
+printf logs with no levels and no request ids.
+
+`harness-sphere` (https://github.com/LepistaBioinformatics/harness-sphere) is adopted as a
+third submodule and **repurposed to work exclusively for this stack** (AD-022). Two
+features, deliberately sequential — the first measures what the second is designed
+against.
+
+### Features
+
+**harness-sphere-integration (SPEC READY)** — the tool lands as a submodule at
+`crab/harness-sphere` and runs as one compose service on `zombie_net`, exporting OTLP,
+**with no Rust changed**. Host and self come free; the gateway, proxy and webapp are
+covered by TCP probes. Two things make it more than a drop-in: it runs as a *container*
+rather than the host binary its own design principles call for (picoclaw publishes no host
+ports, so a host binary is structurally blind to the agent layer), and `crab-shell-proxy`
+gains one read-only endpoint, `GET /v1/instances`, because the container name hashes the
+`(tenant, subscription, user)` tuple one-way and the proxy is the only holder of the
+preimage — cheaper than giving the watcher a **second** Docker socket in a stack whose
+most privileged service already has one. Its verification section is the point of the
+feature: four questions F2's design depends on, answered by measurement. See
+`.specs/features/harness-sphere-integration/`.
+
+**harness-sphere-zombie-crab-scope (SPEC READY, blocked on the above)** — the reduction
+and the dynamic half. `Layer` collapses from seven to the stack's six real ones — host,
+self, mycelium-gateway, proxy, exoskeleton, picoclaw — with `Container` demoted from a
+peer layer to a *dimension* (everything here runs in a container; a picoclaw container's
+memory is a Harness signal). `prometheus.rs` (770 LOC) and the `ingest` crate (574 LOC)
+are deleted: nothing here exposes Prometheus text and nothing pushes OTLP. **Token cost
+leaves with them and does not come back** — picoclaw does not write tokens to disk, and
+instrumenting it is a non-goal. The dynamic half is the real work: harness-sphere's
+sources are single-valued and boot-resolved (`&'static str` names, `probe()` once at
+startup, a supervisor whose source set never changes), which is the exact opposite of a
+proxy that creates and recreates a container per user on demand. Discovery reconciles two
+surfaces that are allowed to disagree — the proxy's inventory (live containers) and the
+on-disk tenant tree (provisioned workspaces, whose *path* carries the tuple, so session
+metrics survive the proxy being down). See
+`.specs/features/harness-sphere-zombie-crab-scope/`.
+
+---
+
 ## Future Considerations
 
 - Production hardening (TLS termination, secret rotation, Docker-socket privilege — see AD-009 R2)

--- a/.specs/project/STATE.md
+++ b/.specs/project/STATE.md
@@ -1,7 +1,16 @@
 # State
 
-**Last Updated:** 2026-08-28T00:00:00-03:00
-**Current Work:** `project-chat-context-loss` FIXED and verified against the live stack
+**Last Updated:** 2026-09-07T00:00:00-03:00
+**Current Work:** **M5 observability planned, nothing implemented.** Two specs written for
+adopting `harness-sphere` as a third submodule and repurposing it to work exclusively for
+this stack: `harness-sphere-integration` (land it, no Rust changed) and
+`harness-sphere-zombie-crab-scope` (cut the scope, teach it dynamic instances). Four
+gray areas were put to the maintainer and all four answered — see AD-022. The starting
+fact that shapes both: **this stack emits no telemetry at all**, verified by a strict grep
+for `prometheus|opentelemetry|otel` across this repo and both submodules returning zero
+hits. **No code has been written for either feature.**
+
+**Previously:** `project-chat-context-loss` FIXED and verified against the live stack
 (AD-019). Root cause was upstream picoclaw, not this stack: `legacyContextManager` read a
 conversation's history from the DEFAULT agent's session store instead of the routed
 agent's, so every conversation inside a project answered with no history at all, on every
@@ -52,6 +61,71 @@ still operator-gated (needs the backend stack). M4 (crab-shell-proxy) live-conta
 ---
 
 ## Recent Decisions (Last 60 days)
+
+### AD-022: harness-sphere is adopted as a third submodule and repurposed exclusively for this stack (2026-09-07)
+
+**Decision:** `https://github.com/LepistaBioinformatics/harness-sphere` becomes a submodule
+at `crab/harness-sphere` and is then cut down to zombie-crab's shape. Planned as two
+sequential features (`.specs/features/harness-sphere-integration/`,
+`.specs/features/harness-sphere-zombie-crab-scope/`). Four gray areas were put to the
+maintainer; all four were answered, and each is load-bearing.
+
+**1. The upstream repo is repurposed in place, not forked.** Checked rather than assumed:
+0 stars, 0 forks, 0 open issues, and `harnesssphere` is **not on crates.io** (the publish
+workflow is manual and was only ever dry-run). There is no external consumer to break.
+*Cost accepted:* the generic seven-layer "Claw/Harness ecosystem" vision ends. Getting a
+generic watcher back later means forking out of a tree that has had a third of its
+collectors deleted.
+
+**2. `crab-shell-proxy` gains one read-only endpoint (`GET /v1/instances`) instead of
+harness-sphere getting a Docker socket.** The container name is
+`crabshell-<role>-<sha256(tenant::subs::user)[:16]>` and the hash is one-way —
+`manager.go:139-149` says so itself: *"tenant/subscription/user are recovered from the
+container labels and the .crab-owner.json marker, not the name."* So per-tenant
+attribution of a running container needs the Docker API or someone who already holds it.
+The proxy already mounts the socket and runs as root; a second socket-mounting service
+would double the blast radius of the stack's worst-case compromise to obtain a mapping the
+proxy has in memory. *What it does not buy:* the inventory names containers, it does not
+carry cgroup counters — where per-container CPU/memory comes from is left open on purpose
+(F1 OQ-2 / F2 OQ-5), with a read-only `/sys/fs/cgroup` bind as the current preference.
+
+**3. Attribution is the full tuple; `session_id` is never a metric attribute.** Every
+instance metric carries `crab.tenant`/`crab.subscription`/`crab.agent`/`crab.user` — one
+series per container, which is the granularity the stack already creates, and the only one
+that answers "which user is burning the host". `session_id` is excluded **by rule**:
+conversations grow without bound and nothing prunes them, a defect this repo already
+records against the in-memory registry (`background-turn-dock/spec.md:446`, OQ-3). The
+user label is the mycelium account UUID, never the email — the same line the proxy already
+draws.
+
+**4. Two features, not one.** F1 lands the tool with **no Rust changed** so that its first
+run against the stack tests the tree whose behaviour is documented; anything that breaks is
+then a deployment fact or a real upstream limitation, with no third candidate. F2 is
+designed against F1's measurements rather than against inference.
+
+**One decision taken without asking, and why.** It runs as a **compose service on
+`zombie_net`**, contradicting harness-sphere's own "single portable binary" principle. Not
+a preference: picoclaw instances publish no host ports (`18790` exists only on the internal
+network) and the proxy's `18080` is loopback-only and dropped entirely in prod, so a host
+binary would be structurally blind to the agent layer. The usual objection — that a
+container cannot see the host — does not apply: `HostCollector` reads through `sysinfo`,
+which reads `/proc/meminfo` and `/proc/stat`, and **those are not namespaced in Docker**.
+No `/proc` or `/sys` bind is needed for host metrics. That claim is asserted from the
+collector's source and is F1's first verification item, because a wrong answer changes the
+deployment shape.
+
+**Two findings worth keeping even if the features never ship.**
+- **`SessionCollector` will work here**, established from the proxy's own parser rather
+  than by guessing: `internal/history/history.go:73-86` reads picoclaw's JSONL as
+  `{role, content, created_at, tool_calls[], reasoning_content}`, and the collector reads
+  exactly `role` and `tool_calls`. Three distortions come with it — the proxy's own
+  `sessions/durable/` transcripts, **one session file per cron *run*** (which turns
+  "sessions" into "sessions plus every scheduled run since provisioning"), and a full
+  re-read of every transcript on every tick.
+- **Token cost is not obtainable in this stack, at all.** Picoclaw does not write tokens to
+  disk, and the only path harness-sphere had to `gen_ai.client.token.usage` was scraping
+  OpenClaw's Prometheus endpoint, which nothing here exposes. Anyone expecting a token bill
+  from "AI observability" should read this line first.
 
 ### AD-021: a tool-delivered turn's ending is fixed in BOTH places — a fourth picoclaw patch and a bound in the proxy (2026-09-05)
 


### PR DESCRIPTION
Planning only. **No submodule pointer moves in this PR**, so `submodule-pointers.yml` has nothing to check — it can merge independently of the rest of the chain.

## What this is

`harness-sphere` is adopted as a third submodule and repurposed to work exclusively for this stack. Split into two features because the ask is literally sequential, and because the first one *measures* what the second is designed against.

The starting fact: **this stack emits no telemetry at all.** A strict grep for `prometheus|opentelemetry|go.opentelemetry|otelhttp|promhttp|otel` across this repo and both submodules returns zero hits. The entire observability surface is three health endpoints plus unstructured printf logs with no levels and no request ids.

## F1 — `harness-sphere-integration`

Lands the tool as a submodule at `crab/harness-sphere` and runs it as one compose service, **with no Rust changed**. That constraint is the point: the first run against the stack then tests the tree whose behaviour is documented, so anything that breaks is either a deployment fact or a real upstream limitation, with no third candidate.

Three decisions worth reviewing rather than skimming:

- **It runs as a container, not the host binary its own design principles call for.** Picoclaw instances publish no host ports and the proxy's `18080` is dropped entirely in prod, so a host binary would be structurally blind to the agent layer. The usual objection does not apply: `sysinfo` reads `/proc/meminfo`, which Docker does not namespace.
- **`crab-shell-proxy` gains one read-only endpoint, `GET /v1/instances`.** The container name hashes `(tenant::subs::user)` one-way — `manager.go` says so itself — and the proxy holds the only preimage. The alternative was a **second** socket-mounting root service in a stack whose most privileged component already has one.
- **That endpoint gets its own credential, not an agent token.** The profile header is decoded and never verified (`identity.go:67`), so an agent token is the sole gate against a caller on `zombie_net` asserting any `accId` they like. A telemetry component must not hold one. The endpoint is also cross-agent while `resolveAgent` is single-agent, so there is no principled token to pick anyway.

**FR-V1 is already discharged by experiment**, not deferred to deployment: built and run in a container capped at `-m 512m`, it reported the host's 33 GB and ignored the cgroup limit entirely. No `/proc` or `/sys` bind is needed. The measured output is transcribed in the spec.

## F2 — `harness-sphere-zombie-crab-scope`

`Layer` collapses from seven to this stack's six — host, self, mycelium-gateway, proxy, exoskeleton, picoclaw — with **`Container` demoted from a peer layer to a dimension**: everything here runs in a container, so a picoclaw container's memory is a Harness signal, not a Container one.

`prometheus.rs` (770 LOC) and the `ingest` crate (574 LOC) are deleted — nothing here exposes Prometheus text and nothing pushes OTLP. **Token cost leaves with them and does not come back**: picoclaw does not write tokens to disk, and instrumenting it is a non-goal. Stated in its own paragraph so nobody discovers it later.

The dynamic half is the real work. Harness-sphere's sources are single-valued and boot-resolved (`&'static str` names, `probe()` once at startup, a supervisor whose source set never changes) — the exact opposite of a proxy that creates and recreates a container per user on demand.

**F2 has no `design.md` or `tasks.md`, deliberately.** Four of its decisions are written against measurements only F1 can take.

## Review focus

- **DEC-15** (design.md) — the credential decision above.
- **DEC-8** (F2 spec) — `Container` as dimension rather than layer.

Both get expensive to reverse later: the first as a credential provisioned for nothing, the second as dashboards rewritten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
