### PR TITLE
feat(observability): a second dashboard that positions instances

### DIFF
--- a/.specs/features/agent-learning-dashboard/spec.md
+++ b/.specs/features/agent-learning-dashboard/spec.md
@@ -287,11 +287,28 @@ Three things were wrong, each discovered by measurement:
    instead, with the frame reduced to exactly the numeric fields the panel should infer
    from.
 
-**Outcome:** the table is verified working against live data and carries every measure,
-one row per instance. The scatter's configuration is valid — it moved from `Err` to the
-plugin's own loading state — but **`xychart` does not finish loading under headless
-Chromium**, so its render is confirmed only in a real browser. The table therefore ships
-as a peer panel rather than as a fallback to be swapped in later.
+**Then the real blocker, which was not in the dashboard at all.** The panel sat at
+"Loading plugin panel…" forever, in a real browser as well as headless. Grafana's own boot
+log had been saying why since the beginning:
+
+```
+level=error msg="Could not register plugin" pluginId=xychart
+      error="plugin xychart is already registered"
+```
+
+**`xychart` was the only panel that failed to register**, so it never loaded. Disabling the
+`autoMigrateXYChartPanel` toggle did not help. Booting 11.4.0 and 11.6.0 side by side and
+diffing the logs settled it: 11.4.0 logs the error twice, **11.6.0 zero times**. The
+observability overlay now pins **11.6.0**, with the reason written where the version is set.
+
+On 11.6.0 the panel loaded and threw `TypeError: Cannot read properties of undefined
+(reading 'map')` — it dereferences `options.series` unconditionally, so `mapping: "auto"`
+still requires `series: [{}]` to be present. With that, the scatter renders.
+
+**Outcome: every panel renders, verified by screenshot.** One trade: auto mapping turns a
+third numeric field into a second Y series rather than point size, so graph size is not
+encoded on the scatter — the Knowledge graph panel carries it instead. The table ships as a
+peer panel regardless, so every measure is on screen whatever the scatter does.
 
 ## What the live stack showed (FR-L11, discharged)
 

--- a/.specs/features/agent-learning-dashboard/spec.md
+++ b/.specs/features/agent-learning-dashboard/spec.md
@@ -1,6 +1,6 @@
 # agent-learning-dashboard — Spec
 
-**Status:** SPEC. Not implemented.
+**Status:** IMPLEMENTED 2026-09-08. Collectors in harness-sphere#28; dashboard here.
 **Spans:** `harness-sphere` (three new collectors — the substantial part) +
 `zombie-crab-project` (a second Grafana dashboard).
 **Date:** 2026-09-08.
@@ -255,16 +255,58 @@ is a distortion that a plausible implementation gets wrong.
 
 ## Open questions
 
-**OQ-10 — What is a *sustainable* instance?** The request asks for "sustainable use", and
-this spec delivers the raw material — capability, retention, consumption — without naming a
-threshold. A threshold needs a second instance to calibrate against, and inventing one now
-would encode a guess as a line on a chart.
+**OQ-10 — DROPPED by the owner (2026-09-08).** The "sustainable use" threshold is not
+pursued. The dashboard delivers capability, retention and consumption as raw material; no
+line is drawn on the chart, and none is planned.
 
 **OQ-11 — Should `logs/` size be a signal?** 118 KB of `gateway.log` and
 `gateway_panic.log` sit in every workspace. Growth there is a health signal rather than a
 learning one, and it may belong on the stack dashboard instead. Not decided.
 
 **OQ-12 — Cron jobs as a capability axis.** `workspace/cron/jobs.json` names the agent's
-scheduled tasks. A scheduled task is arguably capability, which would make it a third axis
-— but F2 OQ-8 already flags cron as latent-not-manifest in this deployment, so there is
-nothing to calibrate against yet.
+scheduled tasks. A scheduled task is arguably capability — but F2 OQ-8 already flags cron
+as latent-not-manifest here, so there is nothing to calibrate against yet.
+
+## What FR-L10 actually found (2026-09-08)
+
+The gate was worth having: **the first two configurations rendered `Err`**, and the
+failure was found by screenshotting the running Grafana in headless Chromium and reading
+the image, not by reasoning about it.
+
+Three things were wrong, each discovered by measurement:
+
+1. **`labelsToFields` cannot pivot a `format: table` frame.** That format already expands
+   labels into columns, so the transform has nothing to do. Removing it produced the pivot
+   — and then one frame *per series*, which the table exposed as a frame picker.
+2. **The join works; the naming was the problem.** `joinByField` on `crab_user` aligns
+   members as rows correctly. It names each query's value column **`Value #<refId>`** and
+   suffixes every duplicated label column ` 1`, ` 2`, … **per query** — so an exclude list
+   covering only ` 1` left `crab_agent 2` and `__name__ 1` on screen, which is the
+   duplicate-column defect the owner reported.
+3. **The manual `byName` matchers never bound in Grafana 11.4.** `mapping: "auto"` is used
+   instead, with the frame reduced to exactly the numeric fields the panel should infer
+   from.
+
+**Outcome:** the table is verified working against live data and carries every measure,
+one row per instance. The scatter's configuration is valid — it moved from `Err` to the
+plugin's own loading state — but **`xychart` does not finish loading under headless
+Chromium**, so its render is confirmed only in a real browser. The table therefore ships
+as a peer panel rather than as a fallback to be swapped in later.
+
+## What the live stack showed (FR-L11, discharged)
+
+All four predicted numbers landed, and **a second instance appeared during the work**, so
+the table is no longer a single row:
+
+| member | skills | tool calls | retained facts | memory | conversations |
+|---|---|---|---|---|---|
+| `28690354…` | 9 | 125 | 56 | 317 B | 12 |
+| `ba226b3b…` | 9 | 0 | 0 | 317 B | 1 |
+
+`skills` reports **9**, not the 10 directories present. `memory` reports **317 B** from
+**one** non-empty file, not four. `retained facts` is **56** — the number that did not
+exist before this feature.
+
+The second row is already doing the job the feature was built for: same capability, no
+consumption, nothing retained. That is the *Apprentice* quadrant, readable from the table
+without the scatter.

--- a/.specs/project/ROADMAP.md
+++ b/.specs/project/ROADMAP.md
@@ -119,7 +119,7 @@ Telegram / MS Teams channels.
 
 ---
 
-## M6 (SPEC READY): Agent learning — positioning instances, not listing metrics
+## M6 (IN PROGRESS): Agent learning — positioning instances, not listing metrics
 
 **Goal:** a second dashboard that answers "where does each instance sit?" rather than "is
 the stack healthy?". The existing `zombie-crab — stack` is organised by layer, which is
@@ -139,6 +139,12 @@ array is the real learning volume and is not derivable from any file count.
 Framing chosen by the owner: **capability × consumption** — skills against tool calls, with
 graph size as point weight. Skill names may be labels (agent-authored, ~10 per instance);
 entity names never can be (member content, unbounded cardinality).
+
+**Status 2026-09-08:** collectors shipped (harness-sphere#28) and verified against the
+live workspace — the four predicted numbers all landed: skills **9** (not 10), memory
+files **1** (not 4), graph **10 + 10** (not 19), and 56 retained observations. The second
+dashboard is provisioned. What is still open is OQ-10: what threshold makes an instance
+*unsustainable*, which needs a second instance to calibrate.
 
 See `.specs/features/agent-learning-dashboard/`.
 

--- a/deploy/observability/grafana/dashboards/zombie-crab-learning.json
+++ b/deploy/observability/grafana/dashboards/zombie-crab-learning.json
@@ -41,7 +41,7 @@
         "type": "prometheus",
         "uid": "zombie-crab-prom"
       },
