### PR TITLE
docs(specs): agent-learning dashboard — spec

### DIFF
--- a/.specs/features/agent-learning-dashboard/spec.md
+++ b/.specs/features/agent-learning-dashboard/spec.md
@@ -1,0 +1,270 @@
+# agent-learning-dashboard — Spec
+
+**Status:** SPEC. Not implemented.
+**Spans:** `harness-sphere` (three new collectors — the substantial part) +
+`zombie-crab-project` (a second Grafana dashboard).
+**Date:** 2026-09-08.
+**Predecessor:** `harness-sphere-zombie-crab-scope`. Its FR-S group and DEC-13 are this
+feature's premises: one source per workspace, full tuple attribution, no transcript
+content. Not restated.
+
+## Problem
+
+**The request was for a dashboard. The blocker is that none of its data exists.**
+
+harness-sphere currently emits, per workspace: `harness.messages` (by role),
+`harness.sessions`, `tool.calls`, `harness.cron.sessions`. There is no metric for memory,
+for skills, or for the knowledge graph. A dashboard about *learning* built on today's
+metrics could only show how much an instance **talked** — which is the opposite of what
+the request asks for.
+
+So this feature is three collectors first and a dashboard second.
+
+**What the existing dashboard is for, and why a second one:** `zombie-crab — stack` answers
+*"is the stack healthy?"* — liveness, host pressure, watcher footprint. It is organised by
+**layer**, which is the right shape for that question and the wrong shape for this one.
+This dashboard answers *"where does each instance sit?"* and is organised by **instance**.
+The first stays as the general view; nothing moves out of it.
+
+## What is actually on disk (measured 2026-09-08, from inside the running container)
+
+Read as root through the existing read-only `/data` mount. **Counts, names and sizes only
+— no file content was read**, which is the same line FR-S6 draws for the metrics.
+
+One real workspace, `42bb2905…/e0006752…/alpha/28690354…`:
+
+```
+./skills                      0 files          <- empty; the per-workspace one is the real store
+./workspace/skills           14 files, 128 KB
+./workspace/memory            4 files, 4.3 KB
+./workspace-chat-ux/skills    0 files
+./workspace-chat-ux/memory    0 files
+./memory-graph-chat-ux        1 file, 13.5 KB  <- memory.jsonl
+./workspace/cron              1 file            <- jobs.json
+./workspace/state             1 file
+./logs                        2 files, 118 KB
+```
+
+### Three distortions, each measured, each a requirement below
+
+**1. A skill directory is not a skill.** `workspace/skills` holds **10 directories** but
+only **9 `SKILL.md` files** — `shared-content/` has none. Counting directories overcounts
+by 10% here, and the error grows with whatever else the agent leaves in that tree.
+
+**2. Three of the four memory files are empty scaffolding.** `workspace/memory` holds
+`CONTEXT_RECOVERY.md`, `FILE_DELIVERY.md`, `MEMORY_ROUTING.md` — **all zero bytes**,
+created at provisioning — and `MEMORY.md` at 317 bytes. A naive file count reports **4**
+when the truth is **1**: a **4× overcount** on a metric whose entire purpose is to say
+whether the agent retained anything. Every freshly provisioned instance would read as
+already having memory.
+
+**3. The graph is records, not lines.** `memory.jsonl` holds **10 entities + 10
+relations = 20 records**, but `wc -l` returns **19** — the last line carries no trailing
+newline. Counting lines undercounts by one, permanently and silently.
+
+### The shape of the knowledge graph
+
+Verified by parsing keys only:
+
+```
+type="entity"   : name, entityType, observations[], createdAt
+type="relation" : from, to, relationType, createdAt
+```
+
+**`observations` is the learning volume.** It is an array per entity — the facts the agent
+actually retained about that entity. Its summed length across entities is the single most
+meaningful number available here, and it is not derivable from any count of files.
+
+### A location rule that does not match the others
+
+`memory-graph-chat-ux` sits at the **user root**, not under `workspace-chat-ux/`, and is
+named per **project**. So the stack now has three different location rules:
+
+| What | Where |
+|---|---|
+| sessions | `workspace/sessions` **and** `workspace-<project>/sessions` |
+| memory | `workspace/memory` **and** `workspace-<project>/memory` |
+| knowledge graph | `memory-graph-<project>` **at the user root** |
+
+The graph must be enumerated by globbing `memory-graph-*` at the user root, the same way
+FR-S5 enumerates session directories. Assuming one path would silently drop every project
+graph — the same failure that dropped 42% of conversations before FR-S5.
+
+## Goals
+
+- Position **instances**, not metrics: one screen that says which agents are building
+  capability, which are consuming without retaining, and which are dormant.
+- Fit **one screen with no scrolling**.
+- Leave `zombie-crab — stack` untouched as the general view.
+
+## Non-goals
+
+- No transcript content, no observation text, no entity names (DEC-27).
+- No new mount, no Docker socket, no listening port. The existing read-only `/data` bind
+  already reaches every file this needs.
+- Not a replacement for the stack dashboard.
+
+## Decisions
+
+### DEC-25 — Capability × consumption is the primary framing (chosen by the owner)
+
+The dominant panel is a scatter: **X = tool calls, Y = skills**, point size = graph
+entities. It separates agents *building* capability from agents merely *consuming* it, and
+names the quadrants — Especialista, Aprendiz, Operária, Dormente.
+
+The alternatives were a learning-quadrant framing (messages × retention) and a
+four-scatter grid. Messages × memory survives as a **secondary** panel, so the relationship
+the request named directly is still on screen; it just is not what the eye lands on first.
+
+### DEC-26 — Skill names are labels; entity names never are (chosen by the owner)
+
+`harnesssphere.harness.skill{skill.name="github"} 1`, one series per skill. Skill names are
+**agent-authored capability names**, bounded at roughly ten per instance, and knowing
+*which* skills an instance has is most of what "positioning" means.
+
+Entity names are the opposite on both counts: they are **extracted from the member's
+conversations** — so they are member content, and FR-S6 already forbids that — and their
+cardinality is **unbounded**, growing one permanent series per concept ever mentioned. The
+graph is therefore reported as counts only.
+
+### DEC-27 — `observations` is counted, never read
+
+The summed length of the `observations` arrays is emitted. The strings inside them are
+never deserialized into a signal. This is the same construction FR-S6 uses for transcript
+`content`: the parser reaches the array, takes its length, and discards it.
+
+### DEC-28 — A separate collector, not an extension of SessionCollector
+
+Skills, memory and the graph change **rarely**; transcripts change constantly. They belong
+on a slower cadence, and DEC-24's per-file offset machinery has no analogue here — these
+files are read whole, and they are small (13.5 KB for the graph, 4 KB for memory).
+
+Sharing a collector would force one interval onto both and put incremental-read state
+beside code that does not want it.
+
+### DEC-29 — The scatter's feasibility is a known risk with a named fallback
+
+**Verified against the running Grafana 11.4.0, and the first answer was wrong.** `xychart`
+is installed — but it plots X and Y from fields of **one frame**, and two Prometheus
+queries return two frames. Worse, the labels needed to join them are **not columns**: the
+datasource returns them as field *metadata*.
+
+```
+fields: [ {name: "Time"}, {name: "harnesssphere_harness_sessions",
+                           labels: {crab_user: "28690354…", crab_agent: "alpha", …}} ]
+```
+
+So the panel requires a transformation chain before it can plot anything:
+
+```
+2 instant queries → labelsToFields (crab_user, crab_agent) → joinByField (crab_user) → xychart
+```
+
+This is standard Grafana, but it is the one part of this feature that can fail at
+implementation rather than at design. **FR-L10 makes it a gate**, and the fallback if the
+chain does not join is a **table with sparkline columns** — same information, one row per
+instance, no scatter. That trade is accepted in advance rather than discovered.
+
+### DEC-30 — The dashboard cannot be validated by looking at it yet
+
+The live deployment has **one** workspace. A scatter with one point cannot show a pattern,
+and quadrants drawn around a single observation say nothing. This is recorded so the first
+review is not *"the scatter is broken"*.
+
+The feature is still correct to build now: the numbers are real, the collectors are what
+take time, and cardinality grows with adoption rather than with effort. But **visual
+validation waits for a second instance**, and FR-L11 discharges what can be checked
+without one.
+
+## Requirements
+
+### Collection (FR-L)
+
+**FR-L1** A `LearningCollector`, one instance per workspace, discovered by the same
+mechanism as `SessionCollector` (F2 FR-D1) and attributed with the same full tuple
+(`crab.tenant`, `crab.subscription`, `crab.agent`, `crab.user`).
+
+**FR-L2** Its interval is configurable and **slower than the session interval** by default
+(DEC-28).
+
+**FR-L3** `harnesssphere.harness.skills` counts **`SKILL.md` files**, not directories
+(distortion 1). Both `workspace/skills` and `workspace-<project>/skills` are covered.
+
+**FR-L4** `harnesssphere.harness.skill{skill.name=…} = 1` is emitted per skill (DEC-26).
+The name is the **directory name**, never file content.
+
+**FR-L5** `harnesssphere.harness.memory.files` counts only **non-empty** files, and
+`harnesssphere.harness.memory.bytes` sums only their bytes (distortion 2). Zero-byte
+provisioning scaffolds are excluded, explicitly and with a test.
+
+**FR-L6** The knowledge graph is enumerated by globbing `memory-graph-*` at the **user
+root** (the third location rule), and every graph found is summed into the instance's
+totals.
+
+**FR-L7** `harnesssphere.graph.entities` and `harnesssphere.graph.relations` count
+**parsed records** discriminated by the `type` field — never lines (distortion 3). A record
+that fails to parse is skipped, not counted as either.
+
+**FR-L8** `harnesssphere.graph.observations` sums the **length** of each entity's
+`observations` array. The strings are never read into a signal (DEC-27).
+
+**FR-L9** No entity name, relation name, observation text or memory file content appears in
+any signal or label.
+
+### Dashboard (FR-D)
+
+**FR-D1** A **second** dashboard, `zombie-crab — learning`, provisioned beside the
+existing one. `zombie-crab — stack` is not modified.
+
+**FR-D2** It fits **one 1080p screen with no vertical scrolling** — a hard constraint, not
+a preference. Panels are cut to fit rather than the layout being allowed to grow.
+
+**FR-D3** The dominant panel is the capability scatter of DEC-25, with named quadrants and
+a legend keyed by `crab.agent` / `crab.user`.
+
+**FR-D4** A secondary panel relates **messages to memory volume**, the relationship the
+request named directly.
+
+**FR-D5** A panel shows **graph growth**: entities, relations, and observations-per-entity
+— the last being the density measure, not a raw count.
+
+**FR-D6** A panel shows **skills per instance**, and — because DEC-26 allows it — *which*
+skills.
+
+**FR-D7** Every panel description states what the number **excludes**, in the manner
+established by the stack dashboard: a reader must be able to tell from the panel that
+memory excludes empty scaffolds and skills counts `SKILL.md` files.
+
+**FR-D8** Ratios are computed in **PromQL**, not baked into the collector. The collector
+emits facts; the dashboard composes them. A ratio in the collector cannot be re-derived
+when the question changes.
+
+### Verification (FR-V)
+
+**FR-L10 (gate)** The `labelsToFields → joinByField → xychart` chain is proven to render
+against live data **before** the layout is finalised. If it cannot join, the dashboard
+ships the table fallback of DEC-29 and this spec is amended rather than the panel being
+left broken.
+
+**FR-L11** What can be verified with one instance is verified: every new metric appears in
+Prometheus with the full tuple, `skills` reports **9** (not 10), `memory.files` reports
+**1** (not 4), and `graph.entities` + `graph.relations` report **10 + 10** (not 19).
+
+These are the four measured numbers from this document, and they are the point: each one
+is a distortion that a plausible implementation gets wrong.
+
+## Open questions
+
+**OQ-10 — What is a *sustainable* instance?** The request asks for "sustainable use", and
+this spec delivers the raw material — capability, retention, consumption — without naming a
+threshold. A threshold needs a second instance to calibrate against, and inventing one now
+would encode a guess as a line on a chart.
+
+**OQ-11 — Should `logs/` size be a signal?** 118 KB of `gateway.log` and
+`gateway_panic.log` sit in every workspace. Growth there is a health signal rather than a
+learning one, and it may belong on the stack dashboard instead. Not decided.
+
+**OQ-12 — Cron jobs as a capability axis.** `workspace/cron/jobs.json` names the agent's
+scheduled tasks. A scheduled task is arguably capability, which would make it a third axis
+— but F2 OQ-8 already flags cron as latent-not-manifest in this deployment, so there is
+nothing to calibrate against yet.

