### PR TITLE
docs: resolve F1 OQ-6, advance harness-sphere to the reduction, design F2's dynamic half

### DIFF
--- a/.specs/features/harness-sphere-integration/spec.md
+++ b/.specs/features/harness-sphere-integration/spec.md
@@ -234,8 +234,16 @@ allowed by the rules file, provided the PR body says which pointers are branch h
 **FR-C1** One new compose service, `harness-sphere`, built from `./crab/harness-sphere`,
 joined to `zombie_net`. It publishes **no host ports**.
 
-**FR-C2** It runs as a **non-root** user and mounts **no Docker socket** (DEC-3). If an
-implementation task adds `/var/run/docker.sock` to this service, the task is wrong.
+**FR-C2** It mounts **no Docker socket** (DEC-3). If an implementation task adds
+`/var/run/docker.sock` to this service, the task is wrong.
+
+> **AMENDED 2026-09-08 (OQ-6).** This requirement also said "it runs as a **non-root**
+> user". That half is withdrawn: harness-sphere runs as a privileged daemon, because the
+> tenant tree is `root:root 0700` and no other option preserved F2 DEC-10's resilience.
+> The no-Docker-socket half is **unweakened** — it was always the load-bearing one, since
+> a socket grants control while root-on-a-read-only-bind grants reading. Two further
+> constraints join it as load-bearing: the `/data` bind stays `:ro`, and the watcher opens
+> **no listening port**. See the OQ-6 resolution for the full argument.
 
 **FR-C3** It mounts **no `/proc` and no `/sys`** bind for host metrics (DEC-2 — the
 container's own `/proc` is already the host's). A bind may only be added if FR-V1
@@ -601,9 +609,11 @@ the answer changes its shape. Four candidates, none chosen:
    local uid, and the directory names are account UUIDs.
 2. **Give the watcher a supplementary group** that can traverse. Narrower than (1), but
    still requires changing what the proxy sets, and adds a group to provision.
-3. **Run the watcher as root.** Rejected on sight: it contradicts FR-C2 and dissolves the
-   privilege argument the whole design is built on. Recorded only so it is visibly
-   rejected rather than quietly available.
+3. **Run the watcher as root.** ← **CHOSEN, 2026-09-08.** See the resolution below.
+   *Original text, kept because being wrong in public is the point of writing options
+   down:* "Rejected on sight: it contradicts FR-C2 and dissolves the privilege argument
+   the whole design is built on. Recorded only so it is visibly rejected rather than
+   quietly available."
 4. **The proxy serves session counts over its API**, as a sibling of `GET /v1/instances`,
    and the disk surface is abandoned. Most consistent with DEC-3's reasoning — the proxy is
    the component that already has the privilege, so do not manufacture a second one — and
@@ -614,6 +624,55 @@ property outright. Session metrics would then stop when the proxy stops, rather 
 degrading to disk-only. A watcher that goes blind exactly when the thing it watches breaks
 is the failure mode DEC-10 was written to avoid — so choosing (4) means accepting that
 trade explicitly, not forgetting it was ever offered.
+
+### OQ-6 — RESOLVED 2026-09-08: the watcher runs as a privileged daemon
+
+**Decided by the owner: harness-sphere runs in production as a daemon, with privileges.**
+That is option 3, which this document had rejected on sight. The rejection was wrong, and
+specifically wrong in a way worth naming rather than quietly reversing.
+
+**Why the rejection was overstated.** The privilege argument this design is built on is
+DEC-3, and DEC-3 is about the **Docker socket**. A socket grants *control*: start, stop,
+exec into any container, mount any host path — a direct path to host root. Root inside
+this container grants *reading*, and only across a bind that is mounted `:ro`, in a
+process that holds no socket and opens no listening port. Those are different grants, and
+collapsing them into one word ("privilege") is what produced a reflexive no.
+
+**Three constraints make it defensible, and they are now load-bearing.** They must not be
+relaxed one at a time by a later change that only looks at one of them:
+
+1. the `/data` bind stays **read-only** — the watcher can never write into the tenant tree;
+2. **no Docker socket**, ever (DEC-3, unchanged and unweakened);
+3. **no listening port** — every collector pulls; there is no inbound surface at all.
+
+**The residual risk, stated plainly.** A compromise of harness-sphere can read every
+tenant's transcripts. That is inherent to *any* design where a telemetry component derives
+metrics from transcripts, including option 1 and option 2; it is not a cost this option
+introduces. FR-S6 remains the control that matters: **no transcript content is ever read
+into a signal** — counts, names and sizes only.
+
+**What it costs compared to the alternatives, honestly:** nothing that was on the table.
+Option 1 required weakening `0700` on the host — making every workspace path enumerable
+by any local uid, where the directory names are account UUIDs. Option 2 required changing
+what the proxy sets and provisioning a group. Option 4 was the expensive one: it would
+have **destroyed F2 DEC-10's resilience property**, so session metrics would stop when
+the proxy stopped, instead of degrading to disk-only.
+
+**DEC-10 survives intact.** That is the concrete win here, and it was the thing most at
+risk: the two-surface reconcile (inventory ∪ disk) stays possible, so the watcher still
+degrades rather than going blind exactly when the component it watches breaks.
+
+**FR-C2 is amended, in half.** "No Docker socket" stands, unweakened. "Non-root" does not
+survive, and F2's FR-C9 is corrected accordingly — it currently asserts that both halves
+carry forward unchanged, which is no longer true.
+
+**Sequencing, which is a deliberate choice and not an oversight:** the compose change
+(`user: "0:0"`) lands with the FR-S session collection that needs it, **not before**.
+Today `session_dir` is empty, so root would be a privilege with no consumer — the same
+thing F2's reduction just deleted 1,344 lines for being.
+
+**FR-V3 stays BLOCKED until that lands**, and is now unblockable rather than blocked: the
+barrier is a scheduling decision, not a permission wall.
 
 **OQ-4 — Nothing reaps abandoned workspaces.** There is no reaper and no GC: containers
 are stopped on idle only in `scale-to-zero` mode, and both agents ship as `continuous`, so

