### PR TITLE
feat(observability): somewhere for the metrics to land, and a UI to read them

### DIFF
--- a/deploy/observability/grafana/dashboards/provider.yml
+++ b/deploy/observability/grafana/dashboards/provider.yml
@@ -1,0 +1,10 @@
+apiVersion: 1
+providers:
+  - name: zombie-crab
+    orgId: 1
+    folder: ""
+    type: file
+    disableDeletion: false
+    allowUiUpdates: true
+    options:
+      path: /etc/grafana/provisioning/dashboards

--- a/deploy/observability/grafana/dashboards/zombie-crab-stack.json
+++ b/deploy/observability/grafana/dashboards/zombie-crab-stack.json
@@ -1,0 +1,195 @@
+{
+  "uid": "zombie-crab-stack",
+  "title": "zombie-crab — stack",
+  "description": "Every panel here is built on a metric name verified against a live Prometheus, not inferred from OTel semconv. The OTLP->Prometheus translation renames things (dots to underscores, unit suffixes appended), so the semconv name is not the query name.",
+  "tags": ["zombie-crab", "harness-sphere"],
+  "timezone": "browser",
+  "editable": true,
+  "schemaVersion": 39,
+  "refresh": "10s",
+  "time": { "from": "now-30m", "to": "now" },
+  "panels": [
+    {
+      "type": "row",
+      "title": "Service liveness — the four layers a probe can reach",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 }
+    },
+    {
+      "type": "stat",
+      "title": "Endpoints up",
+      "description": "harnesssphere.endpoint.up, one series per probe target. A target that is down reads 0 here rather than going absent — the collector emits an honest zero and stays alive, which is why the watcher needs no depends_on ordering.",
+      "gridPos": { "h": 5, "w": 10, "x": 0, "y": 1 },
+      "datasource": { "type": "prometheus", "uid": "zombie-crab-prom" },
+      "targets": [
+        {
+          "expr": "harnesssphere_endpoint_up",
+          "legendFormat": "{{server_address}}",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "colorMode": "background",
+        "graphMode": "none",
+        "textMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            { "type": "value", "options": { "0": { "text": "DOWN", "color": "red", "index": 0 } } },
+            { "type": "value", "options": { "1": { "text": "UP", "color": "green", "index": 1 } } }
+          ],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "red", "value": null }, { "color": "green", "value": 1 }] }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Probe latency",
+      "description": "TCP connect time per target. A rising line here is the earliest sign a service is struggling, before it fails a health check.",
+      "gridPos": { "h": 5, "w": 14, "x": 10, "y": 1 },
+      "datasource": { "type": "prometheus", "uid": "zombie-crab-prom" },
+      "targets": [
+        {
+          "expr": "harnesssphere_endpoint_probe_duration_seconds",
+          "legendFormat": "{{server_address}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "s", "custom": { "fillOpacity": 8, "showPoints": "never" } },
+        "overrides": []
+      }
+    },
+    {
+      "type": "row",
+      "title": "Host (hospedeiro) — the real machine, not this container",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 6 }
+    },
+    {
+      "type": "timeseries",
+      "title": "Host CPU utilisation",
+      "description": "sysinfo reads /proc/stat, which Docker does not namespace, so this is the HOST — measured, not assumed: a container capped at 512m still reported the host's 33 GB.",
+      "gridPos": { "h": 7, "w": 8, "x": 0, "y": 7 },
+      "datasource": { "type": "prometheus", "uid": "zombie-crab-prom" },
+      "targets": [{ "expr": "system_cpu_utilization", "legendFormat": "cpu", "refId": "A" }],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "custom": { "fillOpacity": 15, "showPoints": "never" }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Host memory by state",
+      "description": "used / free / available. 'available' is the one that matters for headroom — 'free' excludes reclaimable cache and reads alarmingly low on a healthy machine.",
+      "gridPos": { "h": 7, "w": 10, "x": 8, "y": 7 },
+      "datasource": { "type": "prometheus", "uid": "zombie-crab-prom" },
+      "targets": [
+        {
+          "expr": "system_memory_usage_bytes",
+          "legendFormat": "{{system_memory_state}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "bytes", "custom": { "fillOpacity": 10, "showPoints": "never" } },
+        "overrides": []
+      }
+    },
+    {
+      "type": "gauge",
+      "title": "Host memory used",
+      "gridPos": { "h": 7, "w": 3, "x": 18, "y": 7 },
+      "datasource": { "type": "prometheus", "uid": "zombie-crab-prom" },
+      "targets": [{ "expr": "system_memory_utilization", "refId": "A" }],
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 0.8 },
+              { "color": "red", "value": 0.92 }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "gauge",
+      "title": "Swap used",
+      "description": "Swap climbing on a host that runs agent containers is the earliest warning that the box is oversubscribed.",
+      "gridPos": { "h": 7, "w": 3, "x": 21, "y": 7 },
+      "datasource": { "type": "prometheus", "uid": "zombie-crab-prom" },
+      "targets": [{ "expr": "system_paging_utilization", "refId": "A" }],
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 0.2 },
+              { "color": "red", "value": 0.5 }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "row",
+      "title": "Watcher (self) — is the thing measuring you healthy?",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 14 }
+    },
+    {
+      "type": "timeseries",
+      "title": "Watcher memory",
+      "description": "Resident and virtual. A watcher whose own footprint grows without bound is a watcher about to become the incident.",
+      "gridPos": { "h": 6, "w": 12, "x": 0, "y": 15 },
+      "datasource": { "type": "prometheus", "uid": "zombie-crab-prom" },
+      "targets": [
+        { "expr": "process_memory_usage_bytes", "legendFormat": "resident", "refId": "A" },
+        { "expr": "process_memory_virtual_bytes", "legendFormat": "virtual", "refId": "B" }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "bytes", "custom": { "fillOpacity": 8, "showPoints": "never" } },
+        "overrides": []
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Watcher CPU",
+      "gridPos": { "h": 6, "w": 12, "x": 12, "y": 15 },
+      "datasource": { "type": "prometheus", "uid": "zombie-crab-prom" },
+      "targets": [{ "expr": "process_cpu_utilization", "legendFormat": "{{process_executable_name}}", "refId": "A" }],
+      "fieldConfig": {
+        "defaults": { "unit": "percentunit", "min": 0, "custom": { "fillOpacity": 8, "showPoints": "never" } },
+        "overrides": []
+      }
+    },
+    {
+      "type": "text",
+      "title": "What is NOT here, and why",
+      "gridPos": { "h": 7, "w": 24, "x": 0, "y": 21 },
+      "options": {
+        "mode": "markdown",
+        "content": "**Four layers are missing from this dashboard, and none of them is an oversight.**\n\n- **picoclaw (per-tenant agent containers)** — the layer this project exists to run. Requires dynamic instance discovery, which is the next feature. Today the watcher's sources are all single-valued and resolved once at boot.\n- **Per-container CPU/memory** for the gateway, proxy and webapp — needs a cgroup source; still an open question, because the watcher deliberately holds no Docker socket.\n- **Session / AI activity** (messages by role, tool calls) — **blocked**: `data/tenants` is `root:root 0700`, so the non-root watcher cannot traverse it. This also breaks the on-disk fallback the next feature's design relied on.\n- **Token cost** — **not obtainable in this stack at all.** picoclaw does not write token counts to disk, and the only path that ever existed was scraping an endpoint this stack does not run. It is not coming later.\n\nWhat *is* here is everything a metrics-only pipeline can honestly show today."
+      }
+    }
+  ]
+}