--- a/.specs/project/ROADMAP.md
+++ b/.specs/project/ROADMAP.md
@@ -119,6 +119,29 @@ Telegram / MS Teams channels.
 
 ---
 
+## M6 (SPEC READY): Agent learning — positioning instances, not listing metrics
+
+**Goal:** a second dashboard that answers "where does each instance sit?" rather than "is
+the stack healthy?". The existing `zombie-crab — stack` is organised by layer, which is
+right for health and wrong for this; it stays as the general view.
+
+**The blocker was never the dashboard.** None of the data existed: harness-sphere emits
+messages, sessions and tool calls, so a "learning" dashboard built on today's metrics could
+only show how much an agent *talked*. Three new collectors come first — skills, memory and
+the knowledge graph — all reachable through the read-only `/data` mount that already exists.
+
+Measured on the live workspace before speccing, and each number is a trap a plausible
+implementation falls into: skills are **9 `SKILL.md` files across 10 directories**; memory
+is **1 non-empty file out of 4** (three are zero-byte provisioning scaffolds, a 4×
+overcount); the graph is **20 records where `wc -l` says 19**. The entity `observations`
+array is the real learning volume and is not derivable from any file count.
+
+Framing chosen by the owner: **capability × consumption** — skills against tool calls, with
+graph size as point weight. Skill names may be labels (agent-authored, ~10 per instance);
+entity names never can be (member content, unbounded cardinality).
+
+See `.specs/features/agent-learning-dashboard/`.
+
 ## M5 (IN PROGRESS): Observability — harness-sphere
 
 **Goal:** the stack stops being unobservable. Today it emits **nothing** — a strict grep