--- a/.specs/features/harness-sphere-zombie-crab-scope/design.md
+++ b/.specs/features/harness-sphere-zombie-crab-scope/design.md
@@ -1,0 +1,178 @@
+# harness-sphere-zombie-crab-scope — Design
+
+**Status:** DESIGN. Covers the **unimplemented half** of F2 — dynamic discovery (FR-D) and
+session collection (FR-S). The scope reduction (FR-R) shipped in harness-sphere#23 and is
+not re-designed here.
+**Date:** 2026-09-08.
+**Premises:** F2 `spec.md` (DEC-8…DEC-14), F1 `spec.md` (DEC-1…DEC-4 + the OQ-6
+resolution), F1 `design.md` (DEC-15…DEC-19). Not restated.
+
+## The one decision everything else follows from
+
+`Supervisor::run(self)` **consumes** `self`. It moves `self.sources` into per-task spawns
+and afterwards holds no handle to any of them. The set of sources is fixed from the moment
+`run` is called until the process exits.
+
+FR-D10 — add and remove at runtime, where removal actually terminates the task — is not an
+increment on that. **It changes who owns what.** Every other requirement in FR-D is
+downstream of how this is settled, so it is settled first and explicitly.
+
+```mermaid
+flowchart TB
+    subgraph now["TODAY — ownership ends at spawn"]
+        R1["run(self)"] -->|"moves sources"| T1["task: host"]
+        R1 --> T2["task: self"]
+        R1 --> T3["task: probe"]
+        R1 -.->|"no handle kept"| X1["set is fixed for the process lifetime"]
+    end
+    subgraph next["FR-D — the supervisor keeps the registry"]
+        D["discovery task"] -->|"SupervisorCmd"| CH[["mpsc command channel"]]
+        CH --> R2["run(): select! { fatal | ctrl_c | cmd }"]
+        R2 --> REG[("HashMap&lt;String, SourceHandle&gt;<br/>keyed by FR-D8 owned name")]
+        REG --> T4["task: session:tenant-a/…"]
+        REG --> T5["task: probe:crabshell-alpha-9f…"]
+        R2 -->|"Add"| REG
+        R2 -->|"Remove → graceful stop"| REG
+    end
+```
+
+### DEC-20 — Discovery is a control-plane task, not a `SignalSource`
+
+Discovery holds an `mpsc::Sender<SupervisorCmd>`; `run`'s `select!` gains a third arm
+alongside `fatal_rx` and `ctrl_c`. The supervisor keeps a `HashMap<String, SourceHandle>`
+keyed by the owned name from FR-D8.
+
+Stated positively so nobody builds the alternative: **discovery must not be modelled as a
+`SignalSource` that emits control messages sideways through the signal sink.** That would
+put control traffic on the data path, where it inherits batching latency, the drop-newest
+backpressure policy, and the circuit breaker — three behaviours that are correct for
+telemetry and wrong for "stop watching this container".
+
+Discovery *does* emit signals of its own (FR-D5's watcher-layer failure signal, FR-D4's
+anomaly), through the ordinary sink. It is both, and only the control edge is special.
+
+### DEC-21 — Removal is a graceful stop, not `abort()`
+
+**This is where DEC-12 breaks if it is done the obvious way.** Today's shutdown path is
+`abort()` on every handle, relying on the dropped sink clones to close the channel and
+trigger the drain's final flush. That is correct for *process exit* and wrong for
+*removing one source*:
+
+- the channel stays open (other sources still hold clones), so nothing triggers a flush;
+- `abort()` lands at an arbitrary await point, discarding whatever the task had collected.
+
+A retired instance would then go **silent** — the exact failure DEC-12 exists to prevent,
+arrived at by way of the shutdown code that already looked correct.
+
+Removal is therefore ordered:
+
+```mermaid
+sequenceDiagram
+    participant D as discovery
+    participant S as supervisor
+    participant T as source task
+    participant K as sink → drain
+    D->>S: Remove("session:t/s/a/u")
+    S->>T: stop signal (oneshot / CancellationToken)
+    T->>K: terminal signal — up=0, DEC-12
+    T-->>S: task returns
+    S->>S: join with timeout
+    Note over S,T: abort() ONLY if the join times out
+    S->>S: drop handle from registry
+```
+
+The terminal signal is emitted **by the source**, before it returns — not synthesised by
+the supervisor. The source is the only thing that knows its own attribute set, and a
+synthesised signal would have to reconstruct the full FR-D2 tuple from the registry key,
+which is a parser for a string we control on both ends: avoidable.
+
+`abort()` survives only as the timeout fallback, and a timeout there is itself worth a
+`Watcher`-layer signal.
+
+### DEC-22 — `ProbeResult::NotApplicable` is not reachable for discovered sources
+
+F1's STATE.md calls this "a loaded gun", and FR-D9 walks straight past it. `NotApplicable`
+**permanently drops a source**: `supervise_source` logs and returns from the task.
+
+At boot that is right — "there is no cgroup on this host" is a fact about the host and will
+not change. For a source *discovered at runtime* it is a trap: a container that is still
+starting when discovery probes it is a **transient** condition, and answering
+`NotApplicable` would unwatch that tenant until the process restarts. Worse, it would
+manifest as a tenant that is simply missing from dashboards, with no error anywhere.
+
+**Discovered sources never return `NotApplicable`.** A per-instance probe answers `Ready`
+or `Unavailable`, and `Unavailable` degrades that instance alone under the existing
+backoff. This is enforced at the construction site rather than trusted: the discovery path
+builds its sources through a constructor whose probe cannot produce the variant.
+
+`Fatal` stays reachable only from `Host` and `Watcher`, unchanged.
+
+### DEC-23 — Probe targets carry their own layer, and this is what fills Proxy and Webapp
+
+`EndpointProbeCollector` stamps `Layer::Gateway` on every target
+(`crates/collectors/src/probe.rs:28`). Targets become `(address, layer, attributes)`.
+
+Two of the six layers are empty in `main` today for exactly this reason. This is the change
+that fills them, and it is worth landing early: it is small, it is independently
+verifiable on the existing Grafana dashboard, and it converts the dashboard's
+`harnesssphere_endpoint_up` panel from three anonymous rows into three named layers.
+
+Config grows from `probe_targets = ["host:port"]` to a table array. The scalar form is
+**not** kept as a compatibility shim — this tool has one consumer, whose config file is in
+this repository.
+
+### DEC-24 — Session read offsets live in memory, per collector instance
+
+FR-S4 requires incremental reads with shrink handling. The offset map is **in-process
+state, not a persisted file**.
+
+A restart re-reads each transcript once. That is bounded by the corpus size, happens at
+most once per process lifetime, and produces no wrong numbers — the metrics are absolute
+gauges re-derived from disk (F2 spec, DEC-13), so a full re-read yields exactly the value a
+resumed read would. Persisting offsets would add a writable path to a component whose
+**read-only mount is one of the three constraints holding up the OQ-6 privilege argument**.
+It is not worth it.
+
+Shrink handling stays as FR-S4 states it: a file smaller than its recorded offset is
+re-read from zero, never treated as a negative delta.
+
+## How the two surfaces reconcile (DEC-10, now implementable)
+
+```mermaid
+flowchart LR
+    P["crab-shell-proxy<br/>GET /v1/instances"] -->|"running / stopped /<br/>provisioned / orphaned"| U{"union by<br/>WorkspaceKey"}
+    F["/data tenants tree<br/>(:ro, traversed as root)"] -->|"tenants/*/subscriptions/*<br/>/agents/*/users/*"| U
+    U -->|"both"| A["watch fully"]
+    U -->|"disk only — FR-D3"| B["watch sessions;<br/>report provisioned-not-running"]
+    U -->|"inventory only — FR-D4"| C["surface as anomaly"]
+    P -.->|"unreachable — FR-D5"| E["degrade to disk only<br/>+ Watcher-layer failure signal"]
+```
+
+The FR-D5 edge is the resilience property that survived OQ-6 and is the reason option 4
+was declined. It must have a test that actually stops the proxy, not one that mocks a
+404 — the failure being designed against is the proxy being *down*, which is also when
+its metrics matter most.
+
+## Build order
+
+**Two PRs, deliberately.** FR-D carries the runtime-architecture risk; FR-S depends on it
+only for the instance list.
+
+| | Contents | Why this boundary |
+|---|---|---|
+| **PR 1 — FR-D** | DEC-20…DEC-23: command channel, registry, graceful removal, per-target probe layers, the inventory+disk reconcile | Landing it alone yields **per-tenant `harnesssphere_endpoint_up` on the dashboard that is already verified** — real confirmation the discovery loop works, before transcript reading is layered on top |
+| **PR 2 — FR-S** | DEC-24 + the session collector rewrite (N directories, `workspace-<project>`, `durable/` and cron exclusion, incremental reads) | Carries the `user: "0:0"` compose change, which is exactly the PR that needs it (F1 OQ-6 sequencing) |
+
+That split also keeps the privilege grant honest: root arrives in the same change as the
+first code that reads a path requiring it.
+
+## Open questions carried forward
+
+- **F2 OQ-6** (per-container CPU/memory: cgroup bind vs. shipping without) — unaffected by
+  the F1 OQ-6 resolution. Note that running as root does **not** make `/sys/fs/cgroup`
+  appear; that is still a mount decision.
+- **OQ-7** (discovery interval at real scale) — F1 measured a cardinality of **one**
+  workspace, so nothing here is currently constrained by volume.
+- **OQ-8** (cron inflation) — predicted and *not* observed: zero `agent:cron-` keys in the
+  live tree. Latent, not manifest. FR-S3 is written against a mechanism in the proxy's
+  `history.go`, not against an observation.