-      "description": "One point per instance. X = tool calls (what it consumes). Y = skills it has built.\n\nQuadrants, clockwise from top right:\n\u2022 Specialist \u2014 uses a lot and has built a lot. The pattern to replicate.\n\u2022 Worker \u2014 uses a lot, has built little. Working without accumulating: a candidate for a prompt review, or for being given skills.\n\u2022 Dormant \u2014 little of either. Provisioned and idle.\n\u2022 Apprentice \u2014 has skills but barely uses tools. Capability sitting unused.\n\n`skills` counts SKILL.md files, not directories: the measured workspace holds 10 directories and 9 skills.",
+      "description": "One point per instance. X = tool calls (what it consumes). Y = skills it has built.\n\nQuadrants, clockwise from top right:\n\u2022 Specialist \u2014 uses a lot and has built a lot. The pattern to replicate.\n\u2022 Worker \u2014 uses a lot, has built little. Working without accumulating: a candidate for a prompt review, or for being given skills.\n\u2022 Dormant \u2014 little of either. Provisioned and idle.\n\u2022 Apprentice \u2014 has skills but barely uses tools. Capability sitting unused.\n\n`skills` counts SKILL.md files, not directories: the measured workspace holds 10 directories and 9 skills.\n\nGraph size is not encoded here \u2014 Grafana's auto mapping turns a third numeric field into a second Y series rather than point size. The Knowledge graph panel carries it instead.",
       "targets": [
         {
           "refId": "A",
@@ -216,7 +216,10 @@
         },
         "tooltip": {
           "mode": "single"
-        }
+        },
+        "series": [
+          {}
+        ]
       },
       "fieldConfig": {
         "defaults": {
@@ -502,7 +505,10 @@
         },
         "tooltip": {
           "mode": "single"
-        }
+        },
+        "series": [
+          {}
+        ]
       },
       "fieldConfig": {
         "defaults": {

--- a/deploy/observability/grafana/dashboards/zombie-crab-learning.json
+++ b/deploy/observability/grafana/dashboards/zombie-crab-learning.json
@@ -41,7 +41,7 @@
         "type": "prometheus",
         "uid": "zombie-crab-prom"
       },
-      "description": "One point per instance. X = tool calls (what it consumes). Y = skills it has built.\n\nQuadrants, clockwise from top right:\n\u2022 Specialist \u2014 uses a lot and has built a lot. The pattern to replicate.\n\u2022 Worker \u2014 uses a lot, has built little. Working without accumulating: a candidate for a prompt review, or for being given skills.\n\u2022 Dormant \u2014 little of either. Provisioned and idle.\n\u2022 Apprentice \u2014 has skills but barely uses tools. Capability sitting unused.\n\n`skills` counts SKILL.md files, not directories: the measured workspace holds 10 directories and 9 skills.\n\nGraph size is not encoded here \u2014 Grafana's auto mapping turns a third numeric field into a second Y series rather than point size. The Knowledge graph panel carries it instead.",
+      "description": "One point per instance. X = tool calls (what it consumes). Y = skills it has built.\n\nQuadrants, clockwise from top right:\n\u2022 Specialist \u2014 uses a lot and has built a lot. The pattern to replicate.\n\u2022 Worker \u2014 uses a lot, has built little. Working without accumulating: a candidate for a prompt review, or for being given skills.\n\u2022 Dormant \u2014 little of either. Provisioned and idle.\n\u2022 Apprentice \u2014 has skills but barely uses tools. Capability sitting unused.\n\n`skills` counts SKILL.md files, not directories: the measured workspace holds 10 directories and 9 skills.\n\nGraph size is not encoded here \u2014 Grafana's auto mapping turns a third numeric field into a second Y series rather than point size. The Knowledge graph panel carries it instead.\n\nAxes are SYMLOG, not log: an instance with zero tool calls or zero retained facts is exactly what this chart needs to show, and log(0) is undefined \u2014 a plain log axis would drop those points silently. Symlog is linear below 1 and logarithmic above it.\n\nHover a point to see which member it is; the Instances table below is the printed key, listing the same members and numbers.",
       "targets": [
         {
           "refId": "A",
@@ -49,7 +49,7 @@
             "type": "prometheus",
             "uid": "zombie-crab-prom"
           },
-          "expr": "harnesssphere_tool_calls",
+          "expr": "label_replace(harnesssphere_tool_calls, \"point\", \"$1\", \"crab_user\", \"(.{8}).*\")",
           "instant": true,
           "range": false,
           "format": "table"
@@ -60,7 +60,7 @@
             "type": "prometheus",
             "uid": "zombie-crab-prom"
           },
-          "expr": "harnesssphere_harness_skills",
+          "expr": "label_replace(harnesssphere_harness_skills, \"point\", \"$1\", \"crab_user\", \"(.{8}).*\")",
           "instant": true,
           "range": false,
           "format": "table"
@@ -198,11 +198,31 @@
               "telemetry_sdk_version 5": true,
               "telemetry_sdk_version 6": true,
               "telemetry_sdk_version 7": true,
-              "crab_user": true
+              "crab_user": true,
+              "point 1": true,
+              "point 2": true,
+              "point 3": true,
+              "point 4": true,
+              "point 5": true,
+              "point 6": true,
+              "point 7": true
             },
             "renameByName": {
               "Value #A": "tool calls",
-              "Value #B": "skills"
+              "Value #B": "skills",
+              "point": "member"
+            }
+          }
+        },
+        {
+          "id": "partitionByValues",
+          "options": {
+            "fields": [
+              "member"
+            ],
+            "keepFields": true,
+            "naming": {
+              "asLabels": true
             }
           }
         }
@@ -212,7 +232,8 @@
         "legend": {
           "displayMode": "list",
           "placement": "bottom",
-          "showLegend": true
+          "showLegend": true,
+          "calcs": []
         },
         "tooltip": {
           "mode": "single"
@@ -227,11 +248,40 @@
             "show": "points",
             "pointSize": {
               "fixed": 11
+            },
+            "scaleDistribution": {
+              "type": "symlog",
+              "log": 10,
+              "linearThreshold": 1
             }
-          },
-          "min": 0
+          }
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "tool calls"
+            },
+            "properties": [
+              {
+                "id": "custom.axisLabel",
+                "value": "tool calls  (symlog)"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "skills"
+            },
+            "properties": [
+              {
+                "id": "custom.axisLabel",
+                "value": "skills  (symlog)"
+              }
+            ]
+          }
+        ]
       }
     },
     {
@@ -331,7 +381,7 @@
         "type": "prometheus",
         "uid": "zombie-crab-prom"
       },
-      "description": "X = messages exchanged. Y = memory bytes retained. A point low and to the right talks a lot and keeps little.\n\n`memory` sums NON-EMPTY files only. Three of the four memory files in a freshly provisioned workspace are zero bytes \u2014 counting them would make every new instance read as already having memory, a 4x overcount.",
+      "description": "X = messages exchanged. Y = memory bytes retained. A point low and to the right talks a lot and keeps little.\n\n`memory` sums NON-EMPTY files only. Three of the four memory files in a freshly provisioned workspace are zero bytes \u2014 counting them would make every new instance read as already having memory, a 4x overcount.\n\nAxes are SYMLOG, not log: an instance with zero tool calls or zero retained facts is exactly what this chart needs to show, and log(0) is undefined \u2014 a plain log axis would drop those points silently. Symlog is linear below 1 and logarithmic above it.\n\nHover a point to see which member it is; the Instances table below is the printed key, listing the same members and numbers.",
       "targets": [
         {
           "refId": "A",
@@ -339,7 +389,7 @@
             "type": "prometheus",
             "uid": "zombie-crab-prom"
           },
-          "expr": "sum by (crab_tenant, crab_agent, crab_user) (harnesssphere_harness_messages)",
+          "expr": "label_replace(sum by (crab_tenant, crab_agent, crab_user) (harnesssphere_harness_messages), \"point\", \"$1\", \"crab_user\", \"(.{8}).*\")",
           "instant": true,
           "range": false,
           "format": "table"
@@ -350,7 +400,7 @@
             "type": "prometheus",
             "uid": "zombie-crab-prom"
           },
-          "expr": "harnesssphere_harness_memory_bytes",
+          "expr": "label_replace(harnesssphere_harness_memory_bytes, \"point\", \"$1\", \"crab_user\", \"(.{8}).*\")",
           "instant": true,
           "range": false,
           "format": "table"
@@ -488,12 +538,32 @@
               "telemetry_sdk_version 5": true,
               "telemetry_sdk_version 6": true,
               "telemetry_sdk_version 7": true,
-              "crab_user": true
+              "crab_user": true,
+              "point 1": true,
+              "point 2": true,
+              "point 3": true,
+              "point 4": true,
+              "point 5": true,
+              "point 6": true,
+              "point 7": true
             },
             "renameByName": {
               "Value #A": "messages",
               "Value #B": "memory bytes",
-              "crab_user": "member"
+              "crab_user": "member",
+              "point": "member"
+            }
+          }
+        },
+        {
+          "id": "partitionByValues",
+          "options": {
+            "fields": [
+              "member"
+            ],
+            "keepFields": true,
+            "naming": {
+              "asLabels": true
             }
           }
         }
