### PR TITLE
docs(state): record AD-023 — the withdrawn non-root requirement

### DIFF
--- a/.specs/project/ROADMAP.md
+++ b/.specs/project/ROADMAP.md
@@ -119,12 +119,18 @@ Telegram / MS Teams channels.
 
 ---
 
-## M5 (planned): Observability — harness-sphere
+## M5 (IN PROGRESS): Observability — harness-sphere
 
 **Goal:** the stack stops being unobservable. Today it emits **nothing** — a strict grep
-for `prometheus|opentelemetry|otel` across this repo and both submodules returns zero
-hits, and the entire observability surface is three health endpoints plus unstructured
+for `prometheus|opentelemetry|otel` across this repo and both submodules returned zero
+hits, and the entire observability surface was three health endpoints plus unstructured
 printf logs with no levels and no request ids.
+
+**Status 2026-09-08:** no longer true. The watcher ships, exports OTLP, and an opt-in
+overlay (`docker-compose.observability.yaml`) carries OTel Collector → Prometheus →
+Grafana with a provisioned dashboard whose every query was verified against live data.
+The scope reduction landed (−1,562 LOC). What remains is dynamic per-tenant instance
+discovery — see `.specs/features/harness-sphere-zombie-crab-scope/tasks.md`, groups D and S.
 
 `harness-sphere` (https://github.com/LepistaBioinformatics/harness-sphere) is adopted as a
 third submodule and **repurposed to work exclusively for this stack** (AD-022). Two
@@ -133,7 +139,7 @@ against.
 
 ### Features
 
-**harness-sphere-integration (SPEC READY)** — the tool lands as a submodule at
+**harness-sphere-integration (DONE, 2026-09-08)** — the tool lands as a submodule at
 `crab/harness-sphere` and runs as one compose service on `zombie_net`, exporting OTLP,
 **with no Rust changed**. Host and self come free; the gateway, proxy and webapp are
 covered by TCP probes. Two things make it more than a drop-in: it runs as a *container*
@@ -146,7 +152,7 @@ most privileged service already has one. Its verification section is the point o
 feature: four questions F2's design depends on, answered by measurement. See
 `.specs/features/harness-sphere-integration/`.
 
-**harness-sphere-zombie-crab-scope (SPEC READY, blocked on the above)** — the reduction
+**harness-sphere-zombie-crab-scope (REDUCTION DONE; dynamic half designed, not started)** — the reduction
 and the dynamic half. `Layer` collapses from seven to the stack's six real ones — host,
 self, mycelium-gateway, proxy, exoskeleton, picoclaw — with `Container` demoted from a
 peer layer to a *dimension* (everything here runs in a container; a picoclaw container's

--- a/.specs/project/STATE.md
+++ b/.specs/project/STATE.md
@@ -62,6 +62,43 @@ still operator-gated (needs the backend stack). M4 (crab-shell-proxy) live-conta
 
 ## Recent Decisions (Last 60 days)
 
+### AD-023: harness-sphere runs as a privileged daemon; FR-C2's "non-root" is withdrawn (2026-09-08)
+
+**A stated requirement was withdrawn.** F1 FR-C2 said the watcher "runs as a **non-root**
+user and mounts **no Docker socket**". Only the second half survives.
+
+**Why.** The tenant tree is `root:root 0700`. A non-root watcher cannot traverse it at all,
+which blocked F1 FR-V3 and the whole of F2's session-collection group (F1 OQ-6). Of four
+options, three were bad: weakening `0700` on the host makes every workspace path
+enumerable by any local uid, and the directory names are account UUIDs; a supplementary
+group means changing what the proxy sets; and having the proxy serve session counts over
+its API would have **destroyed F2 DEC-10's resilience** — session metrics stopping when
+the proxy stops, instead of degrading to disk-only.
+
+**The distinction that was originally missed**, and the reason "run as root" was first
+rejected on sight: DEC-3's privilege argument is about the **Docker socket**, which grants
+*control* — start, stop, exec into any container, a path to host root. Root here grants
+*reading*, across a `:ro` bind, in a process holding no socket and opening no port.
+
+**Three constraints are load-bearing and must not be relaxed one at a time:**
+
+1. the `/data` bind stays **`:ro`**;
+2. **no Docker socket** — DEC-3 unweakened, and still the load-bearing one;
+3. **no listening port** — every collector pulls; there is no inbound surface.
+
+**Residual risk:** a compromise reads every tenant's transcripts. Inherent to deriving
+metrics from transcripts at all, not introduced by this option. FR-S6 (no transcript
+content in any signal) is the control that matters.
+
+**Not yet in effect.** `user: "0:0"` lands with the FR-S session collection that needs it
+(F2 tasks.md, S-07). While `session_dir` is empty, root would be a privilege with no
+consumer. FR-V3 stays blocked but is now unblock*able* — a scheduling decision, not a
+permission wall.
+
+Full argument: `.specs/features/harness-sphere-integration/spec.md`, the OQ-6 resolution.
+**Careful:** there are two OQ-6s in this feature pair. F1's is permissions and is closed;
+F2's is cgroup counters and is open.
+
 ### AD-022: harness-sphere is adopted as a third submodule and repurposed exclusively for this stack (2026-09-07)
 
 **Decision:** `https://github.com/LepistaBioinformatics/harness-sphere` becomes a submodule


### PR DESCRIPTION
Follow-up to #64. Docs only, one commit.

#64 recorded the OQ-6 resolution in both **feature** specs and in harness-sphere's own
`STATE.md` — but not in **this repository's project-level `STATE.md`**, the file loaded
into context every session and where AD-022 lives.

That gap matters more than ordinary bookkeeping, because this decision **withdraws a
stated requirement**: F1 FR-C2's "runs as a non-root user". A future session reading
`STATE.md` alone would not have seen it, and would have found the record disagreeing with
itself depending on which file was opened — the same class of miss as DEC-10's
self-contradicting amendment, which #64 fixed.

**AD-023** records:

- the three constraints that are now load-bearing and must not be relaxed one at a time —
  the `/data` bind stays `:ro`, **no Docker socket** (DEC-3, unweakened), and **no
  listening port**;
- the distinction that was originally missed, and that made "run as root" look
  unthinkable: a socket grants *control* (start/stop/exec, a path to host root), while
  root here grants *reading*, across a read-only bind, with no inbound surface at all;
- why the three alternatives were worse — weakening `0700` makes every workspace path
  enumerable by any local uid *and the directory names are account UUIDs*; a
  supplementary group means changing what the proxy sets; and having the proxy serve
  session counts would have **destroyed F2 DEC-10's resilience**;
- the residual risk, plainly: a compromise reads every tenant's transcripts. Inherent to
  deriving metrics from transcripts at all — equally true of the alternatives — and not
  introduced by this choice. **FR-S6 is the control that matters**;
- that the privilege is **not yet in effect**: `user: "0:0"` lands with FR-S (tasks.md
  S-07), because while `session_dir` is empty root has no consumer.

It also warns that the two OQ-6s in this feature pair are unrelated — F1's is permissions
and is closed, F2's is cgroup counters and is open.

**ROADMAP M5** moves `planned → IN PROGRESS`. Its premise was written in the present
tense — *"the stack emits nothing... a strict grep returns zero hits"* — and is no longer
true, so it now reads as history with a dated status line. Both features get accurate
status: integration **done**, scope-reduction **half done**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)