--- a/.specs/features/harness-sphere-zombie-crab-scope/spec.md
+++ b/.specs/features/harness-sphere-zombie-crab-scope/spec.md
@@ -1,8 +1,17 @@
 # harness-sphere-zombie-crab-scope — Spec
 
-**Status:** SPEC. Not implemented. **Blocked on `harness-sphere-integration` (F1)** — not
-by ceremony, but because four of its decisions (DEC-9, DEC-11, DEC-12, F1 OQ-2) are written
-against measurements F1 takes and this spec does not have.
+**Status:** **PARTIALLY IMPLEMENTED (2026-09-08).**
+
+- **Scope reduction (FR-R1–R8) — DONE**, harness-sphere#23. Net −1,562 LOC: `crates/ingest`
+  and `collectors/src/prometheus.rs` deleted, `Layer` cut to the six of DEC-8.
+- **Dynamic discovery (FR-D) and session collection (FR-S) — NOT STARTED.** No longer
+  blocked: F1's measurements exist, and **F1 OQ-6 resolved 2026-09-08** (the watcher runs
+  as a privileged daemon), which was the one open question that changed this feature's
+  shape.
+- **F2 OQ-6 (per-container counters), OQ-7 (discovery interval), OQ-8 (cron) remain open.**
+  Note there are two OQ-6s in this feature pair and they are unrelated: F1's is about
+  filesystem permissions and is now closed; this document's is about cgroup counters and
+  is not.
 **Spans:** `harness-sphere` (the substantial change — reduction and dynamic discovery) +
 `zombie-crab-project` (compose, submodule pointer). `crab-shell-proxy` is **not** touched:
 F1 already shipped the endpoint this feature consumes (F1 FR-P8).
