### PR TITLE
fix(observability): give harness-sphere a stable hostname

### DIFF
--- a/deploy/observability/.env.example
+++ b/deploy/observability/.env.example
@@ -27,6 +27,16 @@ COMPOSE_FILE=docker-compose.yaml:docker-compose.observability.yaml
 # To go back to the base stack for one command, name the file explicitly:
 #   docker compose -f docker-compose.yaml up -d
 #
+# --- Identity ----------------------------------------------------------------
+# The name that lands in the `host.name` resource attribute, and therefore in the
+# `host_name` label on every series.
+#
+# It MUST be stable. A container's hostname defaults to its own id, which changes on
+# every recreate -- and because host.name is a label, each redeploy forks a brand new
+# time series, so every panel shows the same metric once per container generation.
+# Set it to the real machine's name; these metrics genuinely describe the host.
+# HARNESS_SPHERE_HOST_NAME=my-machine
+
 # --- Ports and versions (all optional; defaults shown) -----------------------
 # GRAFANA_PORT=3001          # 3000 is taken by chat-webapp
 # PROMETHEUS_PORT=9090

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -377,6 +377,25 @@ services:
     restart: unless-stopped
     networks:
       - zombie_net
+    # STABLE HOSTNAME, and this is not cosmetic.
+    #
+    # A container's hostname defaults to its own ID, and harness-sphere reads
+    # /proc/sys/kernel/hostname to fill the `host.name` resource attribute. That is
+    # wrong twice over:
+    #
+    #   1. These metrics ARE the host's -- system.cpu/memory come from /proc, which
+    #      Docker does not namespace (that is the whole reason this service needs no
+    #      /proc bind). Labelling them with a CONTAINER id says they describe
+    #      something they do not.
+    #   2. The id changes on every `up --build` / recreate, and `host.name` is a
+    #      label, so EVERY REDEPLOY FORKS A NEW TIME SERIES. Five had already
+    #      accumulated in one evening of iteration -- panels show each metric once
+    #      per generation, and the count grows with deploys forever.
+    #
+    # Set HARNESS_SPHERE_HOST_NAME to the real machine's name in .env. The default is
+    # stable rather than accurate, which is the important half: a wrong-but-constant
+    # label groups correctly, a correct-but-changing one never does.
+    hostname: ${HARNESS_SPHERE_HOST_NAME:-zombie-crab-host}
     # Runs as root, and this is the one place that decision is visible, so it is
     # argued here rather than assumed (AD-023, F1 OQ-6).
     #


### PR DESCRIPTION
Panels were showing every host and watcher metric several times over — two `cpu` series,
two `resident`, **six "Endpoints up" tiles for three services**. Not duplicated *panels*:
duplicated **series inside them**.

## Cause

A container's hostname defaults to **its own ID**, and harness-sphere reads
`/proc/sys/kernel/hostname` to fill the `host.name` resource attribute. `host.name` becomes
a Prometheus label, so **every `up --build` forks a brand new time series**.

Five distinct values had already accumulated in a single evening of iteration:

```
5f967102e6cb   643cf820ebdc   67c40bf42079   b7a180467f76   f472b0f3010c
```

That is what the screenshot showed: each panel drawing the same metric once per container
generation.

## This is wrong twice

1. **The metrics are the host's.** `system.cpu.*` and `system.memory.*` come from `/proc`,
   which Docker does not namespace — that is the whole reason this service needs no `/proc`
   bind, and it was measured, not assumed. Labelling them with a *container* id says they
   describe something they do not. The real machine here is `BIOINFO001-SAMUELELIAS`; the
   label said `b7a180467f76`.
2. **The churn is unbounded.** It grows with deploy count, forever. Nothing prunes it.

## Fix

A stable `hostname:` on the service, overridable via `HARNESS_SPHERE_HOST_NAME` so it can
be the real machine's name. **No code change** — the binary already reports whatever
hostname the container is given.

The default is *stable* rather than *accurate*, and that is the important half:

> a wrong-but-constant label groups correctly; a correct-but-changing one never does.

## The existing duplicates need no cleanup

Series recorded under the old ids stop matching queries after the usual 5-minute staleness
window and leave the TSDB at retention. They will fall off the panels on their own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)