### PR DESCRIPTION
Spec only, no code. Opening it before implementing because the request turned out to be a
different shape than it looked.

## The request was a dashboard. The blocker is that none of its data exists

harness-sphere emits `harness.messages`, `harness.sessions`, `tool.calls`. There is **no
metric for memory, skills, or the knowledge graph**. A "learning" dashboard built on today's
metrics could only show how much an agent **talked** — the opposite of what was asked.

**This is three collectors first, a dashboard second.**

The good news, measured through the read-only `/data` mount that already exists: **all of it
is on disk.** No new mount, no Docker socket, no instrumentation of picoclaw.

## Three distortions found by measuring, each now a requirement

Each is a trap a plausible implementation falls into, and none announces itself:

| | Naive answer | Truth | |
|---|---|---|---|
| **Skills** | 10 directories | **9 `SKILL.md`** | `shared-content/` is a directory that is not a skill |
| **Memory** | 4 files | **1 non-empty** | Three are **zero-byte provisioning scaffolds** — a **4× overcount** on the one metric whose purpose is to say whether the agent retained anything |
| **Graph** | `wc -l` → 19 | **20 records** | No trailing newline on the last line. Parse records, never count lines |

A freshly provisioned instance would have read as *already having memory*.

## A third location rule

```
sessions   workspace/sessions        AND  workspace-<project>/sessions
memory     workspace/memory          AND  workspace-<project>/memory
graph      memory-graph-<project>    AT THE USER ROOT          ← different
```