@@ -154,10 +163,12 @@ matters.
 >
 > **Consequence for this decision:** the two-surface reconciliation still stands as the
 > right shape, but its *resilience* claim is currently false, and FR-D3, FR-D5 and the
-> whole FR-S group are blocked on F1 OQ-6. If OQ-6 resolves to "the proxy serves session
-> counts over its API", the disk surface disappears entirely and this decision collapses
-> to one surface — in which case the resilience property above is **lost, not deferred**,
-> and that trade must be accepted explicitly rather than forgotten.
+> whole FR-S group were blocked on F1 OQ-6. **UNBLOCKED 2026-09-08: OQ-6 resolved to
+> running the watcher as a privileged daemon, so the disk surface is reachable and this
+> decision stands in full.** The outcome that would have collapsed it to one surface —
+> "the proxy serves session counts over its API" — was considered and not chosen,
+> precisely because it would have made the resilience property above **lost, not
+> deferred**.
 >
 > **One thing the same measurement settled in this decision's favour:** the on-disk path
 > really does carry the full tuple, and there are **two** session directories per
@@ -341,8 +352,23 @@ content path at all, which is the stronger position.)
 ### Deployment (FR-C)
 
 **FR-C9** Compose gains whatever mount FR-D's resource collection settles on
-(F1 OQ-2) — and nothing more. F1 FR-C2's "no Docker socket, non-root" survives this feature
-unchanged.
+(F1 OQ-2) — and nothing more.
+
+**CORRECTED 2026-09-08.** This requirement said F1 FR-C2's "no Docker socket, non-root"
+survives unchanged. **Only half of that is still true.**
+
+- **"No Docker socket" survives, unweakened.** It was always the load-bearing half: a
+  socket grants *control* over every container and a path to host root.
+- **"Non-root" does not survive.** F1 OQ-6 resolved to running the watcher as a privileged
+  daemon, because the tenant tree is `root:root 0700` and every alternative either weakened
+  `0700` on the host or destroyed DEC-10's resilience.
+
+Three constraints replace it and are load-bearing — a later change must not relax them one
+at a time: the `/data` bind stays **`:ro`**, there is **no Docker socket**, and the watcher
+opens **no listening port**.
+
+The compose change (`user: "0:0"`) lands **with FR-S**, not before: while `session_dir` is
+empty, root is a privilege with no consumer.
 
 **FR-C10** New configuration keys follow the existing `.env` convention with documented
 defaults.