--- a/deploy/observability/grafana/datasources/prometheus.yml
+++ b/deploy/observability/grafana/datasources/prometheus.yml
@@ -1,0 +1,11 @@
+# Provisioned so the stack is useful on first boot with no clicking. A dashboard
+# that requires a manual datasource setup is a dashboard nobody opens twice.
+apiVersion: 1
+datasources:
+  - name: Prometheus
+    uid: zombie-crab-prom
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false

--- a/deploy/observability/harnesssphere.otlp.toml
+++ b/deploy/observability/harnesssphere.otlp.toml
@@ -1,0 +1,93 @@
+# DERIVED from crab/harness-sphere/config.zombie-crab.toml by changing exactly two
+# lines: exporter -> "otlp" and otlp_endpoint -> the collector on zombie_net.
+#
+# It is a separate file rather than an env override because harness-sphere has no
+# env override for otlp_endpoint -- only HARNESSSPHERE_EXPORTER exists
+# (harnesssphere/src/config.rs). The overlay bind-mounts this over the config the
+# image bakes in, so the submodule needs no change at all.
+#
+# If the upstream config gains a field, re-derive rather than hand-edit:
+#   sed -e 's|^exporter = .*|exporter = "otlp"|' \
+#       -e 's|^otlp_endpoint = .*|otlp_endpoint = "http://otel-collector:4317"|' \
+#       crab/harness-sphere/config.zombie-crab.toml > deploy/observability/harnesssphere.otlp.toml
+
+# HarnessSphere — configuration for the zombie-crab stack.
+#
+# This file is what the container runs (baked to /etc/harnesssphere/config.toml).
+# It configures ONLY fields that exist today: this is the "land it, change no Rust"
+# step, so that the first run against the live stack tests the tree whose behaviour
+# is documented.
+#
+# NO SECRET GOES IN THIS FILE. It is committed. Anything sensitive arrives by
+# environment.
+
+# --- Critical sources: host (hospedeiro) and self. ---------------------------
+# These two are the only mandatory layers; if either cannot be read, the watcher
+# exits non-zero rather than pretending to observe.
+#
+# The host values are the HOST's, not this container's, and that is measured
+# rather than assumed: sysinfo reads /proc/meminfo and /proc/stat, which Docker
+# does not namespace. A run capped at -m 512m reported the host's 33 GB.
+host_interval_secs = 10
+self_interval_secs = 30
+critical_threshold = 3
+
+# --- Export ------------------------------------------------------------------
+# `stdout` is the deliberate default: it proves the whole pipeline with no backend
+# to stand up, and choosing a durable backend is a separate decision that should be
+# made with a real cardinality figure in hand. Override with HARNESSSPHERE_EXPORTER.
+exporter = "otlp"
+otlp_endpoint = "http://otel-collector:4317"
+service_name = "harnesssphere"
+metric_export_interval_secs = 15
+
+# --- Probes: the three fixed compose services --------------------------------
+# Named by their COMPOSE SERVICE NAMES on zombie_net. Note the third one: the
+# repository is called `crab-exoskeleton-webapp`, but the compose service — and
+# therefore the only name that resolves on this network — is `chat-webapp`.
+#
+# No depends_on is needed for these, and adding `condition: service_healthy` would
+# be wrong. EndpointProbeCollector::probe() never touches the network (it returns
+# Ready when the target list is non-empty); reachability is decided per tick inside
+# collect(), which emits endpoint.up = 0 for a target that is down. Ordering the
+# watcher behind the health of what it watches would suppress the exact signal it
+# exists to produce.
+probe_targets = [
+    "mycelium-gateway:8080",
+    "crab-shell-proxy:8080",
+    "chat-webapp:3000",
+]
+
+# --- Session-derived AI activity ---------------------------------------------
+# EMPTY ON PURPOSE, and set by the operator at deploy time as a one-off probe.
+#
+# Two reasons it does not ship populated. First, a development checkout has no
+# tenants/ tree, so any committed path would resolve nowhere. Second, this field is
+# single-valued while the stack has one sessions/ directory PER WORKSPACE — pointing
+# it at one member would emit a metric that silently describes one tenant and looks
+# like it describes the stack. Multiplexing it is the next feature's job.
+#
+# When set for that probe, expect three known distortions and read them as such:
+#   1. sessions/durable/ holds crab-shell-proxy's own append-only transcripts. The
+#      collector's read_dir is non-recursive, so it should skip them; if that ever
+#      changes, every message is counted twice.
+#   2. Every scheduled-task RUN writes its own session file, so `harness.sessions`
+#      drifts from "conversations" towards "conversations plus every cron run since
+#      provisioning". The paired .meta.json key (agent:cron-*) is what tells them apart.
+#   3. Every transcript is re-read IN FULL on every tick.
+session_dir = ""
+session_source = "picoclaw"
+
+# --- Deliberately unset ------------------------------------------------------
+# Each of these is single-valued and resolved once at boot, which is precisely why
+# the dynamic-discovery feature exists. Setting any of them to one arbitrary
+# instance would produce a metric that describes one tenant and reads like it
+# describes the stack.
+container_cgroup = ""
+container_id = ""
+watch_processes = []
+
+# --- Not built into this image -----------------------------------------------
+# The `ingest` and `prometheus` features are OFF (see Dockerfile): nothing in this
+# stack pushes OTLP to us, and nothing exposes a Prometheus exposition endpoint.
+# Both collectors are slated for deletion in the scope-reduction feature.

