### PR TITLE
feat(observability): picoclaw usage, per member — and the privilege that needs it

### DIFF
--- a/deploy/observability/.env.example
+++ b/deploy/observability/.env.example
@@ -1,0 +1,36 @@
+# =============================================================================
+# Observability overlay — copy the COMPOSE_FILE line into the .env at the REPO
+# ROOT (not into this directory).
+# =============================================================================
+#
+# THE PROBLEM THIS SOLVES, which has bitten this stack more than once:
+#
+#   docker compose up -d          # <-- reverts harness-sphere to the BASE file
+#
+# Compose only applies an overlay when you name it. Run any command without the
+# `-f` chain -- `up -d`, `restart`, `up -d <one-service>` -- and every service the
+# overlay overrides silently falls back to docker-compose.yaml. For harness-sphere
+# that means the exporter goes back to `stdout` and the config bind-mount
+# disappears, so it prints metrics to its own logs instead of sending them.
+#
+# NOTHING REPORTS THIS. Every container stays healthy, harness-sphere keeps
+# collecting, its logs look busy -- and Grafana goes empty. The only visible
+# symptom is a dashboard with no data.
+#
+# Setting COMPOSE_FILE makes the overlay the default, so a bare `docker compose
+# up -d` is correct and there is nothing to remember:
+COMPOSE_FILE=docker-compose.yaml:docker-compose.observability.yaml
+
+# The separator is ':' on Linux/macOS. On Windows it is ';' (COMPOSE_PATH_SEPARATOR
+# overrides it).
+#
+# To go back to the base stack for one command, name the file explicitly:
+#   docker compose -f docker-compose.yaml up -d
+#
+# --- Ports and versions (all optional; defaults shown) -----------------------
+# GRAFANA_PORT=3001          # 3000 is taken by chat-webapp
+# PROMETHEUS_PORT=9090
+# PROMETHEUS_RETENTION=15d
+# OTEL_COLLECTOR_TAG=0.116.1
+# PROMETHEUS_TAG=v3.1.0
+# GRAFANA_TAG=11.4.0