--- a/.specs/features/harness-sphere-zombie-crab-scope/spec.md
+++ b/.specs/features/harness-sphere-zombie-crab-scope/spec.md
@@ -154,21 +154,27 @@ with full attribution and only the liveness/resource signals degrade. A watcher 
 telemetry disappears when the thing it watches breaks is worthless at the moment it
 matters.
 
-> **AMENDED 2026-09-07 — that fallback does not currently exist, and this decision cannot
-> be implemented as written.** F1's FR-V3 measured it against the live stack: `data/tenants`
-> is `root:root 0700`, so a non-root watcher cannot traverse it at all. The mount is
-> read-only and present; the process simply cannot enter. Neither uid 10001 (the watcher)
-> nor uid 1000 (what the proxy chowns workspace leaves to) can reach a `sessions/`
-> directory, because traversal is barred at the top before leaf ownership matters.
+> **AMENDED 2026-09-07, then RESOLVED 2026-09-08. The fallback now exists.** Read both
+> halves — the first is why this looked dead, the second is why it is not.
 >
-> **Consequence for this decision:** the two-surface reconciliation still stands as the
-> right shape, but its *resilience* claim is currently false, and FR-D3, FR-D5 and the
-> whole FR-S group were blocked on F1 OQ-6. **UNBLOCKED 2026-09-08: OQ-6 resolved to
-> running the watcher as a privileged daemon, so the disk surface is reachable and this
-> decision stands in full.** The outcome that would have collapsed it to one surface —
-> "the proxy serves session counts over its API" — was considered and not chosen,
-> precisely because it would have made the resilience property above **lost, not
-> deferred**.
+> **2026-09-07 — the wall.** F1's FR-V3 measured it against the live stack: `data/tenants`
+> is `root:root 0700`, so a **non-root** watcher cannot traverse it at all. The mount is
+> read-only and present; the process simply could not enter. Neither uid 10001 (the
+> watcher) nor uid 1000 (what the proxy chowns workspace leaves to) could reach a
+> `sessions/` directory, because traversal is barred at the top before leaf ownership
+> matters.
+>
+> **2026-09-08 — the wall was the *non-root* half, and that half is gone.** The watcher
+> runs as a privileged daemon (F1 OQ-6), so it traverses `0700` regardless of the mode
+> bit. Nothing on the host was changed to achieve this: no `chmod`, no supplementary
+> group, no new endpoint on the proxy.
+>
+> **Consequence for this decision:** the two-surface reconciliation stands as the right
+> shape **and its resilience claim is true again**. FR-D3, FR-D5 and the whole FR-S group
+> were blocked on this and are now unblocked. The outcome that would have collapsed the
+> design to a single surface — "the proxy serves session counts over its API" — was
+> considered and **not** chosen, precisely because it would have made the resilience
+> property above **lost, not deferred**.
 >
 > **One thing the same measurement settled in this decision's favour:** the on-disk path
 > really does carry the full tuple, and there are **two** session directories per