--- a/deploy/observability/otel-collector-config.yaml
+++ b/deploy/observability/otel-collector-config.yaml
@@ -1,0 +1,39 @@
+# OTel Collector — the translator between what harness-sphere speaks and what
+# Prometheus can read.
+#
+# It exists for one concrete reason: harness-sphere's OTLP exporter is built with
+# `.with_tonic()` (crates/export/src/otlp.rs), so it speaks OTLP over **gRPC**.
+# Prometheus's own OTLP receiver is HTTP-only, so the two cannot be wired
+# directly. This collector receives gRPC and re-exposes everything in Prometheus
+# exposition format for scraping.
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+
+processors:
+  batch:
+    timeout: 5s
+
+exporters:
+  prometheus:
+    endpoint: 0.0.0.0:8889
+    # Without this, the OTel Resource attributes (service.name, host.name) are
+    # dropped and every series looks anonymous. They are how a signal is traced
+    # back to what produced it.
+    resource_to_telemetry_conversion:
+      enabled: true
+
+service:
+  # Metrics only. harness-sphere emits no traces and no logs -- it boots
+  # `sources=3 receivers=0` -- so declaring those pipelines would advertise
+  # capability the stack does not have.
+  pipelines:
+    metrics:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [prometheus]
+  telemetry:
+    logs:
+      level: warn