@@ -501,7 +571,10 @@
       "options": {
         "mapping": "auto",
         "legend": {
-          "showLegend": false
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": []
         },
         "tooltip": {
           "mode": "single"
@@ -516,11 +589,27 @@
             "show": "points",
             "pointSize": {
               "fixed": 10
+            },
+            "scaleDistribution": {
+              "type": "symlog",
+              "log": 10,
+              "linearThreshold": 1
             }
-          },
-          "min": 0
+          }
         },
         "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "messages"
+            },
+            "properties": [
+              {
+                "id": "custom.axisLabel",
+                "value": "messages  (symlog)"
+              }
+            ]
+          },
           {
             "matcher": {
               "id": "byName",
@@ -528,8 +617,8 @@
             },
             "properties": [
               {
-                "id": "unit",
-                "value": "bytes"
+                "id": "custom.axisLabel",
+                "value": "memory bytes  (symlog)"
               }
             ]
           }

--- a/deploy/observability/grafana/dashboards/zombie-crab-learning.json
+++ b/deploy/observability/grafana/dashboards/zombie-crab-learning.json
@@ -1,0 +1,595 @@
+{
+  "uid": "zombie-crab-learning",
+  "title": "zombie-crab \u2014 aprendizado",
+  "description": "Posiciona INST\u00c2NCIAS, n\u00e3o m\u00e9tricas. O dashboard 'zombie-crab \u2014 stack' responde 'a stack est\u00e1 saud\u00e1vel?' e \u00e9 organizado por camada; este responde 'onde cada inst\u00e2ncia est\u00e1?' e \u00e9 organizado por membro. Cabe em uma tela.",
+  "tags": [
+    "zombie-crab",
+    "harness-sphere",
+    "aprendizado"
+  ],
+  "timezone": "browser",
+  "editable": true,
+  "schemaVersion": 39,
+  "refresh": "1m",
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "panels": [
+    {
+      "type": "row",
+      "title": "Posicionamento \u2014 capacidade constru\u00edda \u00d7 consumo",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      }
+    },
+    {
+      "type": "xychart",
+      "title": "Capacidade \u00d7 consumo",
+      "gridPos": {
+        "h": 13,
+        "w": 14,
+        "x": 0,
+        "y": 1
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "zombie-crab-prom"
+      },
+      "description": "Cada ponto \u00e9 uma inst\u00e2ncia. X = chamadas de ferramenta (consumo). Y = skills com SKILL.md (capacidade constru\u00edda). O TAMANHO do ponto \u00e9 o n\u00famero de entidades no grafo de conhecimento.\n\nQUADRANTES, no sentido hor\u00e1rio a partir do alto-direito:\n\u2022 Especialista \u2014 usa muito e construiu muito. O padr\u00e3o a replicar.\n\u2022 Oper\u00e1ria \u2014 usa muito, construiu pouco. Trabalha, n\u00e3o acumula: candidata a revis\u00e3o de prompt ou a ganhar skills.\n\u2022 Dormente \u2014 pouco de ambos. Provisionada e ociosa.\n\u2022 Aprendiz \u2014 construiu skills mas usa pouco. Capacidade parada.\n\nskills conta arquivos SKILL.md, n\u00e3o diret\u00f3rios: no workspace medido h\u00e1 10 diret\u00f3rios e 9 skills.\n\nATEN\u00c7\u00c3O: com uma \u00fanica inst\u00e2ncia isto mostra UM ponto. Quadrantes desenhados em volta de uma observa\u00e7\u00e3o n\u00e3o dizem nada \u2014 o valor aparece a partir da segunda inst\u00e2ncia.",
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "zombie-crab-prom"
+          },
+          "expr": "harnesssphere_tool_calls",
+          "instant": true,
+          "range": false,
+          "format": "table",
+          "legendFormat": "__auto"
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "zombie-crab-prom"
+          },
+          "expr": "harnesssphere_harness_skills",
+          "instant": true,
+          "range": false,
+          "format": "table",
+          "legendFormat": "__auto"
+        },
+        {
+          "refId": "C",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "zombie-crab-prom"
+          },
+          "expr": "harnesssphere_graph_entities",
+          "instant": true,
+          "range": false,
+          "format": "table",
+          "legendFormat": "__auto"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "labelsToFields",
+          "options": {
+            "mode": "columns",
+            "keepLabels": [
+              "crab_user",
+              "crab_agent",
+              "crab_tenant"
+            ]
+          }
+        },
+        {
+          "id": "joinByField",
+          "options": {
+            "byField": "crab_user",
+            "mode": "outer"
+          }
+        }
+      ],
+      "options": {
+        "mapping": "manual",
+        "series": [
+          {
+            "x": {
+              "matcher": {
+                "id": "byName",
+                "options": "harnesssphere_tool_calls"
+              }
+            },
+            "y": {
+              "matcher": {
+                "id": "byName",
+                "options": "harnesssphere_harness_skills"
+              }
+            },
+            "size": {
+              "matcher": {
+                "id": "byName",
+                "options": "harnesssphere_graph_entities"
+              },
+              "min": 6,
+              "max": 40
+            },
+            "color": {
+              "matcher": {
+                "id": "byName",
+                "options": "crab_agent"
+              }
+            },
+            "name": "inst\u00e2ncia"
+          }
+        ],
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "show": "points",
+            "pointSize": {
+              "fixed": 10
+            },
+            "axisLabel": ""
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "harnesssphere_tool_calls"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "chamadas de ferramenta"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "harnesssphere_harness_skills"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "skills"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "harnesssphere_graph_entities"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "entidades no grafo"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "type": "bargauge",
+      "title": "Grafo de conhecimento",
+      "gridPos": {
+        "h": 7,
+        "w": 10,
+        "x": 14,
+        "y": 1
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "zombie-crab-prom"
+      },
+      "description": "O que o agente reteve, n\u00e3o o que ele falou.\n\nobserva\u00e7\u00f5es \u00e9 a soma do TAMANHO dos arrays `observations` de cada entidade \u2014 os fatos efetivamente guardados. \u00c9 o \u00fanico n\u00famero aqui que nenhuma contagem de arquivos deriva.\n\nRegistros s\u00e3o parseados, nunca contados por linha: o arquivo real tem 20 registros e `wc -l` diz 19, porque a \u00faltima linha n\u00e3o tem newline.\n\nO CONTE\u00daDO das observa\u00e7\u00f5es nunca sai do disco \u2014 s\u00f3 o comprimento do array.",
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "zombie-crab-prom"
+          },
+          "expr": "sum(harnesssphere_graph_observations)",
+          "legendFormat": "observa\u00e7\u00f5es retidas",
+          "instant": true
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "zombie-crab-prom"
+          },
+          "expr": "sum(harnesssphere_graph_entities)",
+          "legendFormat": "entidades",
+          "instant": true
+        },
+        {
+          "refId": "C",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "zombie-crab-prom"
+          },
+          "expr": "sum(harnesssphere_graph_relations)",
+          "legendFormat": "rela\u00e7\u00f5es",
+          "instant": true
+        },
+        {
+          "refId": "D",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "zombie-crab-prom"
+          },
+          "expr": "sum(harnesssphere_graph_observations) / clamp_min(sum(harnesssphere_graph_entities),1)",
+          "legendFormat": "observa\u00e7\u00f5es por entidade",
+          "instant": true
+        }
+      ],
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "displayMode": "gradient",
+        "orientation": "horizontal",
+        "showUnfilled": true
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "xychart",
+      "title": "Conversa \u00d7 reten\u00e7\u00e3o",
+      "gridPos": {
+        "h": 6,
+        "w": 10,
+        "x": 14,
+        "y": 8
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "zombie-crab-prom"
+      },
+      "description": "A rela\u00e7\u00e3o pedida diretamente: X = mensagens trocadas, Y = bytes de mem\u00f3ria retidos.\n\nUm ponto no canto inferior-direito fala muito e guarda pouco.\n\nmemory.bytes soma apenas arquivos N\u00c3O-VAZIOS. Tr\u00eas dos quatro arquivos de mem\u00f3ria de um workspace rec\u00e9m-provisionado t\u00eam zero byte (CONTEXT_RECOVERY, FILE_DELIVERY, MEMORY_ROUTING) \u2014 cont\u00e1-los faria toda inst\u00e2ncia nova parecer j\u00e1 ter mem\u00f3ria.",
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "zombie-crab-prom"
+          },
+          "expr": "sum by (crab_user, crab_agent, crab_tenant) (harnesssphere_harness_messages)",
+          "instant": true,
+          "range": false,
+          "format": "table",
+          "legendFormat": "__auto"
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "zombie-crab-prom"
+          },
+          "expr": "harnesssphere_harness_memory_bytes",
+          "instant": true,
+          "range": false,
+          "format": "table",
+          "legendFormat": "__auto"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "labelsToFields",
+          "options": {
+            "mode": "columns",
+            "keepLabels": [
+              "crab_user",
+              "crab_agent",
+              "crab_tenant"
+            ]
+          }
+        },
+        {
+          "id": "joinByField",
+          "options": {
+            "byField": "crab_user",
+            "mode": "outer"
+          }
+        }
+      ],
+      "options": {
+        "mapping": "manual",
+        "series": [
+          {
+            "x": {
+              "matcher": {
+                "id": "byName",
+                "options": "Value #A"
+              }
+            },
+            "y": {
+              "matcher": {
+                "id": "byName",
+                "options": "harnesssphere_harness_memory_bytes"
+              }
+            },
+            "name": "inst\u00e2ncia"
+          }
+        ],
+        "legend": {
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "show": "points",
+            "pointSize": {
+              "fixed": 9
+            }
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "table",
+      "title": "Inst\u00e2ncias \u2014 todas as medidas, uma linha cada",
+      "gridPos": {
+        "h": 6,
+        "w": 14,
+        "x": 0,
+        "y": 14
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "zombie-crab-prom"
+      },
+      "description": "A mesma informa\u00e7\u00e3o do scatter em forma leg\u00edvel, e o fallback se a jun\u00e7\u00e3o de campos do scatter n\u00e3o renderizar (FR-L10).\n\nOrdene por qualquer coluna para ranquear. 'obs/msg' \u00e9 densidade de aprendizado: quanto do que foi conversado virou fato retido.",
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "zombie-crab-prom"
+          },
+          "expr": "harnesssphere_harness_skills",
+          "instant": true,
+          "range": false,
+          "format": "table",
+          "legendFormat": "__auto"
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "zombie-crab-prom"
+          },
+          "expr": "harnesssphere_tool_calls",
+          "instant": true,
+          "range": false,
+          "format": "table",
+          "legendFormat": "__auto"
+        },
+        {
+          "refId": "C",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "zombie-crab-prom"
+          },
+          "expr": "harnesssphere_graph_observations",
+          "instant": true,
+          "range": false,
+          "format": "table",
+          "legendFormat": "__auto"
+        },
+        {
+          "refId": "D",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "zombie-crab-prom"
+          },
+          "expr": "harnesssphere_harness_memory_bytes",
+          "instant": true,
+          "range": false,
+          "format": "table",
+          "legendFormat": "__auto"
+        },
+        {
+          "refId": "E",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "zombie-crab-prom"
+          },
+          "expr": "sum by (crab_user, crab_agent, crab_tenant) (harnesssphere_harness_sessions)",
+          "instant": true,
+          "range": false,
+          "format": "table",
+          "legendFormat": "__auto"
+        },
+        {
+          "refId": "F",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "zombie-crab-prom"
+          },
+          "expr": "sum by (crab_user, crab_agent, crab_tenant) (harnesssphere_graph_observations) / clamp_min(sum by (crab_user, crab_agent, crab_tenant) (harnesssphere_harness_messages),1)",
+          "instant": true,
+          "range": false,
+          "format": "table",
+          "legendFormat": "__auto"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "labelsToFields",
+          "options": {
+            "mode": "columns",
+            "keepLabels": [
+              "crab_user",
+              "crab_agent",
+              "crab_tenant"
+            ]
+          }
+        },
+        {
+          "id": "joinByField",
+          "options": {
+            "byField": "crab_user",
+            "mode": "outer"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "crab_tenant": true
+            },
+            "renameByName": {
+              "crab_user": "membro",
+              "crab_agent": "agente",
+              "harnesssphere_harness_skills": "skills",
+              "harnesssphere_tool_calls": "ferramentas",
+              "harnesssphere_graph_observations": "observa\u00e7\u00f5es",
+              "harnesssphere_harness_memory_bytes": "mem\u00f3ria",
+              "Value #E": "conversas",
+              "Value #F": "obs/msg"
+            }
+          }
+        }
+      ],
+      "options": {
+        "showHeader": true,
+        "cellHeight": "sm",
+        "footer": {
+          "show": false
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "filterable": true
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "mem\u00f3ria"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "bytes"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "obs/msg"
+            },
+            "properties": [
+              {
+                "id": "decimals",
+                "value": 2
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "type": "bargauge",
+      "title": "Skills por inst\u00e2ncia",
+      "gridPos": {
+        "h": 6,
+        "w": 10,
+        "x": 14,
+        "y": 14
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "zombie-crab-prom"
+      },
+      "description": "QUAIS skills cada inst\u00e2ncia construiu, n\u00e3o apenas quantas.\n\nNomes de skill podem ser labels porque s\u00e3o capacidades autorais do agente, limitadas a ~10 por inst\u00e2ncia. Nomes de ENTIDADE do grafo nunca podem: s\u00e3o extra\u00eddos das conversas do membro e a cardinalidade \u00e9 ilimitada.",
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "zombie-crab-prom"
+          },
+          "expr": "sum by (skill_name) (harnesssphere_harness_skill)",
+          "legendFormat": "{{skill_name}}",
+          "instant": true
+        }
+      ],
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "displayMode": "basic",
+        "orientation": "horizontal",
+        "showUnfilled": false
+      },
+      "fieldConfig": {
+        "defaults": {
+          "max": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    }
+  ]
+}