--- a/.specs/features/harness-sphere-zombie-crab-scope/tasks.md
+++ b/.specs/features/harness-sphere-zombie-crab-scope/tasks.md
@@ -1,0 +1,83 @@
+# harness-sphere-zombie-crab-scope — Tasks
+
+**Status:** Group R **DONE** (harness-sphere#23). Groups D and S **not started**.
+**Date:** 2026-09-08.
+**Design:** `design.md` (DEC-20…DEC-24). **Spec:** `spec.md` (FR-R, FR-D, FR-S, FR-C).
+
+Build order: `R ✓ → D → S`. D and S are two PRs on purpose (design.md, "Build order") —
+D carries the runtime-architecture risk, S carries the privilege grant.
+
+## Group R — scope reduction ✅ DONE
+
+| ID | What | Requirement | Status |
+|---|---|---|---|
+| R-01 | Delete `crates/ingest` + the `Receiver` port + supervisor receiver loop | FR-R2 | ✅ hs#23 |
+| R-02 | Delete `collectors/src/prometheus.rs`, its feature, fixture and 4 config fields | FR-R1 | ✅ hs#23 |
+| R-03 | `Layer` → the six of DEC-8, no fallback arm | FR-R3, FR-R4, FR-R5 | ✅ hs#23 |
+| R-04 | `config.example.toml` + `config.zombie-crab.toml` describe only surviving fields | FR-R6 | ✅ hs#23 |
+| R-05 | README / PROJECT.md / STATE.md describe six layers and one stack | FR-R7 | ✅ hs#23 |
+| R-06 | build + test + audit green | FR-R8 | ✅ hs#23 (audit needed an h2 bump; it did not pass on `main` either) |
+
+**Measured, not estimated:** −1,562 LOC. Default dependency graph 140 → 78 unique entries;
+`h2` left the default build entirely and is now reachable only under `--features otlp`,
+as a client rather than a listening server.
+
+## Group D — dynamic discovery (PR 1)
+
+| ID | What | Where | Depends on | Done when |
+|---|---|---|---|---|
+| D-01 | `SourceDescriptor.name` becomes `String` | `domain/src/ports.rs` + every collector | — | Workspace compiles; no `&'static str` name remains |
+| D-02 | `SupervisorCmd` enum + command channel; `run`'s `select!` gains a third arm | `runtime/src/lib.rs` | D-01 | A test adds a source to a *running* supervisor and sees its signals |
+| D-03 | Source registry `HashMap<String, SourceHandle>` | `runtime/src/lib.rs` | D-02 | Duplicate-name adds are rejected, not silently shadowed |
+| D-04 | **Graceful removal** — stop signal → source emits terminal → join with timeout → `abort()` only as fallback | `runtime/src/lib.rs` | D-03 | A test removes a source and observes the **terminal signal** (DEC-12), not merely the absence of further ones |
+| D-05 | `probe()` per instance at discovery; `NotApplicable` unreachable for discovered sources | `runtime`, `domain` | D-03 | A discovered source whose target is briefly down is still collecting after the target returns |
+| D-06 | Probe targets become `(address, layer, attributes)` | `collectors/src/probe.rs`, config | D-01 | Gateway, Proxy and Webapp appear as three distinct layers on the existing dashboard |
+| D-07 | Inventory client for `GET /v1/instances` (bearer from `CRAB_TELEMETRY_TOKEN`) | new collector module | — | 404 (token unset ⇒ route unregistered) is handled as "no inventory", not as an error |
+| D-08 | Disk surface: glob `tenants/*/subscriptions/*/agents/*/users/*` | same module | — | Bounded — a glob, never a transcript walk (FR-D13) |
+| D-09 | Reconcile the two surfaces; emit FR-D3 / FR-D4 / FR-D5 outcomes | same module | D-07, D-08 | All four union states from `design.md` are covered by tests |
+| D-10 | Discovery task drives add/remove through the command channel | composition root | D-04, D-09 | A container created *after* boot is collected within one interval, no restart (FR-D6) |
+
+**D-04 is the risk in this group.** The existing shutdown path (`abort()` + rely on
+dropped sink clones to close the channel) is correct for process exit and silently wrong
+for removing one source — the channel stays open, so no flush is triggered. Getting this
+wrong produces exactly the symptom DEC-12 was written to prevent, and produces it
+invisibly.
+
+**FR-D5 needs a test that stops the proxy**, not one that mocks a 404. The property being
+protected is behaviour when the proxy is *down*, which is when its metrics matter most.
+
+## Group S — session collection (PR 2)
+
+| ID | What | Where | Depends on | Done when |
+|---|---|---|---|---|
+| S-01 | One session source per workspace, attributed by the FR-D2 tuple | `collectors/src/session.rs` | D-10 | `session_dir` as a scalar is gone |
+| S-02 | Cover **both** directories: `workspace/sessions` **and** `workspace-<project>/sessions` | same | S-01 | A fixture with a project workspace counts 12, not 7 (FR-S5) |
+| S-03 | Exclude `sessions/durable/` explicitly, with a test | same | S-01 | A recursive-walk regression fails the test instead of doubling every count |
+| S-04 | Exclude cron sessions via the `.meta.json` `key` prefix `agent:cron-` | same | S-01 | Cron fixtures do not inflate `harness.sessions` |
+| S-05 | Incremental reads with a per-file offset; **a shrunk file re-reads from zero** | same | S-01 | A test truncates a file mid-run and the count does not go negative |
+| S-06 | No transcript content in any signal | same | S-01 | Asserted, not assumed (FR-S6) |
+| S-07 | Compose: `user: "0:0"` on `harness-sphere`, with the three load-bearing constraints named in a comment | `docker-compose.yaml` | S-01 | `/data` still `:ro`; still no Docker socket; still no ports |
+| S-08 | Discharge F1 **FR-V3** against the live stack | — | S-07 | The three predicted distortions are each reported by name |
+
+**S-07 is the privilege grant.** It lands here and not earlier because while `session_dir`
+is empty, root has no consumer. Its comment must name all three constraints
+(`:ro`, no socket, no listening port) — they hold up the OQ-6 argument together, and a
+later change must not relax them one at a time.
+
+## Traceability
+
+| Requirement | Task(s) |
+|---|---|
+| FR-R1…R8 | R-01…R-06 ✅ |
+| FR-D1, D13 | D-07, D-08, D-09 |
+| FR-D2 | D-09, S-01 |
+| FR-D3, D4, D5 | D-09 |
+| FR-D6 | D-10 |
+| FR-D7 | D-04 |
+| FR-D8 | D-01 |
+| FR-D9 | D-05 |
+| FR-D10 | D-02, D-03, D-04 |
+| FR-D11, D12 | D-06 |
+| FR-S1…S6 | S-01…S-06 |
+| FR-C9, C10 | S-07 |
+| FR-C11 | pointer bump per `.claude/rules/submodule-pointers.md` |

--- a/deploy/observability/harnesssphere.otlp.toml
+++ b/deploy/observability/harnesssphere.otlp.toml
@@ -87,7 +87,8 @@ container_cgroup = ""
 container_id = ""
 watch_processes = []
 
-# --- Not built into this image -----------------------------------------------
-# The `ingest` and `prometheus` features are OFF (see Dockerfile): nothing in this
-# stack pushes OTLP to us, and nothing exposes a Prometheus exposition endpoint.
-# Both collectors are slated for deletion in the scope-reduction feature.
+# --- Gone, not merely unconfigured -------------------------------------------
+# The OTLP ingest receiver and the Prometheus scraper were DELETED (harness-sphere
+# #23), not disabled. Nothing in this stack pushes OTLP at us and nothing exposes
+# an exposition endpoint, so both were a receive path with no sender. There is no
+# feature flag to turn them back on.


### PR DESCRIPTION
Four commits: one decision, one pointer bump, two planning artifacts. **No product code
changes in this repository.**

## 1. F1 OQ-6 is resolved — the watcher runs as a privileged daemon

The watcher could not traverse `data/tenants` (`root:root 0700`). That blocked FR-V3 and
the *entire* FR-S group. Four options were on the table; the owner chose **option 3**,
which this spec had recorded as **"rejected on sight"**.

**The original rejection text is kept verbatim, not edited away** — being wrong in public
is the point of writing options down. What is added is *why* it was wrong:

> F1's privilege argument is DEC-3, and **DEC-3 is about the Docker socket**. A socket
> grants *control*: start, stop, exec into any container, mount any host path — a direct
> path to host root. Root inside this container grants *reading*, across a bind mounted
> `:ro`, in a process holding no socket and opening no port. Collapsing those two into one
> word ("privilege") is what produced a reflexive no.

**Three constraints are now load-bearing** and must not be relaxed one at a time by a later
change that only looks at one of them:

1. the `/data` bind stays **`:ro`**;
2. **no Docker socket**, ever (DEC-3, unweakened);
3. **no listening port** — every collector pulls; there is no inbound surface.

**Residual risk, stated rather than argued away:** a compromise of harness-sphere reads
every tenant's transcripts. That is inherent to deriving metrics from transcripts *at all*
— it is equally true of options 1 and 2 — and is not introduced by this choice. FR-S6
(no transcript content ever enters a signal) remains the control that matters.

**What it buys, and it was the thing most at risk: F2 DEC-10 survives intact.** Option 4
(the proxy serves session counts over its API) would have destroyed its resilience
property — session metrics stopping when the proxy stops, instead of degrading to
disk-only. A watcher that goes blind exactly when the thing it watches breaks is the
failure DEC-10 was written to avoid.

**Nothing on the host changed to achieve this:** no `chmod`, no supplementary group, no new
proxy endpoint.

`FR-C2` is amended **in half** — "no Docker socket" stands, "non-root" is withdrawn — and
F2's `FR-C9`, which asserted both halves carry forward unchanged, is corrected.

> **Sequencing, deliberate:** the `user: "0:0"` compose change lands with the FR-S session
> collection that needs it, **not here**. While `session_dir` is empty, root would be a
> privilege with no consumer — the same thing F2's reduction just deleted 1,344 lines for
> being. **FR-V3 is therefore still blocked, but now unblock*able*** — a scheduling
> decision, not a permission wall.

*(Note there are two OQ-6s in this feature pair and they are unrelated: F1's is filesystem
permissions and is now closed; F2's is cgroup counters and is not. The specs now say so.)*

## 2. Submodule pointer → harness-sphere#23 (the scope reduction)

−1,562 LOC: `crates/ingest` and the Prometheus scraper deleted, `Layer` cut to six.

**Nothing here had to change for it — verified rather than assumed.** The reduced binary
was booted against all three TOMLs this stack feeds it:

| Config | Result |
|---|---|
| `config.example.toml` | `sources=2 exporter=otlp` ✅ |
| `config.zombie-crab.toml` (baked into the image) | `sources=3 exporter=stdout` ✅ |
| `deploy/observability/harnesssphere.otlp.toml` (bind-mounted **over** the baked config by the overlay) | `sources=3 exporter=otlp` ✅ |

The third was the one worth checking: it is derived by `sed` from `config.zombie-crab.toml`
and is mounted only under the observability overlay — so a regression there would have
broken the overlay while leaving the base stack healthy, which is a confusing thing to
diagnose later. (`Config` derives `#[serde(default)]` and **not** `deny_unknown_fields`, so
stale keys are ignored rather than fatal; none were present regardless.) The only stale
thing found was a comment still calling both collectors "slated for deletion", fixed here.

The boot lines no longer carry `receivers=` — its absence is the cheapest confirmation the
removal took.

## 3. DEC-10's amendment no longer contradicts itself

Its 2026-09-07 header still declared the disk fallback nonexistent and its resilience claim
"currently false", while the paragraph added below said the opposite. Restructured into two
dated halves: what the wall was, and why the *non-root* half of it is gone.

## 4. F2 gets `design.md` and `tasks.md`

Deliberately absent until now — they were gated on measurements only a live deployment
could produce. Built around the decision that is easy to mistake for an increment:

> `Supervisor::run(self)` **consumes** `self`, moves sources into spawns, and keeps no
> handle. **FR-D10 does not extend that model, it replaces it.**

| | |
|---|---|
| **DEC-20** | Discovery is a control-plane task with its own command channel — **not** a `SignalSource` emitting control messages through the signal sink, which would inherit batching latency, drop-newest backpressure and the circuit breaker: correct for telemetry, wrong for "stop watching this container" |
| **DEC-21** | Removal is a **graceful stop, not `abort()`**. Today's shutdown relies on dropped sink clones closing the channel to trigger a flush — correct for process exit, silently wrong for removing *one* source: the channel stays open, nothing flushes, and the retired instance goes **silent**, which is precisely the failure DEC-12 exists to prevent |
| **DEC-22** | `NotApplicable` is unreachable for discovered sources. It *permanently drops* a source — right at boot, a trap at runtime: a container still starting when discovery probes it is transient, and answering `NotApplicable` unwatches that tenant until restart, appearing as a tenant simply missing from dashboards with no error anywhere |
| **DEC-23** | Probe targets carry their own layer — the change that fills `Proxy` and `Webapp`, which ship **empty** today because `probe.rs:28` stamps `Gateway` on every target |
| **DEC-24** | Session offsets stay **in memory**. Persisting them would add a writable path to a component whose read-only mount is one of the three constraints holding up the OQ-6 argument |

`tasks.md` splits the rest into **two PRs**: Group D (discovery, supervisor mutability,
per-target layers) carries the architecture risk and — landed alone — yields **per-tenant
`endpoint_up` on the Grafana dashboard already verified in F1**, real confirmation the loop
works before transcripts are layered on. Group S carries the session rewrite *and* the
`user: "0:0"` change, so the privilege arrives in the same change as the first code needing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)