--- a/deploy/observability/prometheus.yml
+++ b/deploy/observability/prometheus.yml
@@ -1,0 +1,11 @@
+# Scrapes the collector, which is the only thing that holds harness-sphere's
+# metrics. Nothing else in this stack exposes Prometheus text -- that was the
+# starting condition this whole feature was written against.
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: harness-sphere
+    static_configs:
+      - targets: ["otel-collector:8889"]

--- a/deploy/standalone/.env.example
+++ b/deploy/standalone/.env.example
@@ -95,3 +95,12 @@ CHAT_WEBAPP_DB_NAME=chatwebapp
 # patch). Point it at docker.io/sipeed/picoclaw:latest to run stock picoclaw --
 # projects stop working, nothing else changes.
 #CRAB_PICOCLAW_IMAGE=zombie-crab/picoclaw:0.3.1-glob
+
+# --- Observability backend (opt-in overlay) ---------------------------------
+# Only read when you bring the stack up with the extra file:
+#   docker compose -f docker-compose.yaml -f docker-compose.observability.yaml up -d
+# That overlay flips harness-sphere from stdout to OTLP and adds an OTel
+# Collector, Prometheus and Grafana. Without it none of these matter.
+GRAFANA_PORT=3001
+PROMETHEUS_PORT=9090
+PROMETHEUS_RETENTION=15d