--- a/deploy/observability/grafana/dashboards/zombie-crab-learning.json
+++ b/deploy/observability/grafana/dashboards/zombie-crab-learning.json
@@ -1,11 +1,11 @@
 {
   "uid": "zombie-crab-learning",
-  "title": "zombie-crab \u2014 aprendizado",
-  "description": "Posiciona INST\u00c2NCIAS, n\u00e3o m\u00e9tricas. O dashboard 'zombie-crab \u2014 stack' responde 'a stack est\u00e1 saud\u00e1vel?' e \u00e9 organizado por camada; este responde 'onde cada inst\u00e2ncia est\u00e1?' e \u00e9 organizado por membro. Cabe em uma tela.",
+  "title": "zombie-crab \u2014 learning",
+  "description": "Positions INSTANCES, not metrics. 'zombie-crab \u2014 stack' answers 'is the stack healthy?' and is organised by layer; this one answers 'where does each instance sit?' and is organised by member. Fits one screen.",
   "tags": [
     "zombie-crab",
     "harness-sphere",
-    "aprendizado"
+    "learning"
   ],
   "timezone": "browser",
   "editable": true,
@@ -17,8 +17,9 @@
   },
   "panels": [
     {
+      "id": 1,
       "type": "row",
-      "title": "Posicionamento \u2014 capacidade constru\u00edda \u00d7 consumo",
+      "title": "Instance positioning \u2014 capability built vs consumption",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -27,8 +28,9 @@
       }
     },
     {
+      "id": 2,
       "type": "xychart",
-      "title": "Capacidade \u00d7 consumo",
+      "title": "Capability vs consumption",
       "gridPos": {
         "h": 13,
         "w": 14,
@@ -39,7 +41,7 @@
         "type": "prometheus",
         "uid": "zombie-crab-prom"
       },
-      "description": "Cada ponto \u00e9 uma inst\u00e2ncia. X = chamadas de ferramenta (consumo). Y = skills com SKILL.md (capacidade constru\u00edda). O TAMANHO do ponto \u00e9 o n\u00famero de entidades no grafo de conhecimento.\n\nQUADRANTES, no sentido hor\u00e1rio a partir do alto-direito:\n\u2022 Especialista \u2014 usa muito e construiu muito. O padr\u00e3o a replicar.\n\u2022 Oper\u00e1ria \u2014 usa muito, construiu pouco. Trabalha, n\u00e3o acumula: candidata a revis\u00e3o de prompt ou a ganhar skills.\n\u2022 Dormente \u2014 pouco de ambos. Provisionada e ociosa.\n\u2022 Aprendiz \u2014 construiu skills mas usa pouco. Capacidade parada.\n\nskills conta arquivos SKILL.md, n\u00e3o diret\u00f3rios: no workspace medido h\u00e1 10 diret\u00f3rios e 9 skills.\n\nATEN\u00c7\u00c3O: com uma \u00fanica inst\u00e2ncia isto mostra UM ponto. Quadrantes desenhados em volta de uma observa\u00e7\u00e3o n\u00e3o dizem nada \u2014 o valor aparece a partir da segunda inst\u00e2ncia.",
+      "description": "One point per instance. X = tool calls (what it consumes). Y = skills it has built.\n\nQuadrants, clockwise from top right:\n\u2022 Specialist \u2014 uses a lot and has built a lot. The pattern to replicate.\n\u2022 Worker \u2014 uses a lot, has built little. Working without accumulating: a candidate for a prompt review, or for being given skills.\n\u2022 Dormant \u2014 little of either. Provisioned and idle.\n\u2022 Apprentice \u2014 has skills but barely uses tools. Capability sitting unused.\n\n`skills` counts SKILL.md files, not directories: the measured workspace holds 10 directories and 9 skills.",
       "targets": [
         {
           "refId": "A",
@@ -50,8 +52,7 @@
           "expr": "harnesssphere_tool_calls",
           "instant": true,
           "range": false,
-          "format": "table",
-          "legendFormat": "__auto"
+          "format": "table"
         },
         {
           "refId": "B",
@@ -62,75 +63,152 @@
           "expr": "harnesssphere_harness_skills",
           "instant": true,
           "range": false,
-          "format": "table",
-          "legendFormat": "__auto"
-        },
-        {
-          "refId": "C",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "zombie-crab-prom"
-          },
-          "expr": "harnesssphere_graph_entities",
-          "instant": true,
-          "range": false,
-          "format": "table",
-          "legendFormat": "__auto"
+          "format": "table"
         }
       ],
       "transformations": [
-        {
-          "id": "labelsToFields",
-          "options": {
-            "mode": "columns",
-            "keepLabels": [
-              "crab_user",
-              "crab_agent",
-              "crab_tenant"
-            ]
-          }
-        },
         {
           "id": "joinByField",
           "options": {
             "byField": "crab_user",
             "mode": "outer"
           }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "Time 1": true,
+              "Time 2": true,
+              "Time 3": true,
+              "Time 4": true,
+              "Time 5": true,
+              "Time 6": true,
+              "Time 7": true,
+              "__name__": true,
+              "__name__ 1": true,
+              "__name__ 2": true,
+              "__name__ 3": true,
+              "__name__ 4": true,
+              "__name__ 5": true,
+              "__name__ 6": true,
+              "__name__ 7": true,
+              "crab_agent": true,
+              "crab_agent 1": true,
+              "crab_agent 2": true,
+              "crab_agent 3": true,
+              "crab_agent 4": true,
+              "crab_agent 5": true,
+              "crab_agent 6": true,
+              "crab_agent 7": true,
+              "crab_subscription": true,
+              "crab_subscription 1": true,
+              "crab_subscription 2": true,
+              "crab_subscription 3": true,
+              "crab_subscription 4": true,
+              "crab_subscription 5": true,
+              "crab_subscription 6": true,
+              "crab_subscription 7": true,
+              "crab_tenant": true,
+              "crab_tenant 1": true,
+              "crab_tenant 2": true,
+              "crab_tenant 3": true,
+              "crab_tenant 4": true,
+              "crab_tenant 5": true,
+              "crab_tenant 6": true,
+              "crab_tenant 7": true,
+              "exported_job": true,
+              "exported_job 1": true,
+              "exported_job 2": true,
+              "exported_job 3": true,
+              "exported_job 4": true,
+              "exported_job 5": true,
+              "exported_job 6": true,
+              "exported_job 7": true,
+              "harness_name": true,
+              "harness_name 1": true,
+              "harness_name 2": true,
+              "harness_name 3": true,
+              "harness_name 4": true,
+              "harness_name 5": true,
+              "harness_name 6": true,
+              "harness_name 7": true,
+              "harnesssphere_layer": true,
+              "harnesssphere_layer 1": true,
+              "harnesssphere_layer 2": true,
+              "harnesssphere_layer 3": true,
+              "harnesssphere_layer 4": true,
+              "harnesssphere_layer 5": true,
+              "harnesssphere_layer 6": true,
+              "harnesssphere_layer 7": true,
+              "host_name": true,
+              "host_name 1": true,
+              "host_name 2": true,
+              "host_name 3": true,
+              "host_name 4": true,
+              "host_name 5": true,
+              "host_name 6": true,
+              "host_name 7": true,
+              "instance": true,
+              "instance 1": true,
+              "instance 2": true,
+              "instance 3": true,
+              "instance 4": true,
+              "instance 5": true,
+              "instance 6": true,
+              "instance 7": true,
+              "job": true,
+              "job 1": true,
+              "job 2": true,
+              "job 3": true,
+              "job 4": true,
+              "job 5": true,
+              "job 6": true,
+              "job 7": true,
+              "service_name": true,
+              "service_name 1": true,
+              "service_name 2": true,
+              "service_name 3": true,
+              "service_name 4": true,
+              "service_name 5": true,
+              "service_name 6": true,
+              "service_name 7": true,
+              "telemetry_sdk_language": true,
+              "telemetry_sdk_language 1": true,
+              "telemetry_sdk_language 2": true,
+              "telemetry_sdk_language 3": true,
+              "telemetry_sdk_language 4": true,
+              "telemetry_sdk_language 5": true,
+              "telemetry_sdk_language 6": true,
+              "telemetry_sdk_language 7": true,
+              "telemetry_sdk_name": true,
+              "telemetry_sdk_name 1": true,
+              "telemetry_sdk_name 2": true,
+              "telemetry_sdk_name 3": true,
+              "telemetry_sdk_name 4": true,
+              "telemetry_sdk_name 5": true,
+              "telemetry_sdk_name 6": true,
+              "telemetry_sdk_name 7": true,
+              "telemetry_sdk_version": true,
+              "telemetry_sdk_version 1": true,
+              "telemetry_sdk_version 2": true,
+              "telemetry_sdk_version 3": true,
+              "telemetry_sdk_version 4": true,
+              "telemetry_sdk_version 5": true,
+              "telemetry_sdk_version 6": true,
+              "telemetry_sdk_version 7": true,
+              "crab_user": true
+            },
+            "renameByName": {
+              "Value #A": "tool calls",
+              "Value #B": "skills"
+            }
+          }
         }
       ],
       "options": {
-        "mapping": "manual",
-        "series": [
-          {
-            "x": {
-              "matcher": {
-                "id": "byName",
-                "options": "harnesssphere_tool_calls"
-              }
-            },
-            "y": {
-              "matcher": {
-                "id": "byName",
-                "options": "harnesssphere_harness_skills"
-              }
-            },
-            "size": {
-              "matcher": {
-                "id": "byName",
-                "options": "harnesssphere_graph_entities"
-              },
-              "min": 6,
-              "max": 40
-            },
-            "color": {
-              "matcher": {
-                "id": "byName",
-                "options": "crab_agent"
-              }
-            },
-            "name": "inst\u00e2ncia"
-          }
-        ],
+        "mapping": "auto",
         "legend": {
           "displayMode": "list",
           "placement": "bottom",
@@ -145,54 +223,18 @@
           "custom": {
             "show": "points",
             "pointSize": {
-              "fixed": 10
-            },
-            "axisLabel": ""
-          }
+              "fixed": 11
+            }
+          },
+          "min": 0
         },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "harnesssphere_tool_calls"