The graph is per **project**, one level **up**. Enumerated by glob like FR-S5 — assuming one
path is exactly how 42% of conversations went missing before.

## `observations` is the number that matters

The graph's entity records carry an `observations` array — the facts the agent actually
retained. **Its summed length is the real learning volume, and no count of files can derive
it.**

## Owner decisions

- **Capability × consumption** as the framing: skills against tool calls, graph size as
  point weight, quadrants named. Messages × memory survives as the secondary panel, so the
  relationship the request named directly is still on screen.
- **Skill names may be labels** (agent-authored, ~10 per instance, and knowing *which*
  skills an instance has is most of what positioning means). **Entity names never** — they
  are extracted from member conversations, so FR-S6 already forbids them, and their
  cardinality is unbounded: one permanent series per concept ever mentioned.

## Two things recorded as risks rather than discovered later

**DEC-29 — the scatter might not be buildable, and I checked rather than assumed.** My first
answer was wrong: `xychart` *is* installed, but it plots X and Y from **one frame**, and the
Prometheus datasource returns the join labels as field **metadata, not columns**:

```
fields: [{name: "Time"}, {name: "harnesssphere_harness_sessions",
                          labels: {crab_user: "28690354…", …}}]
```

So it needs `labelsToFields → joinByField → xychart`. Standard Grafana, but the one part
that can fail at implementation. **FR-L10 gates it**, with the fallback — a table with
sparkline columns — accepted in advance instead of improvised.

**DEC-30 — it cannot be validated by looking at it yet.** The deployment has **one**
workspace. Quadrants drawn around a single point say nothing. Recorded so the first review
is not *"the scatter is broken"*. FR-L11 discharges what a single instance *can* prove: that
skills reports **9 not 10**, memory **1 not 4**, graph **10 + 10 not 19**.

## Not in scope

No transcript content, no observation text, no entity names. No new mount. The existing
`zombie-crab — stack` dashboard is **not modified** — it is organised by layer, which is
right for health and wrong for this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)