--- a/deploy/observability/grafana/dashboards/zombie-crab-stack.json
+++ b/deploy/observability/grafana/dashboards/zombie-crab-stack.json
@@ -392,17 +392,217 @@
       }
     },
     {
-      "type": "text",
-      "title": "What is NOT here, and why",
+      "type": "row",
+      "title": "Harness (picoclaw) \u2014 per tenant, per member",
       "gridPos": {
-        "h": 7,
+        "h": 1,
         "w": 24,
         "x": 0,
         "y": 21
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Workspaces watched",
+      "description": "harnesssphere.discovery.workspaces \u2014 how many (tenant, subscription, agent, user) workspaces discovery currently has a collector for. Created after boot? It appears within one discovery interval, no restart.",
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 0,
+        "y": 22
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "zombie-crab-prom"
+      },
+      "targets": [
+        {
+          "expr": "harnesssphere_discovery_workspaces",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "colorMode": "value",
+        "graphMode": "area"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Discovery scans",
+      "description": "A scan counter that STOPS ADVANCING is how you tell 'no workspaces' from 'discovery died' \u2014 two states that look identical on the gauge to the left. A flat line here is an incident; a flat zero next door is not.",
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 4,
+        "y": 22
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "zombie-crab-prom"
+      },
+      "targets": [
+        {
+          "expr": "harnesssphere_discovery_scans",
+          "legendFormat": "scans",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "fillOpacity": 8,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "bargauge",
+      "title": "Conversations per member",
+      "description": "harnesssphere.harness.sessions. Counts BOTH session directories (project conversations live in a sibling workspace-<project>/sessions \u2014 missing them dropped 42% on the workspace measured), excludes the durable/ mirror (which would exactly double every count), and excludes cron runs.",
+      "gridPos": {
+        "h": 6,
+        "w": 14,
+        "x": 10,
+        "y": 22
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "zombie-crab-prom"
+      },
+      "targets": [
+        {
+          "expr": "harnesssphere_harness_sessions",
+          "legendFormat": "{{crab_tenant}} / {{crab_agent}} / {{crab_user}}",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "displayMode": "gradient",
+        "orientation": "horizontal"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Messages by role",
+      "description": "Absolute counts re-derived from disk each scrape, which is why these are Gauges: pushing an absolute value through the Counter path would double-count every tick. They survive restarts and legitimately FALL when transcripts are rotated away.",
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 28
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "zombie-crab-prom"
+      },
+      "targets": [
+        {
+          "expr": "sum by (role) (harnesssphere_harness_messages)",
+          "legendFormat": "{{role}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "fillOpacity": 12,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "normal"
+            }
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Tool calls, and cron runs excluded",
+      "description": "tool.calls is the surviving signal from the deleted Tools layer \u2014 it comes from picoclaw's session JSONL, which is a real source. cron.sessions is reported rather than silently dropped: 'we excluded 40% of your files and told you nothing' is its own failure mode.",
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 28
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "zombie-crab-prom"
+      },
+      "targets": [
+        {
+          "expr": "sum(harnesssphere_tool_calls)",
+          "legendFormat": "tool calls",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(harnesssphere_harness_cron_sessions)",
+          "legendFormat": "cron runs (excluded from conversations)",
+          "refId": "B"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "fillOpacity": 8,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "text",
+      "title": "What is NOT here, and why",
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 35
       },
       "options": {
         "mode": "markdown",
-        "content": "**Three layers are still missing from this dashboard, and none is an oversight.**\n\n- **picoclaw (per-tenant agent containers)** \u2014 the layer this project exists to run. `SessionCollector` is compiled and tested but switched **off** (`session_dir = \"\"`): it takes *one* boot-resolved directory while the proxy creates a workspace per `(tenant, subscription, agent, user)` at runtime. Workspace discovery is in progress.\n- **Per-container CPU/memory** \u2014 needs a cgroup source; still open, because the watcher deliberately holds no Docker socket.\n- **Token cost** \u2014 **not obtainable in this stack at all.** picoclaw writes no token counts to disk and the only path that ever existed was scraping an endpoint this stack does not run. It is not coming later.\n\n**Now fixed:** Gateway, Proxy and Webapp are three distinct layers here. They used to share one label \u2014 and in fact carried no layer at all."
+        "content": "**What is still missing, and why none of it is an oversight.**\n\n- **The proxy's live instance inventory.** Discovery reads the **on-disk** tenant tree \u2014 the resilient surface, and enough to attribute every conversation to a member. What it cannot yet say is whether that member's container is *running*. This is exactly the designed degraded mode: session metrics keep flowing when the proxy is down, which is when they matter most.\n- **Per-instance liveness** for agent containers \u2014 needs the inventory above, because harness-sphere never computes the container-name hash itself. Duplicating a preimage the proxy owns would diverge silently the day the prefix changes.\n- **Per-container CPU/memory** \u2014 needs a cgroup source; still open, because the watcher deliberately holds no Docker socket.\n- **Token cost** \u2014 **not obtainable in this stack at all.** picoclaw writes no token counts to disk and the only path that ever existed was scraping an endpoint this stack does not run. It is not coming later."
       }
     }
   ]

--- a/deploy/observability/harnesssphere.otlp.toml
+++ b/deploy/observability/harnesssphere.otlp.toml
@@ -1,16 +1,3 @@
-# DERIVED from crab/harness-sphere/config.zombie-crab.toml by changing exactly two
-# lines: exporter -> "otlp" and otlp_endpoint -> the collector on zombie_net.
-#
-# It is a separate file rather than an env override because harness-sphere has no
-# env override for otlp_endpoint -- only HARNESSSPHERE_EXPORTER exists
-# (harnesssphere/src/config.rs). The overlay bind-mounts this over the config the
-# image bakes in, so the submodule needs no change at all.
-#
-# If the upstream config gains a field, re-derive rather than hand-edit:
-#   sed -e 's|^exporter = .*|exporter = "otlp"|' \
-#       -e 's|^otlp_endpoint = .*|otlp_endpoint = "http://otel-collector:4317"|' \
-#       crab/harness-sphere/config.zombie-crab.toml > deploy/observability/harnesssphere.otlp.toml
-
 # HarnessSphere — configuration for the zombie-crab stack.
 #
 # This file is what the container runs (baked to /etc/harnesssphere/config.toml).
@@ -52,8 +39,9 @@ metric_export_interval_secs = 15
 # collect(), which emits endpoint.up = 0 for a target that is down. Ordering the
 # watcher behind the health of what it watches would suppress the exact signal it
 # exists to produce.
-# Each target names the layer it belongs to. One collector used to stamp one layer on
-# every target, so the proxy and the webapp both filed themselves under "gateway".
+# Each target names the layer it belongs to. Before this, one collector stamped one
+# layer on every target, so the proxy and the webapp both filed themselves under
+# "gateway" and three of the six layers were unanswerable by construction.
 [[probe_targets]]
 address = "mycelium-gateway:8080"
 layer = "gateway"
@@ -66,37 +54,31 @@ layer = "proxy"
 address = "chat-webapp:3000"
 layer = "webapp"
 
-# --- Session-derived AI activity ---------------------------------------------
-# EMPTY ON PURPOSE, and set by the operator at deploy time as a one-off probe.
+# --- Session-derived AI activity (picoclaw workspaces) -----------------------
+# The root of crab-shell-proxy's data directory -- the one containing tenants/.
+# The compose file mounts it read-only at /data.
 #
-# Two reasons it does not ship populated. First, a development checkout has no
-# tenants/ tree, so any committed path would resolve nowhere. Second, this field is
-# single-valued while the stack has one sessions/ directory PER WORKSPACE — pointing
-# it at one member would emit a metric that silently describes one tenant and looks
-# like it describes the stack. Multiplexing it is the next feature's job.
+# harness-sphere rescans this tree on `discovery_interval_secs` and runs ONE session
+# collector per (tenant, subscription, agent, user), each attributed with the full
+# tuple. This replaces the old single-valued `session_dir`, which could only ever
+# name one workspace and so emitted a metric that described one member while reading
+# like it described the stack.
 #
-# When set for that probe, expect three known distortions and read them as such:
-#   1. sessions/durable/ holds crab-shell-proxy's own append-only transcripts. The
-#      collector's read_dir is non-recursive, so it should skip them; if that ever
-#      changes, every message is counted twice.
-#   2. Every scheduled-task RUN writes its own session file, so `harness.sessions`
-#      drifts from "conversations" towards "conversations plus every cron run since
-#      provisioning". The paired .meta.json key (agent:cron-*) is what tells them apart.
-#   3. Every transcript is re-read IN FULL on every tick.
-session_dir = ""
+# Traversal requires privileges: the tree is root:root 0700 (AD-023).
+data_root = "/data"
+discovery_interval_secs = 30
+# Slower than discovery on purpose: finding a workspace is a directory glob, reading
+# one is IO proportional to its conversation history.
+session_interval_secs = 60
 session_source = "picoclaw"
 
-# --- Deliberately unset ------------------------------------------------------
-# Each of these is single-valued and resolved once at boot, which is precisely why
-# the dynamic-discovery feature exists. Setting any of them to one arbitrary
-# instance would produce a metric that describes one tenant and reads like it
-# describes the stack.
+# --- Still single-valued, still empty ----------------------------------------
 container_cgroup = ""
 container_id = ""
 watch_processes = []
 
 # --- Gone, not merely unconfigured -------------------------------------------
-# The OTLP ingest receiver and the Prometheus scraper were DELETED (harness-sphere
-# #23), not disabled. Nothing in this stack pushes OTLP at us and nothing exposes
-# an exposition endpoint, so both were a receive path with no sender. There is no
-# feature flag to turn them back on.
+# The OTLP ingest receiver and the Prometheus scraper were DELETED, not disabled.
+# Nothing in this stack pushes OTLP at us and nothing exposes an exposition
+# endpoint, so both were a receive path with no sender. There is no feature flag
+# to turn them back on.

--- a/docker-compose.observability.yaml
+++ b/docker-compose.observability.yaml
@@ -4,6 +4,18 @@
 #   docker compose -f docker-compose.yaml -f docker-compose.observability.yaml up -d
 #   → Grafana on http://localhost:${GRAFANA_PORT:-3001}  (anonymous, no login)
 #
+# THE `-f` CHAIN IS NOT OPTIONAL ON ANY COMMAND, and forgetting it fails silently.
+# `docker compose up -d`, `restart`, or `up -d harness-sphere` without both files
+# reverts every service this overlay overrides back to the base file: harness-sphere
+# returns to the `stdout` exporter and loses its config mount, so it prints metrics
+# into its own logs instead of sending them. Every container stays healthy and
+# Grafana simply goes empty -- there is no error anywhere.
+#
+# To stop having to remember, put this in the .env at the repo root (see
+# deploy/observability/.env.example) and a bare `docker compose up -d` is correct:
+#
+#   COMPOSE_FILE=docker-compose.yaml:docker-compose.observability.yaml
+#
 # OPT-IN ON PURPOSE. The base file stays one added service exporting to stdout,
 # which proves the pipeline with nothing to stand up. This overlay is for
 # actually looking at the numbers over time.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -377,11 +377,27 @@ services:
     restart: unless-stopped
     networks:
       - zombie_net
-    # No `user:` override -- the image already runs as uid 10001 (see its
-    # Dockerfile). And NO docker.sock: crab-shell-proxy already mounts one and
-    # runs as root, so a second socket-mounting service would double the blast
-    # radius of the stack's worst compromise. Instance identity comes from the
-    # proxy's read-only GET /v1/instances instead.
+    # Runs as root, and this is the one place that decision is visible, so it is
+    # argued here rather than assumed (AD-023, F1 OQ-6).
+    #
+    # WHY: crab-shell-proxy creates the tenant tree as `root:root 0700`. A non-root
+    # watcher cannot TRAVERSE it -- not a leaf-permission problem, the barrier is at
+    # the top -- so session metrics were impossible without this. The alternatives
+    # were worse: chmod 0755 makes every workspace path enumerable by any local uid
+    # and the directory names are account UUIDs; and moving session counts into the
+    # proxy's API would have destroyed the disk fallback, so telemetry would stop
+    # exactly when the proxy stops.
+    #
+    # WHAT KEEPS IT NARROW -- three constraints, load-bearing TOGETHER. A later
+    # change must not relax them one at a time:
+    #   1. the /data bind below stays :ro -- it can read the tree, never write it;
+    #   2. NO docker.sock, ever. That is the grant that actually matters: a socket
+    #      is start/stop/exec on any container and a path to host root. This is
+    #      read-only file access. crab-shell-proxy already holds the socket; a
+    #      second holder would double the blast radius of the worst compromise.
+    #   3. NO published ports -- every collector pulls, so there is no inbound
+    #      surface at all.
+    user: "0:0"
     #
     # No /proc or /sys bind either, and that was MEASURED rather than assumed: a
     # container capped at -m 512m reported the host's 33 GB, because sysinfo


### PR DESCRIPTION
Picks up **harness-sphere#26** (`5057ab5`). This is the change where **the layer this stack
exists to run finally produces metrics**.

## The privilege lands here, deliberately not earlier

`user: "0:0"` was decided in **AD-023** but held back while `session_dir` was empty — root
with no consumer is exactly the kind of thing this project deleted 1,344 lines for being.
It arrives in the same commit as the first code that needs it.

The compose comment argues it in place rather than leaving a bare uid:

**Why:** the tenant tree is `root:root 0700`, and the barrier is **traversal at the top**,
not leaf permissions. The alternatives were worse — `chmod 0755` makes every workspace path
enumerable by any local uid *and the directory names are account UUIDs*; moving session
counts into the proxy's API would have **destroyed the disk fallback**, so telemetry would
stop exactly when the proxy stops.

**What keeps it narrow — three constraints, load-bearing *together*.** A later change must
not relax them one at a time:

1. `/data` stays **`:ro`** — it can read the tree, never write it;
2. **no `docker.sock`, ever.** That is the grant that actually matters: a socket is
   start/stop/exec on any container and a path to host root. This is read-only file access;
3. **no published ports** — every collector pulls, so there is no inbound surface.

## What you will see

| Panel | |
|---|---|
| **Conversations per member** | `harness.sessions` broken out by `tenant / agent / user` |
| **Messages by role** | stacked user/assistant/system/tool |
| **Tool calls, and cron runs excluded** | the surviving signal from the deleted Tools layer, beside what was filtered out |
| **Workspaces watched** + **Discovery scans** | two panels on purpose — see below |

**Why discovery gets two panels rather than one:** "workspaces watched = 0" and "discovery
scans flat" look identical on a single gauge, but one means an empty stack and the other
means **discovery died**. Splitting them makes the difference visible instead of a judgement
call at 3am.

The panel descriptions carry the four session distortions — both session directories, the
`durable/` mirror, cron runs, incremental reads — so someone reading a number here knows
what it excludes.

## Also in here

`deploy/observability/harnesssphere.otlp.toml` is **regenerated** from the new baked config
by the documented `sed`, so it carries `data_root` and the per-layer probe targets. Leaving
it stale would break the overlay while the base stack stayed healthy — the half-broken
failure this repo keeps avoiding.

The explainer panel is rewritten and moved to the bottom. It no longer claims picoclaw is
blocked. What remains missing is the proxy's **live inventory**, and that is the *designed*
degraded mode (FR-D5), not a gap: session metrics keep flowing when the proxy is down.

## ⚠️ For whoever restarts the stack

Two things bit this stack twice today, both worth knowing:

```
docker compose -f docker-compose.yaml -f docker-compose.observability.yaml up -d --build
```

- **Omitting the `-f` chain silently reverts every overridden service to the base file** —
  which sends harness-sphere back to the `stdout` exporter and leaves Grafana empty while
  every container still reports healthy.
- A local checkout also needs `git submodule update --init --recursive`, or it builds the
  **old** binary from a stale pointer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)