### PR TITLE
chore(submodule): the harness-sphere image exists — drop the caveat

### DIFF
--- a/deploy/prod/.env.example
+++ b/deploy/prod/.env.example
@@ -44,10 +44,6 @@ CHAT_WEBAPP_DB_NAME=chatwebapp
 MYCELIUM_IMAGE_TAG=9.0.0-rc.13
 CRAB_SHELL_PROXY_TAG=latest
 CHAT_WEBAPP_TAG=latest
-# NOT PUBLISHED YET. harness-sphere ships binary releases only -- it has no image
-# release workflow, and ghcr.io/lepistabioinformatics/harness-sphere 404s. Until
-# that workflow exists, a prod deploy must either omit the harness-sphere service
-# or build it from source; setting a tag here will not conjure an image.
 HARNESS_SPHERE_TAG=latest
 
 # ─── Knowledge graph (crab-shell-proxy's native MCP server) ───────────────────

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -93,15 +93,6 @@ services:
     build: !reset null
     image: ghcr.io/lepistabioinformatics/crab-exoskeleton-webapp:${CHAT_WEBAPP_TAG:-latest}
 
-  # NOT DEPLOYABLE YET. harness-sphere publishes binary releases only -- it has no
-  # release-image.yml, and ghcr.io/lepistabioinformatics/harness-sphere does not
-  # exist (the package 404s). This override is written now so the prod file is
-  # complete and the gap is stated where someone would hit it, rather than
-  # discovered as an image pull failure during a deploy.
-  #
-  # To close it: add an image release workflow to the harness-sphere repo,
-  # mirroring crab-shell-proxy's release-image.yml. Until then, prod either omits
-  # this service or builds it from source.
   harness-sphere:
     build: !reset null
     image: ghcr.io/lepistabioinformatics/harness-sphere:${HARNESS_SPHERE_TAG:-latest}


### PR DESCRIPTION
Closes the gap #60 flagged. Pointer bump plus removing two now-stale comments.

`crab/harness-sphere` → `bb1c0ab` (LepistaBioinformatics/harness-sphere#22, merged), which added `release-image.yml`.

## Why the caveat existed, and why it can go

#60 wrote "NOT DEPLOYABLE YET" into `docker-compose.prod.yaml` and `deploy/prod/.env.example`. That was accurate at the time: `harness-sphere` published **binary releases only**, and `ghcr.io/lepistabioinformatics/harness-sphere` returned 404 — a prod deploy would have failed on an image pull with nothing pointing at the cause.

The workflow has since run on `main` (2m59s, success) and the image is verified **pullable**:

```
$ docker pull ghcr.io/lepistabioinformatics/harness-sphere:latest
Status: Downloaded newer image for ghcr.io/lepistabioinformatics/harness-sphere:latest
```

Checked by pulling it, not by reading the workflow's exit code — the GitHub packages API answered `403` for scope reasons, which is not evidence either way.

## Verification

- `docker compose -f docker-compose.yaml -f docker-compose.prod.yaml config` parses.
- `bb1c0ab` confirmed reachable from `harness-sphere`'s `origin/main`.

## Note on the marketing pointer

LepistaBioinformatics/zombie-crab-project-mkt#16 currently names `eef1416`, which predates this. That is fine and allowed — "reachable, not equal" — but a small second bump after this merges would put the whole chain on the deployable state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
