### PR TITLE
fix(observability): regenerate the overlay config so data_root survives parsing

### DIFF
--- a/deploy/observability/harnesssphere.otlp.toml
+++ b/deploy/observability/harnesssphere.otlp.toml
@@ -42,17 +42,6 @@ metric_export_interval_secs = 15
 # Each target names the layer it belongs to. Before this, one collector stamped one
 # layer on every target, so the proxy and the webapp both filed themselves under
 # "gateway" and three of the six layers were unanswerable by construction.
-[[probe_targets]]
-address = "mycelium-gateway:8080"
-layer = "gateway"
-
-[[probe_targets]]
-address = "crab-shell-proxy:8080"
-layer = "proxy"
-
-[[probe_targets]]
-address = "chat-webapp:3000"
-layer = "webapp"
 
 # --- Session-derived AI activity (picoclaw workspaces) -----------------------
 # The root of crab-shell-proxy's data directory -- the one containing tenants/.
@@ -82,3 +71,19 @@ watch_processes = []
 # Nothing in this stack pushes OTLP at us and nothing exposes an exposition
 # endpoint, so both were a receive path with no sender. There is no feature flag
 # to turn them back on.
+
+# --- Probe targets MUST STAY LAST -------------------------------------------
+# TOML scopes every bare key to the table header above it, so any scalar written
+# below this point is absorbed into the last [[probe_targets]] entry instead of
+# the root table. Add new scalar settings ABOVE this line.
+[[probe_targets]]
+address = "mycelium-gateway:8080"
+layer = "gateway"
+
+[[probe_targets]]
+address = "crab-shell-proxy:8080"
+layer = "proxy"
+
+[[probe_targets]]
+address = "chat-webapp:3000"
+layer = "webapp"


### PR DESCRIPTION
Picks up **harness-sphere#27** (`a7c7449`).

The deployed stack was booting **`discovery=false`** and finding no workspaces — while host
and probe metrics flowed perfectly. No error, healthy container, just a number that never
appeared.

## Why this file was affected

`deploy/observability/harnesssphere.otlp.toml` is *derived* from the submodule's
`config.zombie-crab.toml` by the documented `sed`, so it **inherited the bug verbatim**: the
`[[probe_targets]]` blocks sat in the middle of the file, and TOML scopes every bare key to
the table header above it. `data_root`, `discovery_interval_secs` and
`session_interval_secs` were absorbed into the **last probe target** and dropped as unknown
fields.

Regenerating from the fixed source puts the table arrays last.

## Verified by parsing, not by reading

```
data_root = '/data'
exporter  = 'otlp'
targets   = [('mycelium-gateway:8080','gateway'), ('crab-shell-proxy:8080','proxy'), ('chat-webapp:3000','webapp')]
OK: no key leaked into probe_targets
```

Upstream now also refuses stray keys inside a probe target (`serde(deny_unknown_fields)`),
so a future regeneration that reintroduced the ordering would **fail loudly at boot** rather
than silently disabling discovery.

## Two operational notes from chasing this

- **Deleting a bind-mounted directory detaches the mount.** Replacing
  `deploy/observability/` (even via `git pull`) leaves Grafana, Prometheus and the collector
  serving the *old* inode — which showed up as a dashboard missing its newest panels.
  `--force-recreate` on those three services fixes it.
- The `-f` chain remains mandatory on every command; `deploy/observability/.env.example`
  carries the `COMPOSE_FILE` line that makes it the default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)