--- a/docker-compose.observability.yaml
+++ b/docker-compose.observability.yaml
@@ -1,0 +1,94 @@
+# Opt-in observability backend: somewhere for harness-sphere's metrics to land
+# and a UI to read them in.
+#
+#   docker compose -f docker-compose.yaml -f docker-compose.observability.yaml up -d
+#   → Grafana on http://localhost:${GRAFANA_PORT:-3001}  (anonymous, no login)
+#
+# OPT-IN ON PURPOSE. The base file stays one added service exporting to stdout,
+# which proves the pipeline with nothing to stand up. This overlay is for
+# actually looking at the numbers over time.
+#
+# WHY NOT SIGNOZ, which harness-sphere already vendors under
+# crab/harness-sphere/deploy/signoz/ and which was verified end to end upstream:
+# it is six services including ClickHouse and Zookeeper, and its value is traces
+# and logs. harness-sphere boots `sources=3 receivers=0` -- it emits METRICS
+# ONLY, no traces, no logs -- so that engine would idle while costing gigabytes.
+# Three services sized to the signal that actually exists beats six sized to the
+# signal that does not. The vendored SigNoz stays available for the day traces do.
+
+services:
+  # Point the watcher at the collector instead of stdout.
+  harness-sphere:
+    environment:
+      HARNESSSPHERE_EXPORTER: otlp
+    volumes:
+      # Bind-mounted OVER the config the image bakes in. harness-sphere has no
+      # env override for otlp_endpoint (only HARNESSSPHERE_EXPORTER exists), so
+      # a whole file is the way to redirect it -- and doing it here means the
+      # submodule needs no change.
+      #
+      # Compose appends volume lists across -f layers, so the base file's
+      # read-only /data bind is still here; this is an addition, not a
+      # replacement.
+      - ./deploy/observability/harnesssphere.otlp.toml:/etc/harnesssphere/config.toml:ro
+
+  # Translates OTLP/gRPC into Prometheus exposition. Needed because
+  # harness-sphere's exporter is built .with_tonic() (gRPC) while Prometheus's
+  # own OTLP receiver is HTTP-only -- the two cannot be wired directly.
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:${OTEL_COLLECTOR_TAG:-0.116.1}
+    restart: unless-stopped
+    command: ["--config=/etc/otelcol/config.yaml"]
+    volumes:
+      - ./deploy/observability/otel-collector-config.yaml:/etc/otelcol/config.yaml:ro
+    networks:
+      - zombie_net
+    # No published ports: it is reached only from inside zombie_net.
+
+  prometheus:
+    image: prom/prometheus:${PROMETHEUS_TAG:-v3.1.0}
+    restart: unless-stopped
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+      - --storage.tsdb.path=/prometheus
+      # Keep it modest: this is for watching the stack while it is being built,
+      # not a retention tier.
+      - --storage.tsdb.retention.time=${PROMETHEUS_RETENTION:-15d}
+    volumes:
+      - ./deploy/observability/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus-data:/prometheus
+    networks:
+      - zombie_net
+    # Published so a raw PromQL query is possible when a dashboard disagrees
+    # with what you expect. 9090 is Prometheus's own convention.
+    ports:
+      - "${PROMETHEUS_PORT:-9090}:9090"
+
+  grafana:
+    image: grafana/grafana:${GRAFANA_TAG:-11.4.0}
+    restart: unless-stopped
+    environment:
+      # Anonymous admin access. This is a local development backend on a
+      # loopback-published port, and a login prompt in front of your own CPU
+      # graphs is friction with no threat model behind it. If this is ever
+      # exposed beyond localhost, these three lines are the first thing to
+      # remove.
+      GF_AUTH_ANONYMOUS_ENABLED: "true"
+      GF_AUTH_ANONYMOUS_ORG_ROLE: Admin
+      GF_AUTH_DISABLE_LOGIN_FORM: "true"
+      GF_USERS_DEFAULT_THEME: dark
+    volumes:
+      - ./deploy/observability/grafana/datasources:/etc/grafana/provisioning/datasources:ro
+      - ./deploy/observability/grafana/dashboards:/etc/grafana/provisioning/dashboards:ro
+      - grafana-data:/var/lib/grafana
+    networks:
+      - zombie_net
+    # 3001 because chat-webapp already owns 3000.
+    ports:
+      - "${GRAFANA_PORT:-3001}:3000"
+    depends_on:
+      - prometheus
+
+volumes:
+  prometheus-data:
+  grafana-data:


### PR DESCRIPTION
Answers spec OQ-1, which #58 deliberately deferred until there was a real cardinality figure. There is one now (FR-V4: 1 workspace), and the metrics need somewhere to go.

```
docker compose -f docker-compose.yaml -f docker-compose.observability.yaml up -d
→ Grafana on http://localhost:3001   (anonymous, no login)
→ Prometheus on http://localhost:9090 for raw PromQL
```

**Opt-in.** The base file stays one added service exporting to stdout.

## Not SigNoz, and the reason is the signal

`harness-sphere` vendors a working SigNoz under `crab/harness-sphere/deploy/signoz/`, verified end to end upstream. I did not use it.

It is **six services including ClickHouse and Zookeeper**, and its value is traces and logs. harness-sphere boots `sources=3 receivers=0` — **metrics only, no traces, no logs**. That engine would idle while costing gigabytes. Three services sized to the signal that exists beats six sized to the signal that does not, and the vendored SigNoz stays right where it is for the day traces do.

## Two things that are not arbitrary

**The collector is required, not decoration.** harness-sphere's exporter is built `.with_tonic()` (`crates/export/src/otlp.rs`) — OTLP over **gRPC**. Prometheus's own OTLP receiver is **HTTP-only**. The two cannot be wired directly.

**No submodule change was needed.** harness-sphere has no env override for `otlp_endpoint` — only `HARNESSSPHERE_EXPORTER` exists (`harnesssphere/src/config.rs`) — so the overlay bind-mounts a derived TOML over the config the image bakes in. That file is generated from the shipped one by changing exactly two lines and carries the `sed` command to re-derive it, so it cannot drift.

## Every query is verified, not inferred

The OTLP→Prometheus translation **renames things**: `system.memory.usage` becomes `system_memory_usage_bytes`, and the state label becomes `system_memory_state`. The semconv name is not the query name, so guessing would have shipped a dashboard of empty panels that looks fine in review.

The ten metric names were read back out of a live Prometheus, then all nine dashboard queries confirmed to return data **through Grafana's datasource proxy**:

```
harnesssphere_endpoint_up                      -> 3 series
harnesssphere_endpoint_probe_duration_seconds  -> 3 series
system_memory_usage_bytes                      -> 3 series
system_cpu_utilization                         -> 1 series
system_memory_utilization                      -> 1 series
system_paging_utilization                      -> 1 series
process_cpu_utilization                        -> 1 series
process_memory_usage_bytes                     -> 1 series
process_memory_virtual_bytes                   -> 1 series
```

The datasource `uid` is pinned on both sides rather than left to Grafana's generator, so provisioning cannot quietly produce a dashboard wired to nothing.

## The dashboard says what it cannot show

Its last panel names the four missing layers and why, because a dashboard that silently omits the interesting half teaches the wrong thing about what is being watched:

- **picoclaw instances** — needs dynamic discovery (the next feature).
- **Per-container CPU/memory** — needs a cgroup source; still open, since the watcher deliberately holds no Docker socket.
- **Session / AI activity** — **blocked**: `data/tenants` is `root:root 0700` (see #61).
- **Token cost** — **not obtainable in this stack at all**, and not coming later.

## Verified running

Against the live stack: Prometheus target `up`, Grafana `database: ok`, datasource and dashboard provisioned, every query returning series.

## Note

Anonymous Grafana admin, deliberately — a local backend on a loopback port, where a login prompt in front of your own CPU graphs is friction with no threat model. Three lines to remove if it is ever exposed beyond localhost, flagged in the compose file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