-            },
-            "properties": [
-              {
-                "id": "displayName",
-                "value": "chamadas de ferramenta"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "harnesssphere_harness_skills"
-            },
-            "properties": [
-              {
-                "id": "displayName",
-                "value": "skills"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "harnesssphere_graph_entities"
-            },
-            "properties": [
-              {
-                "id": "displayName",
-                "value": "entidades no grafo"
-              }
-            ]
-          }
-        ]
+        "overrides": []
       }
     },
     {
+      "id": 3,
       "type": "bargauge",
-      "title": "Grafo de conhecimento",
+      "title": "Knowledge graph",
       "gridPos": {
         "h": 7,
         "w": 10,
@@ -203,7 +245,7 @@
         "type": "prometheus",
         "uid": "zombie-crab-prom"
       },
-      "description": "O que o agente reteve, n\u00e3o o que ele falou.\n\nobserva\u00e7\u00f5es \u00e9 a soma do TAMANHO dos arrays `observations` de cada entidade \u2014 os fatos efetivamente guardados. \u00c9 o \u00fanico n\u00famero aqui que nenhuma contagem de arquivos deriva.\n\nRegistros s\u00e3o parseados, nunca contados por linha: o arquivo real tem 20 registros e `wc -l` diz 19, porque a \u00faltima linha n\u00e3o tem newline.\n\nO CONTE\u00daDO das observa\u00e7\u00f5es nunca sai do disco \u2014 s\u00f3 o comprimento do array.",
+      "description": "What the agent RETAINED, as opposed to what it said.\n\n`observations` sums the LENGTH of each entity's observations array \u2014 the facts actually kept. It is the one number here that no count of files can derive.\n\nRecords are parsed, never counted by line: the real file holds 20 records while `wc -l` reports 19, because the last line carries no trailing newline.\n\nObservation CONTENT never leaves the disk \u2014 only the array length.",
       "targets": [
         {
           "refId": "A",
@@ -212,7 +254,7 @@
             "uid": "zombie-crab-prom"
           },
           "expr": "sum(harnesssphere_graph_observations)",
-          "legendFormat": "observa\u00e7\u00f5es retidas",
+          "legendFormat": "observations retained",
           "instant": true
         },
         {
@@ -222,7 +264,7 @@
             "uid": "zombie-crab-prom"
           },
           "expr": "sum(harnesssphere_graph_entities)",
-          "legendFormat": "entidades",
+          "legendFormat": "entities",
           "instant": true
         },
         {
@@ -232,7 +274,7 @@
             "uid": "zombie-crab-prom"
           },
           "expr": "sum(harnesssphere_graph_relations)",
-          "legendFormat": "rela\u00e7\u00f5es",
+          "legendFormat": "relations",
           "instant": true
         },
         {
@@ -242,7 +284,7 @@
             "uid": "zombie-crab-prom"
           },
           "expr": "sum(harnesssphere_graph_observations) / clamp_min(sum(harnesssphere_graph_entities),1)",
-          "legendFormat": "observa\u00e7\u00f5es por entidade",
+          "legendFormat": "observations per entity",
           "instant": true
         }
       ],
@@ -273,8 +315,9 @@
       }
     },
     {
+      "id": 4,
       "type": "xychart",
-      "title": "Conversa \u00d7 reten\u00e7\u00e3o",
+      "title": "Conversation vs retention",
       "gridPos": {
         "h": 6,
         "w": 10,
@@ -285,7 +328,7 @@
         "type": "prometheus",
         "uid": "zombie-crab-prom"
       },
-      "description": "A rela\u00e7\u00e3o pedida diretamente: X = mensagens trocadas, Y = bytes de mem\u00f3ria retidos.\n\nUm ponto no canto inferior-direito fala muito e guarda pouco.\n\nmemory.bytes soma apenas arquivos N\u00c3O-VAZIOS. Tr\u00eas dos quatro arquivos de mem\u00f3ria de um workspace rec\u00e9m-provisionado t\u00eam zero byte (CONTEXT_RECOVERY, FILE_DELIVERY, MEMORY_ROUTING) \u2014 cont\u00e1-los faria toda inst\u00e2ncia nova parecer j\u00e1 ter mem\u00f3ria.",
+      "description": "X = messages exchanged. Y = memory bytes retained. A point low and to the right talks a lot and keeps little.\n\n`memory` sums NON-EMPTY files only. Three of the four memory files in a freshly provisioned workspace are zero bytes \u2014 counting them would make every new instance read as already having memory, a 4x overcount.",
       "targets": [
         {
           "refId": "A",
@@ -293,11 +336,10 @@
             "type": "prometheus",
             "uid": "zombie-crab-prom"
           },
-          "expr": "sum by (crab_user, crab_agent, crab_tenant) (harnesssphere_harness_messages)",
+          "expr": "sum by (crab_tenant, crab_agent, crab_user) (harnesssphere_harness_messages)",
           "instant": true,
           "range": false,
-          "format": "table",
-          "legendFormat": "__auto"
+          "format": "table"
         },
         {
           "refId": "B",
@@ -308,168 +350,10 @@
           "expr": "harnesssphere_harness_memory_bytes",
           "instant": true,
           "range": false,
-          "format": "table",
-          "legendFormat": "__auto"
+          "format": "table"
         }
       ],
       "transformations": [
-        {
-          "id": "labelsToFields",
-          "options": {
-            "mode": "columns",
-            "keepLabels": [
-              "crab_user",
-              "crab_agent",
-              "crab_tenant"
-            ]
-          }
-        },
-        {
-          "id": "joinByField",
-          "options": {
-            "byField": "crab_user",
-            "mode": "outer"
-          }
-        }
-      ],
-      "options": {
-        "mapping": "manual",
-        "series": [
-          {
-            "x": {
-              "matcher": {
-                "id": "byName",
-                "options": "Value #A"
-              }
-            },
-            "y": {
-              "matcher": {
-                "id": "byName",
-                "options": "harnesssphere_harness_memory_bytes"
-              }
-            },
-            "name": "inst\u00e2ncia"
-          }
-        ],
-        "legend": {
-          "showLegend": false
-        },
-        "tooltip": {
-          "mode": "single"
-        }
-      },
-      "fieldConfig": {
-        "defaults": {
-          "custom": {
-            "show": "points",
-            "pointSize": {
-              "fixed": 9
-            }
-          }
-        },
-        "overrides": []
-      }
-    },
-    {
-      "type": "table",
-      "title": "Inst\u00e2ncias \u2014 todas as medidas, uma linha cada",
-      "gridPos": {
-        "h": 6,
-        "w": 14,
-        "x": 0,
-        "y": 14
-      },
-      "datasource": {
-        "type": "prometheus",
-        "uid": "zombie-crab-prom"
-      },
-      "description": "A mesma informa\u00e7\u00e3o do scatter em forma leg\u00edvel, e o fallback se a jun\u00e7\u00e3o de campos do scatter n\u00e3o renderizar (FR-L10).\n\nOrdene por qualquer coluna para ranquear. 'obs/msg' \u00e9 densidade de aprendizado: quanto do que foi conversado virou fato retido.",
-      "targets": [
-        {
-          "refId": "A",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "zombie-crab-prom"
-          },
-          "expr": "harnesssphere_harness_skills",
-          "instant": true,
-          "range": false,
-          "format": "table",
-          "legendFormat": "__auto"
-        },
-        {
-          "refId": "B",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "zombie-crab-prom"
-          },
-          "expr": "harnesssphere_tool_calls",
-          "instant": true,
-          "range": false,
-          "format": "table",
-          "legendFormat": "__auto"
-        },
-        {
-          "refId": "C",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "zombie-crab-prom"
-          },
-          "expr": "harnesssphere_graph_observations",
-          "instant": true,
-          "range": false,
-          "format": "table",
-          "legendFormat": "__auto"
-        },
-        {
-          "refId": "D",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "zombie-crab-prom"
-          },
-          "expr": "harnesssphere_harness_memory_bytes",
-          "instant": true,
-          "range": false,
-          "format": "table",
-          "legendFormat": "__auto"
-        },
-        {
-          "refId": "E",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "zombie-crab-prom"
-          },
-          "expr": "sum by (crab_user, crab_agent, crab_tenant) (harnesssphere_harness_sessions)",
-          "instant": true,
-          "range": false,
-          "format": "table",
-          "legendFormat": "__auto"
-        },
-        {
-          "refId": "F",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "zombie-crab-prom"
-          },
-          "expr": "sum by (crab_user, crab_agent, crab_tenant) (harnesssphere_graph_observations) / clamp_min(sum by (crab_user, crab_agent, crab_tenant) (harnesssphere_harness_messages),1)",
-          "instant": true,
-          "range": false,
-          "format": "table",
-          "legendFormat": "__auto"
-        }
-      ],
-      "transformations": [
-        {
-          "id": "labelsToFields",
-          "options": {
-            "mode": "columns",
-            "keepLabels": [
-              "crab_user",
-              "crab_agent",
-              "crab_tenant"
-            ]
-          }
-        },
         {
           "id": "joinByField",
           "options": {
@@ -482,17 +366,382 @@
           "options": {
             "excludeByName": {
               "Time": true,
-              "crab_tenant": true
+              "Time 1": true,
+              "Time 2": true,
+              "Time 3": true,
+              "Time 4": true,
+              "Time 5": true,
+              "Time 6": true,
+              "Time 7": true,
+              "__name__": true,
+              "__name__ 1": true,
+              "__name__ 2": true,
+              "__name__ 3": true,
+              "__name__ 4": true,
+              "__name__ 5": true,
+              "__name__ 6": true,
+              "__name__ 7": true,
+              "crab_agent": true,
+              "crab_agent 1": true,
+              "crab_agent 2": true,
+              "crab_agent 3": true,
+              "crab_agent 4": true,
+              "crab_agent 5": true,
+              "crab_agent 6": true,
+              "crab_agent 7": true,
+              "crab_subscription": true,
+              "crab_subscription 1": true,
+              "crab_subscription 2": true,
+              "crab_subscription 3": true,
+              "crab_subscription 4": true,
+              "crab_subscription 5": true,
+              "crab_subscription 6": true,
+              "crab_subscription 7": true,
+              "crab_tenant": true,
+              "crab_tenant 1": true,
+              "crab_tenant 2": true,
+              "crab_tenant 3": true,
+              "crab_tenant 4": true,
+              "crab_tenant 5": true,
+              "crab_tenant 6": true,
+              "crab_tenant 7": true,
+              "exported_job": true,
+              "exported_job 1": true,
+              "exported_job 2": true,
+              "exported_job 3": true,
+              "exported_job 4": true,
+              "exported_job 5": true,
+              "exported_job 6": true,
+              "exported_job 7": true,
+              "harness_name": true,
+              "harness_name 1": true,
+              "harness_name 2": true,
+              "harness_name 3": true,
+              "harness_name 4": true,
+              "harness_name 5": true,
+              "harness_name 6": true,
+              "harness_name 7": true,
+              "harnesssphere_layer": true,
+              "harnesssphere_layer 1": true,
+              "harnesssphere_layer 2": true,
+              "harnesssphere_layer 3": true,
+              "harnesssphere_layer 4": true,
+              "harnesssphere_layer 5": true,
+              "harnesssphere_layer 6": true,
+              "harnesssphere_layer 7": true,
+              "host_name": true,
+              "host_name 1": true,
+              "host_name 2": true,
+              "host_name 3": true,
+              "host_name 4": true,
+              "host_name 5": true,
+              "host_name 6": true,
+              "host_name 7": true,
+              "instance": true,
+              "instance 1": true,
+              "instance 2": true,
+              "instance 3": true,
+              "instance 4": true,
+              "instance 5": true,
+              "instance 6": true,
+              "instance 7": true,
+              "job": true,
+              "job 1": true,
+              "job 2": true,
+              "job 3": true,
+              "job 4": true,
+              "job 5": true,
+              "job 6": true,
+              "job 7": true,
+              "service_name": true,
+              "service_name 1": true,
+              "service_name 2": true,
+              "service_name 3": true,
+              "service_name 4": true,
+              "service_name 5": true,
+              "service_name 6": true,
+              "service_name 7": true,
+              "telemetry_sdk_language": true,
+              "telemetry_sdk_language 1": true,
+              "telemetry_sdk_language 2": true,
+              "telemetry_sdk_language 3": true,
+              "telemetry_sdk_language 4": true,
+              "telemetry_sdk_language 5": true,
+              "telemetry_sdk_language 6": true,
+              "telemetry_sdk_language 7": true,
+              "telemetry_sdk_name": true,
+              "telemetry_sdk_name 1": true,
+              "telemetry_sdk_name 2": true,
+              "telemetry_sdk_name 3": true,
+              "telemetry_sdk_name 4": true,
+              "telemetry_sdk_name 5": true,
+              "telemetry_sdk_name 6": true,
+              "telemetry_sdk_name 7": true,
+              "telemetry_sdk_version": true,
+              "telemetry_sdk_version 1": true,
+              "telemetry_sdk_version 2": true,
+              "telemetry_sdk_version 3": true,
+              "telemetry_sdk_version 4": true,
+              "telemetry_sdk_version 5": true,
+              "telemetry_sdk_version 6": true,
+              "telemetry_sdk_version 7": true,
+              "crab_user": true
             },
             "renameByName": {
-              "crab_user": "membro",
-              "crab_agent": "agente",
-              "harnesssphere_harness_skills": "skills",
-              "harnesssphere_tool_calls": "ferramentas",
-              "harnesssphere_graph_observations": "observa\u00e7\u00f5es",
-              "harnesssphere_harness_memory_bytes": "mem\u00f3ria",
-              "Value #E": "conversas",
-              "Value #F": "obs/msg"
+              "Value #A": "messages",
+              "Value #B": "memory bytes",
+              "crab_user": "member"
+            }
+          }
+        }
+      ],
+      "options": {
+        "mapping": "auto",
+        "legend": {
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "show": "points",
+            "pointSize": {
+              "fixed": 10
+            }
+          },
+          "min": 0
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "memory bytes"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "bytes"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": 5,
+      "type": "table",
+      "title": "Instances \u2014 every measure, one row each",
+      "gridPos": {
+        "h": 6,
+        "w": 14,
+        "x": 0,
+        "y": 14
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "zombie-crab-prom"
+      },
+      "description": "The scatter's information in readable form. Sort by any column to rank.\n\nEvery number excludes what the panels above describe: skills counts SKILL.md files, memory counts non-empty files, conversations exclude the durable/ mirror and cron runs.",
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "zombie-crab-prom"
+          },
+          "expr": "harnesssphere_harness_skills",
+          "instant": true,
+          "range": false,
+          "format": "table"
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "zombie-crab-prom"
+          },
+          "expr": "harnesssphere_tool_calls",
+          "instant": true,
+          "range": false,
+          "format": "table"
+        },
+        {
+          "refId": "C",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "zombie-crab-prom"
+          },
+          "expr": "harnesssphere_graph_observations",
+          "instant": true,
+          "range": false,
+          "format": "table"
+        },
+        {
+          "refId": "D",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "zombie-crab-prom"
+          },
+          "expr": "harnesssphere_harness_memory_bytes",
+          "instant": true,
+          "range": false,
+          "format": "table"
+        },
+        {
+          "refId": "E",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "zombie-crab-prom"
+          },
+          "expr": "sum by (crab_tenant, crab_agent, crab_user) (harnesssphere_harness_sessions)",
+          "instant": true,
+          "range": false,
+          "format": "table"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "joinByField",
+          "options": {
+            "byField": "crab_user",
+            "mode": "outer"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "Time 1": true,
+              "Time 2": true,
+              "Time 3": true,
+              "Time 4": true,
+              "Time 5": true,
+              "Time 6": true,
+              "Time 7": true,
+              "__name__": true,
+              "__name__ 1": true,
+              "__name__ 2": true,
+              "__name__ 3": true,
+              "__name__ 4": true,
+              "__name__ 5": true,
+              "__name__ 6": true,
+              "__name__ 7": true,
+              "crab_agent": true,
+              "crab_agent 2": true,
+              "crab_agent 3": true,
+              "crab_agent 4": true,
+              "crab_agent 5": true,
+              "crab_agent 6": true,
+              "crab_agent 7": true,
+              "crab_subscription": true,
+              "crab_subscription 1": true,
+              "crab_subscription 2": true,
+              "crab_subscription 3": true,
+              "crab_subscription 4": true,
+              "crab_subscription 5": true,
+              "crab_subscription 6": true,
+              "crab_subscription 7": true,
+              "crab_tenant": true,
+              "crab_tenant 1": true,
+              "crab_tenant 2": true,
+              "crab_tenant 3": true,
+              "crab_tenant 4": true,
+              "crab_tenant 5": true,
+              "crab_tenant 6": true,
+              "crab_tenant 7": true,
+              "exported_job": true,
+              "exported_job 1": true,
+              "exported_job 2": true,
+              "exported_job 3": true,
+              "exported_job 4": true,
+              "exported_job 5": true,
+              "exported_job 6": true,
+              "exported_job 7": true,
+              "harness_name": true,
+              "harness_name 1": true,
+              "harness_name 2": true,
+              "harness_name 3": true,
+              "harness_name 4": true,
+              "harness_name 5": true,
+              "harness_name 6": true,
+              "harness_name 7": true,
+              "harnesssphere_layer": true,
+              "harnesssphere_layer 1": true,
+              "harnesssphere_layer 2": true,
+              "harnesssphere_layer 3": true,
+              "harnesssphere_layer 4": true,
+              "harnesssphere_layer 5": true,
+              "harnesssphere_layer 6": true,
+              "harnesssphere_layer 7": true,
+              "host_name": true,
+              "host_name 1": true,
+              "host_name 2": true,
+              "host_name 3": true,
+              "host_name 4": true,
+              "host_name 5": true,
+              "host_name 6": true,
+              "host_name 7": true,
+              "instance": true,
+              "instance 1": true,
+              "instance 2": true,
+              "instance 3": true,
+              "instance 4": true,
+              "instance 5": true,
+              "instance 6": true,
+              "instance 7": true,
+              "job": true,
+              "job 1": true,
+              "job 2": true,
+              "job 3": true,
+              "job 4": true,
+              "job 5": true,
+              "job 6": true,
+              "job 7": true,
+              "service_name": true,
+              "service_name 1": true,
+              "service_name 2": true,
+              "service_name 3": true,
+              "service_name 4": true,
+              "service_name 5": true,
+              "service_name 6": true,
+              "service_name 7": true,
+              "telemetry_sdk_language": true,
+              "telemetry_sdk_language 1": true,
+              "telemetry_sdk_language 2": true,
+              "telemetry_sdk_language 3": true,
+              "telemetry_sdk_language 4": true,
+              "telemetry_sdk_language 5": true,
+              "telemetry_sdk_language 6": true,
+              "telemetry_sdk_language 7": true,
+              "telemetry_sdk_name": true,
+              "telemetry_sdk_name 1": true,
+              "telemetry_sdk_name 2": true,
+              "telemetry_sdk_name 3": true,
+              "telemetry_sdk_name 4": true,
+              "telemetry_sdk_name 5": true,
+              "telemetry_sdk_name 6": true,
+              "telemetry_sdk_name 7": true,
+              "telemetry_sdk_version": true,
+              "telemetry_sdk_version 1": true,
+              "telemetry_sdk_version 2": true,
+              "telemetry_sdk_version 3": true,
+              "telemetry_sdk_version 4": true,
+              "telemetry_sdk_version 5": true,
+              "telemetry_sdk_version 6": true,
+              "telemetry_sdk_version 7": true
+            },
+            "renameByName": {
+              "crab_user": "member",
+              "crab_agent 1": "agent",
+              "Value #A": "skills",
+              "Value #B": "tool calls",
+              "Value #C": "retained facts",
+              "Value #D": "memory bytes",
+              "Value #E": "conversations"
             }
           }
         }
@@ -515,7 +764,7 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "mem\u00f3ria"
+              "options": "memory bytes"
             },
             "properties": [
               {
@@ -523,25 +772,14 @@
                 "value": "bytes"
               }
             ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "obs/msg"
-            },
-            "properties": [
-              {
-                "id": "decimals",
-                "value": 2
-              }
-            ]
           }
         ]
       }
     },
     {
+      "id": 6,
       "type": "bargauge",
-      "title": "Skills por inst\u00e2ncia",
+      "title": "Skills per instance",
       "gridPos": {
         "h": 6,
         "w": 10,
@@ -552,7 +790,7 @@
         "type": "prometheus",
         "uid": "zombie-crab-prom"
       },
-      "description": "QUAIS skills cada inst\u00e2ncia construiu, n\u00e3o apenas quantas.\n\nNomes de skill podem ser labels porque s\u00e3o capacidades autorais do agente, limitadas a ~10 por inst\u00e2ncia. Nomes de ENTIDADE do grafo nunca podem: s\u00e3o extra\u00eddos das conversas do membro e a cardinalidade \u00e9 ilimitada.",
+      "description": "WHICH skills each instance has built, not merely how many.\n\nSkill names can be labels because they are agent-authored capability names, bounded at roughly ten per instance. Knowledge-graph ENTITY names cannot: they are extracted from the member's conversations and their cardinality is unbounded.",
       "targets": [
         {
           "refId": "A",
@@ -577,7 +815,6 @@
       },
       "fieldConfig": {
         "defaults": {
-          "max": 1,
           "thresholds": {
             "mode": "absolute",
             "steps": [

--- a/deploy/observability/harnesssphere.otlp.toml
+++ b/deploy/observability/harnesssphere.otlp.toml
@@ -59,6 +59,9 @@ discovery_interval_secs = 30
 # Slower than discovery on purpose: finding a workspace is a directory glob, reading
 # one is IO proportional to its conversation history.
 session_interval_secs = 60
+# Skills, memory files and the knowledge graph. Slower than sessions on purpose: these
+# change rarely, while transcripts change constantly.
+learning_interval_secs = 300
 session_source = "picoclaw"
 
 # --- Still single-valued, still empty ----------------------------------------

--- a/docker-compose.observability.yaml
+++ b/docker-compose.observability.yaml
@@ -77,7 +77,14 @@ services:
       - "${PROMETHEUS_PORT:-9090}:9090"
 
   grafana:
-    image: grafana/grafana:${GRAFANA_TAG:-11.4.0}
+    # 11.6.0, not 11.4.0, and the reason is specific: 11.4.0 FAILS TO REGISTER ITS OWN
+    # XY Chart panel. Its boot log carries
+    #   Could not register plugin pluginId=xychart error="plugin xychart is already registered"
+    # -- xychart is the only panel that errors -- and any xychart panel then sits at
+    # "Loading plugin panel..." forever, with no error shown to the reader. Verified by
+    # booting both versions and diffing the logs: 11.4.0 logs the error twice, 11.6.0 zero
+    # times. Disabling the autoMigrateXYChartPanel toggle does NOT fix it.
+    image: grafana/grafana:${GRAFANA_TAG:-11.6.0}
     restart: unless-stopped
     environment:
       # Anonymous admin access. This is a local development backend on a


### PR DESCRIPTION
Picks up **harness-sphere#28** and adds `zombie-crab — learning` beside the existing
dashboard. The stack dashboard is **not modified** — it answers *"is the stack healthy?"*
and is organised by **layer**; this one answers *"where does each instance sit?"* and is
organised by **member**. Six panels, 20 grid units: one screen, no scrolling.

**Every panel is verified by screenshotting the running dashboard and reading the image**,
not by reasoning about the config. That mattered — see below.

## What it shows, on live data

```
member       skills  tool calls  retained facts  memory  conversations
28690354…         9         125              56   317 B             12
ba226b3b…         9           0               0   317 B              1
```

A second instance appeared during the work, so this is no longer a single point. **The two
rows are already the feature working**: same 9 skills installed, 125 tool calls against 0.
Same capability, one consuming and retaining, one idle — the *Apprentice* quadrant, legible
without the scatter.

All four numbers the spec predicted landed. `skills` is **9**, not the 10 directories
present. `memory` is **one** non-empty file, not four. `retained facts` is **56** — the
number that did not exist before this feature.

## Axes are symlog, and say so

One instance sits at **0 tool calls and 0 retained facts** — exactly the case this chart
exists to surface — and `log(0)` is undefined, so a plain log axis would **drop those points
with no error**. Symlog is linear below 1 and logarithmic above it, so the zero-consumption
instance stays visible at the origin.

Both scatters label their axes `(symlog)`: a reader who assumes linear misreads every
distance on the plot.

## Three real defects found by looking

**1. Grafana 11.4.0 cannot register its own XY Chart.** The panel sat at *"Loading plugin
panel…"* forever, in a real browser too. The boot log had been saying why all along:

```
level=error msg="Could not register plugin" pluginId=xychart
      error="plugin xychart is already registered"
```

`xychart` was the **only** panel that failed to register. Disabling the
`autoMigrateXYChartPanel` toggle did not help. Booting 11.4.0 and 11.6.0 side by side and
diffing the logs settled it: **11.4.0 logs it twice, 11.6.0 zero times.** The overlay now
pins 11.6.0, with the reason written where the version is set.

**2. On 11.6.0 the panel loaded and threw** `TypeError: Cannot read properties of undefined
(reading 'map')` — it dereferences `options.series` unconditionally, so `mapping: "auto"`
still requires `series: [{}]` present.

**3. The table repeated columns** (reported in review). `joinByField` suffixes every
duplicated label column **per query** — ` 1`, ` 2`, ` 3` — while the exclude list covered
only ` 1`. With five queries that left `crab_agent 2` and `__name__ 1` beside the real
measures.

## Point identity, and an honest limit

A short id is derived in PromQL from the member UUID's first eight characters and carried
into the frame, so **hovering a point names it**; the Instances table is the printed key.

**xychart in 11.6 has no always-on point label.** Three routes were tried and each failed
specifically — recorded so nobody repeats them:

- `custom.label: "always"` is not the mechanism; nothing renders.
- `partitionByValues` with `keepFields: false` **deletes the partition field**, which is
  what made `member` vanish from the frame.
- a `displayName` override pointed at the field label **breaks the axis matchers** — they
  match by name, so renaming unbinds them; the plot goes empty.

Also fixed: the short id was first named `instance`, which **collides with Prometheus's own
`instance` label** — already on the exclude list, so the field was deleted before it could
be used.

## Ready for production

`ghcr.io/lepistabioinformatics/harness-sphere:latest` was rebuilt at `85a0b49` (release-image
green), so it carries the learning collector and `docker-compose.prod.yaml` pulls it.

The dashboard is entirely in English. OQ-10 (the "sustainable use" threshold) is dropped at
the owner's request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)