### PR TITLE
feat(ganglion): add crab-ganglion-harness, its specs, and the collector's HTTP receiver

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -14,6 +14,10 @@ only apply inside it; this file holds what applies across the stack.
 When a pointer may be committed, and the check that enforces it, are in
 `.claude/rules/submodule-pointers.md`.
 
+**Everything here and below is written in English** — code comments, commits, PRs,
+issues, specs, docs. Only the parent `zombie-crab-project-mkt` writes Portuguese.
+See `.claude/rules/language.md`.
+
 ## harness-sphere: two rules that are easy to violate by accident
 
 **It never gets a Docker socket.** `crab-shell-proxy` already mounts one and runs as

--- a/.claude/rules/language.md
+++ b/.claude/rules/language.md
@@ -1,0 +1,40 @@
+# Language
+
+**Everything in this repository and its submodules is written in English.**
+
+Not a style preference. This repository is public under `MIT OR Apache-2.0`, it
+has its own remote, its own PRs, and readers outside this team. A comment in
+another language is a barrier to anyone arriving.
+
+Applies without exception by artefact type:
+
+| Artefact | Language |
+|---|---|
+| Code comments | English |
+| Commit messages | English |
+| PR titles and bodies | English |
+| Issues and issue comments | English |
+| `.specs/` | English |
+| `README`, docs, ADRs | English |
+| Test names and failure messages | English |
+| `CHANGELOG` | English |
+
+It applies at every depth of the chain: this repository, `crab/crab-shell-proxy`,
+`crab/crab-exoskeleton-webapp`, `crab/harness-sphere`, `crab/crab-ganglion-harness`.
+
+## The one place that is different, and it is not below this line
+
+The parent monorepo `zombie-crab-project-mkt` — private, marketing and growth —
+writes in **Portuguese**: its `.specs/`, its `social/`, its `deploy/dokploy/`
+comments, its commits and PRs. The boundary is that repository's `modules/`
+directory. See its `.claude/rules/language.md`.
+
+Consequence worth stating: **moving a document across that boundary means
+translating it.** A file coming down from the parent is rewritten in English.
+
+## Chat is not an artefact
+
+This rule governs what gets written to disk or posted to GitHub. Conversation
+with the project owner is in Portuguese regardless of which repository is being
+edited. Writing an English comment while explaining the change in Portuguese is
+correct, not inconsistent.

--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "crab/harness-sphere"]
 	path = crab/harness-sphere
 	url = https://github.com/LepistaBioinformatics/harness-sphere.git
+[submodule "crab/crab-ganglion-harness"]
+	path = crab/crab-ganglion-harness
+	url = https://github.com/LepistaBioinformatics/crab-ganglion-harness.git

--- a/.specs/features/crab-ganglion-harness/architecture-proposal.md
+++ b/.specs/features/crab-ganglion-harness/architecture-proposal.md
@@ -1,0 +1,235 @@
+# crab-ganglion-harness — Clean Architecture migration proposal
+
+> **DECLINED (2026-09-10) — nothing was migrated, and the hexagonal layout at `2fd0348`
+> stands.** The owner's reason, in their words: *"é um projeto pequeno."* That is the same
+> judgement §6 of this document reached from the other side — four modules and four layers is
+> a lot of structure for 1,828 lines, and the migration buys no behaviour. Kept as a record so
+> a future session does not re-derive the analysis; **re-open it only if the Deferred table
+> (DF-1..DF-6) starts landing and `adapter/` becomes the bag §1 warns about.**
+
+**Status:** Declined. Superseded by nothing — `design.md` §1 and AR-1..AR-4 remain in force.
+**Date:** 2026-09-10.
+**Supersedes on approval:** `design.md` §1 (module layout) and AR-1..AR-4.
+**Applies to:** commit `2fd0348` of `crab-ganglion-harness` — 1,828 LOC production, 959 test,
+CI green.
+
+---
+
+## 1. What is wrong with what shipped
+
+The current layout is hexagonal and it works, but it fails Screaming Architecture on its own
+terms. This is what `ls internal/` says today:
+
+```
+domain/  runtime/  adapter/  config/
+```
+
+That names a **pattern**, not a system. It could be a payment gateway, a CRM, a build server.
+Nothing in it says *"this thing holds conversations, calls tools, asks permission, and counts
+tokens"* — which is precisely what the project exists to do, and two of those four are the
+capabilities that justified building it at all.
+
+Two further problems, both consequences of the same thing:
+
+- **Use cases are invisible.** The system's central operation is "answer a turn". It lives as
+  `runtime.Loop.Run`, a method on a struct named after a technical concept. There is no
+  directory anywhere named for what the system *does*.
+- **The modules are not extractable.** `adapter/` is one bag holding LLM access, storage,
+  shell execution and approval. Nothing marks which parts belong together, so lifting
+  approval out into its own module later means reading every file to find out what moves.
+
+---
+
+## 2. The proposal in one picture
+
+**Feature-first at the top (screams), layered inside (Clean), dependencies pointing inward
+only.**
+
+```
+internal/
+├── conversation/            ← answering a turn: the reason the system exists
+│   ├── entity/              ← Enterprise Business Rules
+│   │   ├── message.go           Message, Role, ToolCall
+│   │   ├── transcript.go        the append-only record
+│   │   └── window.go            the derived context
+│   ├── usecase/             ← Application Business Rules
+│   │   ├── answerturn/          THE interactor (was runtime.Loop)
+│   │   │   ├── interactor.go
+│   │   │   ├── boundary.go      input/output ports, owned by the use case
+│   │   │   └── interactor_test.go
+│   │   └── compactcontext/      (was runtime/compact.go)
+│   ├── gateway/             ← Interface Adapters, outward
+│   │   ├── llm/openai/
+│   │   └── persistence/{transcript,window}/
+│   └── controller/          ← Interface Adapters, inward
+│       ├── sse/                 the presenter: turn output → SSE frames
+│       └── telegram/            (later; DQ-5)
+│
+├── approval/                ← gating an action: capability A1
+│   ├── entity/                  ActionRequest, Decision
+│   ├── usecase/requestapproval/
+│   └── gateway/proxyhttp/
+│
+├── toolcalling/             ← what the agent can do
+│   ├── entity/                  Call, Result, Schema
+│   ├── usecase/invoketool/
+│   └── gateway/shell/
+│
+├── accounting/              ← counting tokens: capability A2
+│   ├── entity/                  Usage
+│   ├── usecase/recordusage/
+│   └── gateway/otlp/
+│
+└── platform/                ← Frameworks & Drivers. The ONLY tech-named directory.
+    ├── httpserver/
+    ├── config/
+    └── log/
+```
+
+`ls internal/` now reads: **conversation, approval, toolcalling, accounting, platform.** That
+sentence is the system. And it is not decoration — `approval` and `accounting` are the two
+capabilities the whole investigation concluded had no seam in picoclaw. **The architecture
+now names its own justification.**
+
+---
+
+## 3. The four layers, and the rule that makes them real
+
+| Layer | Directory | May import |
+|---|---|---|
+| Enterprise Business Rules | `*/entity/` | **stdlib only** |
+| Application Business Rules | `*/usecase/*/` | own module's `entity` + stdlib |
+| Interface Adapters | `*/gateway/`, `*/controller/` | own module's `entity` + `usecase` boundaries |
+| Frameworks & Drivers | `platform/`, `cmd/` | anything |
+
+**The Dependency Rule is a test, not a convention.** This is carried over from AR-1, which
+already exists and already passes; the migration widens it rather than inventing it:
+
+- `TestEntitiesImportOnlyStdlib` — every `*/entity/` package.
+- `TestUseCasesDoNotImportAdapters` — no `usecase` may reach a `gateway`, a `controller`, or
+  `platform`.
+- `TestModulesDoNotReachIntoEachOther` — the new one, and the one that buys modularizability
+  (§4).
+
+Two additions Clean makes that hexagonal did not, and both are renames of things already
+built correctly rather than new machinery:
+
+- **Boundaries belong to the use case, not to a shared package.** `answerturn/boundary.go`
+  declares what *that* interactor needs. The single `domain/ports.go` becomes several small
+  files, each next to its consumer. This is what lets a use case be understood alone.
+- **`Sink` becomes the Output Boundary, and the SSE writer becomes the Presenter.** The
+  interactor pushes results through an interface instead of returning them — which is exactly
+  what streaming already does. No behaviour changes; the pattern gets its name.
+
+---
+
+## 4. Modularizable: the rule that makes extraction a `git mv`
+
+> **A module may depend on another module only through interfaces it declares itself.**
+
+`answerturn` needs tools and approval. It does **not** import `toolcalling` or `approval`.
+It declares, in its own `boundary.go`:
+
+```go
+package answerturn
+
+// Ports this interactor needs. Declared HERE, by the consumer -- which is what
+// keeps conversation/ from importing toolcalling/ or approval/ at all.
+type ToolInvoker interface {
+    Available(ctx context.Context) []ToolSpec
+    Invoke(ctx context.Context, c ToolRequest) (ToolOutcome, error)
+}
+
+type ApprovalRequester interface {
+    Request(ctx context.Context, a ApprovalAsk) (ApprovalVerdict, error)
+}
+```
+
+`ToolSpec`, `ToolRequest`, `ToolOutcome` are **conversation's own** types. `toolcalling`
+never sees them: `cmd/` wires a thin translator between `toolcalling.Result` and
+`answerturn.ToolOutcome`.
+
+**That translation is the price, and it is the whole point.** It costs roughly 40 lines in the
+composition root. It buys: any module can be lifted into its own `go.mod`, its own repository,
+or replaced wholesale, without touching the others — and the test proves no one cheated.
+
+Extracting `toolcalling` later becomes: `git mv`, add a `go.mod`, add a `require`. Nothing in
+`conversation` changes, because nothing in `conversation` ever named it.
+
+---
+
+## 5. What actually moves
+
+A pure refactor: **no behaviour change, no new features, tests green at every step.** The 28
+existing tests are the safety net and none of their assertions change — only imports.
+
+| Today | Becomes |
+|---|---|
+| `domain/message.go`, `domain/session.go` | split across `conversation/entity/`, `toolcalling/entity/`, `approval/entity/`, `accounting/entity/` |
+| `domain/ports.go` | dissolved into per-use-case `boundary.go` files |
+| `runtime/loop.go` | `conversation/usecase/answerturn/interactor.go` |
+| `runtime/compact.go` | `conversation/usecase/compactcontext/` |
+| `runtime/noop.go` | per-module null objects, beside their boundaries |
+| `adapter/httpsse/` | `conversation/controller/sse/` (presenter) + `platform/httpserver/` (the listener) |
+| `adapter/provider/openai/` | `conversation/gateway/llm/openai/` |
+| `adapter/store/jsonl/`, `store/window/` | `conversation/gateway/persistence/{transcript,window}/` |
+| `adapter/tool/`, `adapter/tool/exec/` | `toolcalling/` (all four layers) |
+| `adapter/approver/proxy/` | `approval/gateway/proxyhttp/` |
+| `Usage`, telemetry port | `accounting/` |
+| `config/` | `platform/config/` |
+| `domain/arch_test.go` | `internal/arch_test.go`, widened to the three rules of §3 |
+
+Estimated: ~250 lines of genuinely new code (translators, split boundaries, the third arch
+test), ~1,800 moved, one afternoon, one PR.
+
+---
+
+## 6. The honest counterpoint
+
+**This is a lot of directories for 1,828 lines.** Four modules × up to four layers is 14
+packages where there are now 9, and the translation layer of §4 is code that exists purely to
+keep a boundary honest. If the harness stayed this size forever, hexagonal was the right
+answer and this is ceremony.
+
+Three things argue it is not:
+
+1. The spec's own Deferred table (DF-1..DF-6) lists **six** features not yet built — MCP,
+   memory graph, projects, personal models, cron, web tools. Most are new gateways; two are
+   plausibly new modules. The structure is being chosen for the system's size in six months,
+   not today.
+2. `Ingress` already has a second implementation coming (Telegram, DQ-5), and the driving side
+   is where hexagonal was thinnest.
+3. The estimate for the whole harness is 5,000–9,500 LOC. At 1,828 we are at the *start*, and
+   this refactor is cheapest now — the tests exist, nothing depends on the package paths yet,
+   and no proxy integration has been written against them.
+
+**The one thing this does not buy is behaviour.** No requirement in `spec.md` is closer to
+done afterwards. It is a bet on the next 4,000 lines being easier, and it should be taken or
+declined on that basis.
+
+---
+
+## 7. Two calibrations
+
+**Full (recommended).** Everything above: four feature modules, four layers, consumer-owned
+interfaces with translation at the composition root, three enforcement tests. Maximum
+extractability, highest directory count, ~250 new lines.
+
+**Pragmatic.** Same feature-first top level and the same layer rules, but shared entities live
+in `conversation/entity/` and the other modules import them directly — no translation layer.
+Saves ~40 lines of mapping and about half the friction; costs true extractability, since
+lifting `toolcalling` out would drag `conversation/entity` with it. Honest middle ground if
+the modules are never actually expected to leave this repository.
+
+The difference between them is exactly §4, and nothing else.
+
+---
+
+## 8. What I need decided
+
+1. **Full or Pragmatic** (§7).
+2. **Module names.** `conversation` / `approval` / `toolcalling` / `accounting` — these become
+   the vocabulary of the codebase and are expensive to change later. `conversation` is the one
+   worth challenging: alternatives are `turn`, `chat`, or `agent`.
+3. Whether the migration is **one PR** (atomic, one review, larger diff) or **one PR per
+   module** (four reviews, `internal/` inconsistent in between).

--- a/.specs/features/crab-ganglion-harness/design.md
+++ b/.specs/features/crab-ganglion-harness/design.md
@@ -1,0 +1,365 @@
+# crab-ganglion-harness — Design
+
+**Status:** Designed. Not implemented.
+**Date:** 2026-09-09.
+**Reads:** `spec.md` (this directory) for requirements; the parent monorepo's
+`.specs/features/own-go-harness/investigation.md` for why.
+
+This document decides **structure and contracts**. It does not decide task order — that is
+`tasks.md`, which does not exist yet.
+
+---
+
+## 1. Module layout
+
+Mirrors `harness-sphere`'s crate split, which is this house's existing hexagonal precedent:
+`domain` (model, ports, pure policy) → `runtime` (the use case) → adapters → binary.
+
+```
+crab/crab-ganglion-harness/
+├── cmd/crab-ganglion/
+│   └── main.go              # composition root: the ONLY file where adapters meet
+├── internal/
+│   ├── domain/              # AR-1: standard library ONLY
+│   │   ├── message.go       # Message, Role, ToolCall, Usage
+│   │   ├── session.go       # SessionKey, Transcript, Window
+│   │   ├── action.go        # ActionRequest, Decision  (approval)
+│   │   └── ports.go         # the five ports, and nothing else
+│   ├── runtime/             # the agent loop; imports domain only
+│   │   ├── loop.go          # iterate: provider → tools → provider …
+│   │   ├── compact.go       # when and how the Window is rebuilt
+│   │   └── stream.go        # delta fan-out to the sink
+│   └── adapter/
+│       ├── httpsse/         # DRIVING adapter: POST /v1/chat/completions, GET /health
+│       ├── provider/openai/ # Provider — streaming, OpenAI-compatible
+│       ├── store/jsonl/     # TranscriptStore — append-only
+│       ├── store/window/    # ContextStore — derived, rewritable
+│       ├── tool/            # ToolExecutor + the Tool registry (fractal, §3)
+│       │   ├── registry.go
+│       │   └── exec/        # first Tool adapter: process execution
+│       ├── approver/proxy/  # Approver — calls back to crab-shell-proxy
+│       └── telemetry/otlp/  # Telemetry
+└── Dockerfile
+```
+
+**AR-1 is enforced by a test, not by intent** — a unit test walks `internal/domain`'s imports
+and fails on anything outside the standard library. `harnesssphere-domain` holds the line with
+two dependencies; Go's stdlib makes zero reachable, so zero is the bar.
+
+**AR-4 is enforced the same way:** no package under `adapter/` may import another package under
+`adapter/`. Both checks are cheap and they are the whole difference between an architecture and
+an adjective.
+
+---
+
+## 2. The domain: five ports
+
+```go
+package domain
+
+// Provider is the LLM. Streaming is not optional — FR-2 is the reason this
+// harness exists in its current shape.
+type Provider interface {
+    Complete(ctx context.Context, req Completion) (Stream, error)
+}
+
+// Stream yields deltas as the provider emits them. Next returns io.EOF when the
+// completion is done; Usage is valid only after that.
+type Stream interface {
+    Next(ctx context.Context) (Delta, error)
+    Usage() Usage
+    Close() error
+}
+
+// TranscriptStore is append-only and complete. It has no Truncate, no Rewrite
+// and no Compact, and that absence is FR-9 expressed as a type.
+type TranscriptStore interface {
+    Append(ctx context.Context, key SessionKey, m Message) error
+    Read(ctx context.Context, key SessionKey) ([]Message, error)
+}
+
+// ContextStore holds the DERIVED window the model actually sees. Rewriting it is
+// normal; it can be rebuilt from the transcript at any time.
+type ContextStore interface {
+    Load(ctx context.Context, key SessionKey) (Window, error)
+    Save(ctx context.Context, key SessionKey, w Window) error
+}
+
+// ToolExecutor runs one tool call. It is a port so the loop never learns how a
+// tool is implemented, and so a denied action (Approver) can be answered with a
+// Result instead of an error.
+type ToolExecutor interface {
+    Available(ctx context.Context) []ToolSchema
+    Invoke(ctx context.Context, call ToolCall) (Result, error)
+}
+
+// Approver decides whether a proposed action may run. FR-7.
+type Approver interface {
+    Request(ctx context.Context, a ActionRequest) (Decision, error)
+}
+
+// Telemetry is a port so the domain and runtime never import OTel. FR-10.
+type Telemetry interface {
+    Span(ctx context.Context, name string, attrs ...Attr) (context.Context, func(error))
+    Usage(ctx context.Context, u Usage, attrs ...Attr)
+}
+```
+
+### The FR-9 invariant is structural
+
+`TranscriptStore` exposes no way to shorten anything. Compaction writes to `ContextStore`,
+a different port with a different file. **It is not possible to truncate the served transcript
+by compacting the context window, because the code that compacts cannot reach it.**
+
+This is the design answer to the measured picoclaw failure — 102 entries in the live file
+against 465 in the proxy's `durable/` fold-forward — and it is what lets `internal/history`'s
+738-line fold-forward retire rather than being reimplemented here.
+
+---
+
+## 2.1 The driving side is a port too — `Ingress`
+
+Added 2026-09-09, when Telegram entered scope: *"fora o http/sse o único conector que você
+precisará é o telegram, que deverá ser um módulo adicional, não instalação nativa."*
+
+Two driving adapters means the driving side cannot be "the HTTP server"; it has to be a port,
+or the second one becomes a special case.
+
+```go
+// domain — a driving port: something that brings turns in.
+type Ingress interface {
+    // Serve runs until ctx is done. It calls the handler once per inbound turn.
+    Serve(ctx context.Context, h TurnHandler) error
+}
+
+type TurnHandler func(ctx context.Context, t Turn, sink Sink) error
+```
+
+`httpsse` implements `Ingress`. So does Telegram. The loop is reached identically by both and
+knows about neither.
+
+**"Módulo adicional, não instalação nativa" is read as: the core binary contains no Telegram
+code and no Telegram dependency.** picoclaw compiles every channel in — Telegram, Discord,
+Slack — and we use one; that is precisely the "installed natively" shape being rejected. So:
+
+```
+crab-ganglion-harness/
+├── go.mod                    # the core: HTTP/SSE only
+└── ingress/telegram/
+    └── go.mod                # its OWN module — separate binary, separate deps
+```
+
+The Telegram binary is a **client of the harness's own HTTP/SSE API**. It is deployable beside
+a container or centrally, carries its own token handling, and cannot bloat the core image
+(AC-3) or its cold start (AC-1).
+
+**DEC-5 — this layout is an interpretation, and it is cheap to reverse.** If deployment wants
+Telegram *inside* the per-user container instead — picoclaw's model, one bot token per user
+written by `internal/docker/provision.go` the way `channel_list` is today — then it becomes a
+second `Ingress` adapter compiled into the core, and the provisioner grows a token sink. The
+port is what makes that a swap rather than a redesign. **Open as DQ-5**; nothing in v1 depends
+on the answer, because v1 ships `httpsse` alone.
+
+---
+
+## 3. Fractal: the tool subsystem repeats the pattern
+
+`ToolExecutor` is one port with one adapter (`tool/registry.go`). Inside it, the same shape
+again:
+
+```go
+// adapter/tool
+type Tool interface {
+    Name() string
+    Schema() domain.ToolSchema
+    Invoke(ctx context.Context, args json.RawMessage) (domain.Result, error)
+}
+```
+
+`registry.go` satisfies `domain.ToolExecutor` by dispatching to one `Tool` per name; `exec/` is
+the first and only `Tool` in v1. Adding `web_fetch` (DF-6) is a new file implementing `Tool` and
+one registration line — it is not a change to the loop, the port, or the registry.
+
+That nesting is what AR-3 means. **A wrapper that introduces no port is a layer, and review
+rejects it.** The provider subsystem repeats the pattern for vendor differences; nothing else
+in v1 has more than one implementation, so nothing else nests.
+
+---
+
+## 4. One turn, end to end
+
+```
+POST /v1/chat/completions  (httpsse)
+  │
+  ├─ Telemetry.Span("turn")
+  ├─ TranscriptStore.Append(user message)        ← durable BEFORE any model call
+  ├─ ContextStore.Load  → Window
+  │
+  └─ runtime.Loop, iteration i < maxIterations:
+       ├─ Provider.Complete(Window + tools)  → Stream
+       ├─ for Delta := range Stream:
+       │     ├─ content  → sink.Content(delta)   → SSE chunk        (FR-2)
+       │     └─ thought  → sink.Progress{thought}                    (FR-4)
+       ├─ Telemetry.Usage(Stream.Usage())                            (FR-8)
+       ├─ TranscriptStore.Append(assistant message)
+       │
+       ├─ if no tool calls → DONE
+       └─ for each ToolCall:
+            ├─ sink.Progress{Kind:"tool", Tool:name}
+            ├─ Approver.Request(...)  ─── if gated ──▶ §5
+            ├─ ToolExecutor.Invoke(...)  (or the denial Result)
+            └─ TranscriptStore.Append(tool result)
+       └─ runtime.compact(Window) if over budget → ContextStore.Save
+```
+
+**The turn ends when the handler returns.** No grace window, no typing heuristic, no
+cancellation dance — the 500ms race in `internal/pico/turn.go` has no analogue here because
+there is no out-of-band signal to interpret.
+
+**The transcript is written before the model is called and after every step.** A crash mid-turn
+loses the answer, never the question.
+
+---
+
+## 5. Approval — the flow that justified the build
+
+```
+runtime                    Approver(adapter)         crab-shell-proxy
+   │                            │                          │
+   ├─ ActionRequest ───────────▶│                          │
+   │  {tool, args, sessionKey}  ├─ POST /alpha/v1/approvals▶│
+   │                            │                          ├─ resolve member (mycelium)
+   │  sink.Progress{placeholder}│                          ├─ ask / apply policy
+   │  every 10s while waiting ◀─┤◀──── Decision ───────────┤
+   │                            │                          │
+   ├─ allowed → ToolExecutor.Invoke
+   └─ denied  → Result{denied, reason} fed back to the loop
+```
+
+Four decisions, each with its reason:
+
+**DEC-1 — The harness never decides who may approve.** It asks; the proxy resolves identity,
+because the proxy is where mycelium's unforgeable account id already lands. The harness has no
+information the proxy lacks and no way to obtain it — the same argument that made
+`GATEWAY_ALLOW_ALL_USERS` correct for Hermes and would make an in-harness policy engine wrong
+here.
+
+**DEC-2 — A denial is a `Result`, not an error.** The agent is told "that was refused, because
+X" and can react — pick another approach, or explain. A denial that aborts the turn throws away
+the work already done and teaches the agent nothing.
+
+**DEC-3 — Waiting emits progress every 10s.** This is not cosmetic. A blocked approval is
+exactly the silent-stream failure `turn-stream-continuity` documents, and an approval can
+legitimately take minutes. Interval matches that spec's FR-3 for the same reason: the tightest
+plausible hop, not the gateway's 60s.
+
+**DEC-4 — Timeout denies, and the timeout is well under the turn timeout.** Fail closed. A
+timed-out approval is a denial with reason `"no answer"`, so DEC-2's path handles it and the
+turn still completes with an explanation instead of hanging until the turn budget dies.
+
+*Which actions are gated is configuration, not code* — the `Approver` adapter is asked for every
+tool call and answers `allow` immediately for anything the policy does not gate, so v1 can ship
+with an empty gate list and the path still exercised.
+
+---
+
+## 6. Proxy integration
+
+The seam is dormant and live; this is where it wakes.
+
+| Change | File | Shape |
+|---|---|---|
+| `HarnessGanglion = "ganglion"` | `internal/config/config.go:45` | new const |
+| Accept it in validation | `internal/config/config.go:445` | new `case` in a switch with one today |
+| Select the runner | `internal/httpapi/handlers.go` | see below |
+| Container profile | `internal/docker/manager.go` | image/port/mount/user/health from a profile |
+| Provisioner | `internal/docker/provision.go` | own template set; generic `dotenv` sink for keys |
+| Approvals endpoint | `internal/httpapi` | new route, DEC-1 |
+| `DisabledAgents` | `internal/config` | restore (FR-18) |
+
+`Server` carries `Pico Turner` today. **Do not rename it and do not build a registry** — add a
+second field and one resolver:
+
+```go
+type Server struct {
+    Pico     Turner  // unchanged
+    Ganglion Turner  // new
+}
+
+func (s *Server) turnerFor(a config.Agent) Turner {
+    if a.Harness == config.HarnessGanglion {
+        return s.Ganglion
+    }
+    return s.Pico
+}
+```
+
+Two harnesses do not justify a map; the third one is when that changes. `internal/pico` is not
+touched (D-3).
+
+---
+
+## 7. Deferred features answer 501 at one place
+
+Each DF-* item is refused by the **proxy**, not by the harness, in the handler that would have
+served it, keyed on `agent.Harness`. The Hermes work did exactly this and the reason holds: a
+feature that stores a setting the harness never reads is worse than one that refuses — the
+member is told it worked.
+
+A single helper keeps the refusals uniform and greppable:
+
+```go
+func requireHarness(a config.Agent, kinds ...string) error // → 501, naming the harness
+```
+
+---
+
+## 8. Build and delivery
+
+- **Static binary, `CGO_ENABLED=0`, distroless or scratch base.** AC-1 (<10s cold start) and
+  AC-3 (<150MB) both fall out of this; the Hermes failures they answer were s6 + Chromium + 71
+  bundled skills, none of which exist here.
+- **No supervisor, no `--init`.** One process, PID 1, signal handling in `main`.
+- **Non-root, uid 1000**, matching what the proxy already chowns per-user volumes to.
+- **Immutable tag (FR-19).** `ghcr.io/lepistabioinformatics/crab-ganglion:<commit-sha>`, and
+  `CRAB_GANGLION_IMAGE` names that sha. Never a moving tag — the three weeks of a wrong picoclaw
+  binary on `srv1519807` is the whole argument, and it cost nothing to avoid at the start.
+
+---
+
+## 9. Testing
+
+The port split is what makes this testable without Docker, and that is most of its value:
+
+- **`domain`** — pure; table tests, no fakes needed.
+- **`runtime`** — the loop against five in-memory fakes. Every interesting case is reachable
+  here: tool call, denial, timeout-denial, compaction boundary, iteration cap, provider error
+  mid-stream. **This is where the coverage lives.**
+- **`adapter/*`** — thin by construction; each tested against its real protocol, none against
+  the loop.
+- **Golden SSE test** — the one integration test that matters, pinning FR-3 byte-compatibility
+  against recorded proxy output. This does not exist for picoclaw either (spec OQ-2), so it is
+  new work, and it is the only thing standing between a harness swap and a silent regression in
+  the webapp.
+
+---
+
+## Open questions for the tasks phase
+
+- **DQ-1** — `Window` rebuild policy: summarize-and-drop, or drop-oldest with a running summary?
+  The measured picoclaw behaviour (102 kept of 465, one merged summary) is a data point, not a
+  target. Affects `runtime/compact.go` only — the port split means getting it wrong is
+  recoverable.
+- **DQ-2** — Does the approvals endpoint (DEC-1) need to survive a proxy restart mid-wait, or is
+  a denial-on-timeout acceptable for v1? DEC-4 says the latter; worth confirming before it is
+  built.
+- **DQ-3** — Module location: third git submodule under `crab/` like both siblings, or a
+  directory in this repo (spec OQ-4). Submodule matches the pattern and adds a pointer to the
+  chain.
+- **DQ-4** — Does `turn.Request` need a field for the approval correlation id, or does
+  `SessionID` + tool call id suffice? Adding a field to the shared struct is seam surgery and
+  should be avoided if the existing pair is enough.
+- **DQ-5** — Telegram placement (DEC-5): separate binary consuming the harness API, or a second
+  `Ingress` compiled in with a per-user bot token provisioned the way picoclaw's `channel_list`
+  is? The first is what v1 assumes; the second matches picoclaw and needs a proxy-side token
+  sink. v1 ships neither, so this can be answered late.

--- a/.specs/features/crab-ganglion-harness/spec.md
+++ b/.specs/features/crab-ganglion-harness/spec.md
@@ -1,6 +1,7 @@
 # crab-ganglion-harness — Spec
 
-**Status:** Specified. Not implemented.
+**Status:** Specified; the proxy side and the harness core are implemented.
+See "Implementation status" below.
 **Date:** 2026-09-09.
 **Spans:** a new module `crab/crab-ganglion-harness` + integration in `crab-shell-proxy`.
 **Feasibility record:** `zombie-crab-project-mkt/.specs/features/own-go-harness/investigation.md`
@@ -275,6 +276,28 @@ before, not after.
   unrun, and it should be run regardless of this spec.
 
 ---
+
+## Implementation status (2026-09-10)
+
+`crab-ganglion-harness` at `2fd0348`; `crab-shell-proxy` on `feat/ganglion-harness`.
+
+| Requirement | State |
+|---|---|
+| FR-1, FR-2, FR-4, FR-5, FR-6, FR-9, FR-12 | **done** in the harness, with tests |
+| FR-7 approval | **harness side done** (port, loop suspension, heartbeat, fail-closed timeout). The proxy endpoint it calls is **not built** — OQ-3 is still open, and v1 ships an empty gate list so the path runs allow-all |
+| FR-8 token accounting | **accumulated and delivered to the port**; the OTLP adapter is a no-op, so nothing leaves the process yet |
+| FR-10 OTLP | **not done** |
+| FR-3 byte-compatibility | plausible, **unverified** — the golden test of OQ-2 does not exist |
+| FR-11 persona | `GANGLION_SYSTEM_FILE` points at the cascade's `AGENT.md`; read per turn |
+| FR-13..FR-17 | **done** — harness kind, second `Turner`, container profile, provisioning, both session headers |
+| FR-18 `DisabledAgents` | **done** — ganglion only; picoclaw deliberately exempt |
+| FR-19 immutable tag | **enforced by absence of a default**: a ganglion agent with no `ganglionImage` fails the load |
+| DF-1..DF-6 | projects and personal models answer **501**; cron and the memory graph are declared in the gate but their handlers are **not yet wired to it** |
+| AC-1, AC-3 | plausible — the binary is 9.6 MB static, no supervisor. **Not measured against a real cold start** |
+| AC-2, AC-4 | not measured; EX-1..EX-4 not started |
+
+**The harness has never spoken to a real provider.** Every provider test is against
+`httptest` with a recorded stream.
 
 ## Traceability
 

--- a/.specs/features/crab-ganglion-harness/spec.md
+++ b/.specs/features/crab-ganglion-harness/spec.md
@@ -1,0 +1,293 @@
+# crab-ganglion-harness — Spec
+
+**Status:** Specified. Not implemented.
+**Date:** 2026-09-09.
+**Spans:** a new module `crab/crab-ganglion-harness` + integration in `crab-shell-proxy`.
+**Feasibility record:** `zombie-crab-project-mkt/.specs/features/own-go-harness/investigation.md`
+(pt-BR, in the parent monorepo). **Read its §2.5 for why this is being built** — this spec does
+not re-argue the case, it states what must be true.
+
+## Problem
+
+The stack's agent runtime is picoclaw, a third party. Five reasons to replace it were audited
+in the investigation and three did not survive: the WebSocket→SSE translation is not what
+degrades the experience, connection cuts are a four-hop problem that lives elsewhere
+(`turn-stream-continuity`), and the context loss was an upstream bug already fixed — delivered
+late only because a mutable image tag was never re-pulled.
+
+What survived is narrower and harder: **two capabilities have no extension point at all.**
+
+- **Approval flows.** Tool execution today is picoclaw's static path guard — binary, defined
+  upstream, with no notion of who the member is. Suspending a turn to ask an approver and
+  resuming lives in `pkg/agent`, which the out-of-tree channel API does not reach.
+- **Token accounting.** Declared permanently unobtainable by this stack's own dashboard:
+  *"picoclaw writes no token counts to disk … It is not coming later."* No per-tenant billing,
+  quota, budget alert or cost attribution is possible while that holds.
+
+Both are design decisions of the agent loop. Owning the loop is the only way to have them.
+
+## Decisions already taken
+
+| # | Decision | Where it was made |
+|---|---|---|
+| D-1 | Name: `crab-ganglion-harness`; harness kind `ganglion`; image `crab-ganglion` | investigation §8.1 |
+| D-2 | **Rewrite**, using picoclaw as a design reference — not a fork, not a vendored copy | investigation OQ-2 |
+| D-3 | **Alternative to picoclaw, not a replacement.** picoclaw stays the default while this stabilizes | user, 2026-09-09 |
+| D-4 | Hexagonal, modular, fractal — modelled on `harness-sphere`'s crate split | user, 2026-09-09 |
+| D-5 | First target is a **new `agents:` entry**, not a flip of an existing one; **same model** (`deepseek-chat`) | user, 2026-09-09 |
+
+**D-5 in full, because it is easy to get wrong.** The deployed config declares exactly **one**
+proxy agent — `zcrab` (`deploy/dokploy/crab-shell-proxy.config.yaml`), which is why the remote
+containers are named `crabshell-zcrab-*`. Setting `harness: ganglion` on `zcrab` would not be
+coexistence; it would be a cutover of the only agent in production, against D-3. So the first
+target is a **second entry** — same `model.provider`/`model.name` (`deepseek`/`deepseek-chat`)
+and same template, differing only in `harness` — so that a comparison between the two isolates
+the harness as the variable.
+
+*Not decided here, and deliberately:* **who is routed to that entry.** `serviceName` matches the
+`x-mycelium-service-name` mycelium injects, so the audience is mycelium routing configuration at
+deploy time, not a requirement of this spec. It becomes a real decision only at EX-1, where the
+exit criterion needs actual traffic to mean anything.
+
+D-2 is the reason D-4 is a requirement and not a preference: approval and token accounting are
+the two things that justified the rewrite, and they are only *design* rather than *surgery* if
+the ports exist to hang them on.
+
+---
+
+## Architecture requirements
+
+**AR-1 — The domain package imports nothing outside the standard library.**
+This is the enforceable form of "hexagonal", and it is checkable in review in a way the word
+is not. The precedent is in-house: `harnesssphere-domain` is *"canonical model, ports and pure
+policies"* and depends on exactly `async-trait` + `thiserror`. The Go equivalent is a domain
+package holding entities, port interfaces and pure policy — no HTTP, no SQL, no Docker, no
+provider SDK, no OTel.
+
+**AR-2 — Five ports, named here so adapters cannot be invented ad hoc.**
+
+| Port | Driven side | First adapter |
+|---|---|---|
+| `Provider` | out | OpenAI-compatible HTTP, streaming |
+| `SessionStore` | out | append-only JSONL on the mounted volume |
+| `ToolExecutor` | out | in-container process execution |
+| `Approver` | out | callback to `crab-shell-proxy` (FR-7) |
+| `Telemetry` | out | OTLP |
+
+The driving side is the HTTP/SSE server, which is an adapter like any other: it depends on the
+domain, never the reverse.
+
+**AR-3 — Fractal: a subsystem with more than one implementation repeats AR-1/AR-2 internally.**
+The tool subsystem defines a `Tool` port with one adapter per tool; the provider subsystem
+defines the vendor differences behind `Provider`. "Fractal" means this nesting, not additional
+layers — a wrapper that adds no port is a layer to reject in review.
+
+**AR-4 — No dependency may cross from an adapter into another adapter.**
+Adapters know the domain and nothing else about each other. This is what keeps a second
+provider, a second store, or a second approval channel from becoming a refactor.
+
+---
+
+## Functional requirements — the harness
+
+### Turn surface
+
+**FR-1 — HTTP with SSE natively; one turn per request.**
+No protocol translation, no WebSocket, no sidecar. The turn ends when the handler returns —
+this is what retires `internal/pico`'s `graceWindow = 500ms`, a heuristic
+`picoclaw-as-library` §5 calls *"tuned rather than solved"*.
+
+**FR-2 — Content is streamed as token-level deltas, as the provider emits them.**
+*Rationale carries an untested assumption, stated so nobody later reads it as verified:*
+`picoclaw-incremental-streaming/investigation.md` §3(a)–(c) has **not been run**, and it might
+show that picoclaw's one-frame behaviour was a config key all along. That would make streaming
+available without this harness. It does not undo D-2 — FR-7 and FR-8 carry the decision and
+neither depends on streaming — but FR-2 must not be cited as a reason this was necessary.
+
+**FR-3 — The wire format is byte-compatible with what the proxy serves today.**
+The webapp and mycelium sit in front; any drift is a user-visible regression. The proxy already
+consumes deltas correctly (`internal/pico/turn.go:179` does cumulative-content bookkeeping per
+`MessageID` and emits only the new suffix), so a delta-emitting harness needs no webapp change.
+Verification is OQ-2 — no golden-response test exists today.
+
+**FR-4 — Progress signals map to the existing `turn.Progress` contract**
+(`Kind` ∈ `thought | tool | placeholder | typing`), from typed in-process calls rather than
+sniffed from a string.
+
+### The loop
+
+**FR-5 — Multi-iteration tool calling**, bounded by an explicit iteration cap that is reported
+when hit. picoclaw's equivalent ended a turn with no answer at all and recorded it only in a
+summary; a turn that stops because it hit the cap must say so.
+
+**FR-6 — Sessions are disk-backed and survive container restart**, in the mounted per-user
+volume. Not in memory, not in a store that resets.
+
+**FR-7 — Approval flow: the loop can suspend mid-turn, ask, and resume.**
+The `Approver` port takes a proposed action and returns allow/deny before the `ToolExecutor`
+runs. The first adapter calls back to `crab-shell-proxy`, which owns member identity — the
+harness never resolves who may approve, it only asks. A denied action returns to the loop as a
+result the agent can react to, not as a turn failure. **This is one of the two capabilities
+that justified the build.**
+
+**FR-8 — Token accounting is emitted per turn.**
+Prompt, completion and total, read from the provider's `usage` field, attributed to the turn
+and available to `Telemetry`. **The second capability that justified the build.**
+
+**FR-9 — Compacting the context window never truncates the served transcript.**
+Two artifacts, not one contested file: the transcript is append-only and complete; the context
+window is derived. This is stated as an invariant because the live evidence is on record —
+`workspace-chat-ux/sk_v1_c2cff018…` held **102** entries in picoclaw's live file against **465**
+unique in the proxy's `durable/` fold-forward, a 363-entry gap caused by compaction rewriting
+the file. Satisfying FR-9 is what retires `internal/history`'s fold-forward (738 LOC).
+
+**FR-10 — Native OTLP telemetry.**
+Spans for the turn, the provider call, and each tool call; token counts from FR-8 as metrics.
+This is what replaces reading session JSONL from disk on a 60s timer — `harness-sphere` keeps
+its multi-tenant discovery and learning metrics, and loses the archaeology.
+
+**FR-11 — Persona and system prompt** are read from the mounted volume, cascading the same way
+the proxy already materializes them.
+
+**FR-12 — `GET /health`** for the proxy's existing `HealthChecker`.
+
+---
+
+## Functional requirements — proxy integration
+
+The seam is dormant but live; the Hermes work paid for it. These are the places it wakes up.
+
+**FR-13 — `HarnessGanglion = "ganglion"`** alongside `HarnessPicoclaw`, and a `case` in the
+validation switch at `internal/config/config.go:445` — which today accepts exactly one value.
+
+**FR-14 — A second `Turner`** (`internal/httpapi/handlers.go:236`), selected by harness kind.
+`internal/pico` stays live and untouched throughout (D-3).
+
+**FR-15 — A container profile** supplying image, port, mount destination, user and health path,
+instead of the `Picoclaw*` constants.
+
+**FR-16 — A provisioner** writing this harness's own config; the generic `dotenv`/`json`/`file`
+secret sinks already cover provider keys, so picoclaw's `native` `.security.yml` sink is simply
+unused.
+
+**FR-17 — `turn.Request.SessionID`, `SessionKey` and `Model` are read.**
+All three are populated and unread today, kept after the Hermes removal because they describe
+the turn rather than the runner. This harness uses them.
+
+**FR-18 — Restore `DisabledAgents`.**
+An agent whose token or provider key is unset removes itself from `cfg.Agents` at `Load` rather
+than failing the whole proxy. Both append sites lived inside `Harness == HarnessHermes` branches
+and died with that removal; `multi-harness-support/implementation-notes.md` §10 recommends
+bringing it back, and a second harness is when it starts mattering again.
+
+**FR-19 — The image is referenced by an immutable tag or digest.**
+Not a moving tag. This is a requirement and not a note because the failure already happened:
+the Dokploy host ran the wrong picoclaw binary for **three weeks** — `0.3.1-glob` republished
+2026-09-06 and never re-pulled, because the harness image is not a compose service and
+`EnsureImage` only pulls what is absent. Nothing logged, nothing drifted, nothing failed. A
+harness of our own under a moving tag reproduces that exactly. See OQ-8 of the investigation;
+fixing the general case is separate work and is **not** blocked by this spec.
+
+---
+
+## Acceptance criteria
+
+Derived from the four reasons the Hermes harness was withdrawn — the only precedent of an
+alternative harness in this deployment, and therefore the bar.
+
+| # | Criterion | Which Hermes failure it answers |
+|---|---|---|
+| AC-1 | Cold start (create → health OK) **< 10s**, inside the global 35s `startupDeadline`, with no per-agent override | 180s vs 35s |
+| AC-2 | First content byte on the SSE **< 5s** on a typical turn | turn latency near the 60s `gatewayTimeout` |
+| AC-3 | Final image **< 150 MB** | heavyweight per-user image |
+| AC-4 | A named exit criterion, met or explicitly extended (see Coexistence) | a second branch no deployment exercised |
+
+**AC-2 is not the whole of the latency problem, and this spec does not claim it is.** Keeping
+the stream from ever going idle is `turn-stream-continuity` Group A, needed whichever harness
+runs. What FR-2 does is shorten the silence at the source rather than fill it with pings.
+
+---
+
+## Deferred — answered `501`, not silently missing
+
+The Hermes work established the pattern: a feature that a harness cannot serve answers `501`
+rather than blocking the launch or, worse, storing a setting that changes nothing. Each of these
+gets a requirement ID so the gap is tracked.
+
+| # | Deferred | Why it is safe to defer |
+|---|---|---|
+| DF-1 | MCP client | no agent in the first target needs it |
+| DF-2 | Memory graph writes | proxy-side `memgraph` is unaffected; the agent simply does not write |
+| DF-3 | Projects (`agents.list` + dispatch) | picoclaw `config.json` constructs; Hermes answered `501` here too |
+| DF-4 | Personal model overrides | same |
+| DF-5 | Scheduled tasks / cron sessions | proxy-side; no harness surface in v1 |
+| DF-6 | Built-in `web_search` / `web_fetch` | first target is tool-light; adding a tool is one `Tool` adapter (AR-3) |
+
+**A deferred feature must answer `501` with the harness named.** Storing a setting that has no
+effect is the failure mode this table exists to prevent.
+
+---
+
+## Out of scope — permanently
+
+Container lifecycle, scale-to-zero, volume provisioning and chown, secrets materialization,
+mycelium identity and authz, the model registry, the admin API (`/alpha/v1/admin/...`),
+memgraph, projects, cron and the MCP server stay in `crab-shell-proxy`. These are done *to* a
+container; a harness inside one has no business starting, stopping or provisioning anything,
+including itself. Measured and argued in `picoclaw-as-library/investigation.md` §4 and it
+applies here unchanged.
+
+---
+
+## Coexistence and exit
+
+D-3 is right and is also how the Hermes harness died — *"a second branch no deployment
+exercised"*. What separates a healthy coexistence from a dead branch is a criterion written
+before, not after.
+
+- **EX-1** — The D-5 agent entry runs on `ganglion` in production and carries real member
+  traffic. Who that is, is the routing decision D-5 leaves open — but "nobody" does not satisfy
+  EX-1.
+- **EX-2** — It carries that traffic for a stated period with AC-1..AC-3 holding.
+- **EX-3** — FR-7 and FR-8 are exercised by that agent, not merely implemented. They are the
+  reasons this exists; an exit that has not used them proves nothing.
+- **EX-4** — Then, and only then, a decision to make `ganglion` the default, or to extend the
+  period with a stated reason, or to withdraw it the way Hermes was withdrawn — with a
+  `DECISION.md`.
+
+`internal/pico` is deleted only after EX-4 chooses "default", never before.
+
+---
+
+## Open questions
+
+- **OQ-1 — RESOLVED (2026-09-09), see D-5.** A new `agents:` entry beside `zcrab`, same model,
+  `harness: ganglion`. Its audience stays a deploy-time routing decision.
+- **OQ-2 — How is FR-3's byte-compatibility verified?** A golden-response test against the
+  current proxy is the obvious answer and does not exist today. Inherited from
+  `picoclaw-as-library` OQ-2, still unanswered.
+- **OQ-3 — What does the `Approver` port's first adapter speak?** FR-7 says it calls back to the
+  proxy; the shape of that call, and what happens when the approver never answers, is design.
+- **OQ-4 — Where does the module live** — a third git submodule under `crab/`, like its two
+  siblings, or a directory in this repo? The two siblings are submodules, which argues for one;
+  a submodule is also a third pointer in the chain to move.
+- **OQ-5 — Does `picoclaw-incremental-streaming` §3(a)–(c) change FR-2's rationale?** Cheap,
+  unrun, and it should be run regardless of this spec.
+
+---
+
+## Traceability
+
+| Requirement | Source | Verified? |
+|---|---|---|
+| FR-1, FR-4 | investigation §2.1, §3.1 | Yes — `turn.Sink` is a delta contract today |
+| FR-2 | investigation §2.1 | **Rationale rests on an unrun test** — OQ-5 |
+| FR-3 | `internal/pico/turn.go:179` | Yes for the consumer; OQ-2 for the format |
+| FR-7, FR-8 | investigation §2.5 A1, A2 | Yes — A2 quoted from the stack's own dashboard |
+| FR-9 | investigation §3.3 | Yes — measured, 102 vs 465 |
+| FR-10 | investigation §2.5 A3, B | Yes — `harness-sphere` is 4,503 LOC of external observation |
+| FR-13..FR-17 | investigation §5 | Yes — every symbol read in the current tree |
+| FR-18 | `multi-harness-support/implementation-notes.md` §10 | Yes |
+| FR-19 | investigation §2.3 field evidence | Yes — confirmed on `srv1519807` |
+| AC-1..AC-4 | `hermes-removal/DECISION.md`, `implementation-notes.md` §4, §9 | Yes |
+| AR-1..AR-4 | `harness-sphere` crate split | Yes — `harnesssphere-domain` deps read |

--- a/.specs/features/ganglion-conversation-metadata/spec.md
+++ b/.specs/features/ganglion-conversation-metadata/spec.md
@@ -1,0 +1,137 @@
+# ganglion-conversation-metadata — Spec
+
+**Status:** Specified. Not implemented.
+**Date:** 2026-09-10.
+**Spans:** `crab/crab-ganglion-harness` (writes), `crab-shell-proxy` (reads),
+`crab/crab-exoskeleton-webapp` (stops owning).
+**Depends on:** `ganglion-scale-to-zero` **H-1**. The proxy cannot read metadata out of a
+ganglion volume it cannot yet read transcripts out of. H-1 pays for both.
+
+## The premise, corrected
+
+The request was *"o proxy é obrigado a armazenar informações parciais como nome e tags dos
+chats … assim o proxy poderia ser simplificado."*
+
+**The proxy stores none of this.** Its only database is `internal/registry` (bbolt: models,
+deprecation, referrers). Conversation metadata lives in the **chat-webapp's Postgres**:
+
+```sql
+conversations      (id, email, instance, title, updated_at, tenant_id,
+                    subs_acc_id, alias, session_key, session_file, project)
+conversation_tags  (conversation_id, name, value, metadata JSONB)
+```
+
+Two consequences that change the shape of the work:
+
+- **The proxy is not simplified by this — it grows.** Something has to read the files, and
+  that something is the proxy. What simplifies is the **webapp**.
+- The single-source-of-truth argument still holds, and it is not theoretical.
+
+## The problem is real and already has a workaround in the tree
+
+`lib/db.ts:149` names it: *"the postgres/picoclaw divergence"*. Rows were created on
+conversation-open with no transcript behind them, and the listing query still carries
+`title <> 'New chat'` to hide them.
+
+That is the whole case in one line: **the metadata and the thing it describes are written
+by different components, at different moments, with no transaction between them.** The
+create-on-open flow was changed to create-on-first-message to narrow the window; the window
+is narrower, not closed, and the workaround is still load-bearing.
+
+A harness that writes the transcript can write its metadata beside it, in the same place,
+and the two cannot disagree.
+
+## The decision that shapes everything
+
+**The harness owns the WRITE. The proxy reads the FILES. No listing ever wakes a
+container.**
+
+This is the only version compatible with `ganglion-scale-to-zero`, and the tension is worth
+stating because the obvious design fails it: if the sidebar asked the container for its
+conversations, opening the webapp would cold-start every one of a member's agents. A cold
+start to render a sidebar is worse than the divergence being fixed.
+
+The pattern is not new — it is exactly how transcripts already reach the proxy.
+
+```
+harness  ──writes──▶  <userDir>/<segment>/sessions/<key>.meta.json
+proxy    ──reads the volume──▶  GET /v1/conversations
+webapp   ──consumes──▶  sidebar
+```
+
+## Requirements
+
+**CM-1 — The harness writes conversation metadata beside the transcript**, in the same
+directory and under the same durability rules as `ganglion-scale-to-zero` D-1 (fsynced
+before the call returns). Title, tags, and updated-at at minimum.
+
+**CM-2 — Metadata is written in the same turn that creates the conversation.**
+No separate upsert, no second component, no window. This is the requirement that closes the
+divergence; everything else here is plumbing.
+
+**CM-3 — The proxy serves the listing by reading the volume**, never by calling a
+container. A stopped agent's conversations list exactly like a running one's.
+
+**CM-4 — A rename reaches the harness's file.**
+Renaming is a member action, so it arrives at the proxy; the proxy must not write the file
+behind the harness's back (that reintroduces two writers). Either the proxy forwards it —
+which wakes the container, acceptable for an explicit user action, unlike a sidebar render
+— or the harness picks up a rename request left for it. **RESOLVED (DQ-1): the proxy
+forwards to the container.** One writer, invariant intact. Waking on an explicit member
+action costs the 0.2s measured in `ganglion-scale-to-zero` SZ-3. Accepted cost: a rename
+fails when the container cannot start — a new failure mode, and an honest one.
+
+**CM-5 — One file per conversation, beside its transcript. No index.**
+Measured 2026-09-10 on the NVMe volume: listing **600 conversations by opening 600 files
+costs 3.0ms**; a single index file costs 1.4ms. The index saves 1.6ms and reintroduces a
+reconciliation problem *inside* the harness — two representations of the same fact, which
+is precisely what this feature exists to eliminate. Trading the invariant for 1.6ms is a
+bad trade, and it would be a bad trade at ten times the difference.
+
+**CM-6 — Existing Postgres rows are migrated, not stranded.**
+Members have renamed conversations; those titles are real data. A one-time import from
+`conversations`/`conversation_tags` into the harness files, keyed by `session_key`, runs
+before the webapp stops reading its own table.
+
+**CM-7 — Picoclaw agents are unaffected.**
+This is a ganglion capability. A picoclaw conversation keeps its Postgres row, and the
+webapp keeps reading it for those agents. The two paths coexist until picoclaw is retired
+or grows the same file, which is not this work.
+
+**CM-8 — The webapp stops being the source of truth for ganglion conversations**, and its
+`title <> 'New chat'` workaround is removed for them. Keeping the filter for picoclaw rows
+is fine; keeping it for ganglion would mean the divergence it guards against still exists.
+
+## Out of scope
+
+- **Retiring the `conversations` table.** It still serves picoclaw agents (CM-7) and holds
+  `project`, which is a proxy/webapp concept the ganglion answers 501 for (DF-3).
+- **Making picoclaw write its own metadata.** It has no seam for it; that is the ownership
+  problem the whole harness exists to escape.
+- **Tags as a member-facing feature.** This moves where tags live. It does not add UI.
+
+## Acceptance
+
+| # | Criterion |
+|---|---|
+| AC-1 | A new ganglion conversation appears in the sidebar with its title, and the title came from the harness's file |
+| AC-2 | Listing a member's conversations does not start any stopped container — asserted, not observed by eye |
+| AC-3 | A conversation cannot exist in the listing without a transcript, and vice versa, with no title filter hiding the difference |
+| AC-4 | Renamed titles from Postgres survive the migration |
+| AC-5 | Picoclaw conversations list and rename exactly as before |
+
+## Questions closed on 2026-09-10
+
+- **DQ-1 — RESOLVED: the proxy forwards a rename to the container.** See CM-4. One writer
+  keeps the invariant this feature exists for; the 0.2s wake is acceptable on an explicit
+  member action, unlike a sidebar render. The rejected alternative — a request file the
+  harness consumes later — never fails and never wakes anything, but it puts a second
+  writer in the directory and leaves the member staring at an unchanged title until the
+  agent next runs.
+
+- **DQ-2 — RESOLVED: one file per conversation.** See CM-5, with the measurement.
+
+- **DQ-3 — RESOLVED: the proxy is read-only against these files, and that is an
+  invariant, not an implementation detail.** It follows from DQ-1 and is worth stating as
+  a rule because the cheap shortcut — having the proxy write the file directly — is
+  exactly the two-writer divergence this feature removes, reproduced in a new medium.

--- a/.specs/features/ganglion-scale-to-zero/design.md
+++ b/.specs/features/ganglion-scale-to-zero/design.md
@@ -1,0 +1,127 @@
+# ganglion-scale-to-zero — Design
+
+**Status:** Designed. Date: 2026-09-10. Reads `spec.md`.
+
+Only D-2/D-3 need designing. The rest is mechanical: `fsync` is one call, the path move is
+one constant, the cron gate is one predicate.
+
+## D-2/D-3 — the partial answer, without breaking anything that reads the transcript
+
+Two constraints fight each other:
+
+- **FR-9 / `TranscriptStore` has no Truncate, no Rewrite.** That absence is the invariant
+  that made compaction unable to shorten the served transcript. Checkpointing must not
+  introduce a way to rewrite the file.
+- **H-2 — `internal/history`'s existing parser must not see garbage.** It reads every
+  JSONL line as a message. Marking partials with a new field would make an old reader
+  render every checkpoint as a separate assistant message: the answer repeated ten times,
+  growing.
+
+### Rejected: partial entries in the JSONL
+
+`{"role":"assistant","content":"...","partial":true}` appended per checkpoint, with the
+reader filtering. It fails H-2 outright — `internal/history` does not know the field and
+would show every checkpoint. It also needs a turn id to correlate, and it puts
+soon-to-be-garbage in an append-only file that nothing may compact.
+
+### Chosen: a sidecar file, overwritten atomically
+
+```
+<segment>/sessions/<key>.jsonl          the transcript, append-only, unchanged
+<segment>/sessions/<key>.partial.json   the in-flight answer, rewritten per checkpoint
+```
+
+- Every ≤2s of streaming, the accumulated text is written to the sidecar with
+  `os.CreateTemp` + `Sync` + `Rename` — the same atomic dance `store/window` already uses.
+- When the turn completes, the assistant message is appended to the JSONL (fsynced), and
+  **then** the sidecar is removed.
+- The JSONL is byte-identical to what it is today. **H-2 is satisfied by construction, not
+  by a parser change** — an old reader never opens the sidecar.
+- Rewriting the sidecar is fine: it is derived, like the window. The append-only invariant
+  is untouched because the sidecar is not the transcript.
+
+### Supersession without a turn id
+
+The crash window that matters is between "append the final message" and "remove the
+sidecar" — there, both exist and a naive reader would show the answer twice.
+
+No new id is needed. The sidecar records `answers_at`: the `created_at` of the user
+message this turn is answering, which is already written before the provider is called.
+
+```
+fold rule: a sidecar is LIVE only if the transcript holds no assistant
+           message with created_at >= answers_at.
+           Otherwise the turn finished and the sidecar is stale.
+```
+
+Both cases are then correct:
+- crash mid-stream → no assistant message after `answers_at` → the sidecar is the answer
+- crash after append, before remove → an assistant message exists → sidecar ignored
+
+### Who folds, and when
+
+**The reader folds; it does not write.** The proxy, serving history, reads the sidecar and
+appends it as one interrupted assistant message when the rule says it is live.
+
+This is deliberate and it is what keeps two invariants at once:
+
+- the proxy stays **read-only** against the harness's directory
+  (`ganglion-conversation-metadata` DQ-3), and
+- recovery is **immediate** — a member who reloads after a crash sees what they lost,
+  rather than waiting for the next turn to trigger a fold.
+
+The harness removes a stale sidecar on its next start, as housekeeping. Nothing depends on
+that happening promptly.
+
+### Why this does not contradict OQ-2 ("recovery only")
+
+The fold rule keys on *the transcript*, not on liveness of a process. While a turn is
+streaming, the harness holds the answer and the proxy is streaming it — the sidecar exists
+but no reader consults it, because a live turn's reader is the stream. A reader that opens
+the history mid-turn will see the sidecar as live and show it, which is the one case OQ-2
+chose to keep simple. Accepted: it shows *less* than the stream, never something wrong.
+
+## D-1 — fsync
+
+`Store.Append` gains `f.Sync()` before `Close`. Measured 887µs on the deployment's volume;
+three per turn. No batching (spec OQ-1).
+
+`Store.Read` is unchanged.
+
+## D-5 — checkpointing must not stall the stream
+
+The checkpoint runs from the loop, between deltas, not from a goroutine racing the writer:
+a 887µs write every 2 seconds of streaming is 0.04% of that window, so there is nothing to
+parallelise and a second writer would need a lock around the sidecar for no gain.
+
+The rule is a time check on the delta path — `if now.Sub(lastCheckpoint) >= 2s` — so a fast
+stream checkpoints on a wall clock, not per token.
+
+## H-1 — the path
+
+The harness writes `<GANGLION_DATA_DIR>/sessions/`; the proxy reads
+`<userDir>/<segment>/sessions/`. The mount already puts `<userDir>` at
+`GANGLION_DATA_DIR`, so the fix is for the harness to write one level deeper, under the
+`workspace` segment the proxy's `MainWorkspace` already names.
+
+One constant in the composition root. No proxy change (spec H-1's preferred fix).
+
+## SZ-2 — the cron gate
+
+`requireHarnessFeature` already exists and gates by harness. Cron is not a harness property
+— it is a **mode** property, because a stopped container fires no timers whatever runtime
+is inside it. So the gate grows a mode-keyed sibling rather than a new entry in
+`picoclawOnly`:
+
+```go
+func requireContinuousMode(w http.ResponseWriter, a config.Agent, f harnessFeature) bool
+```
+
+Applied at the cron handlers' caller resolver, the same one-chokepoint shape used for
+projects and personal models. It refuses a scale-to-zero picoclaw agent too; none exists
+today, and the property is about the mode.
+
+## Order
+
+H-1 first — it is the prerequisite for both this feature and
+`ganglion-conversation-metadata`, and it is a constant.

--- a/.specs/features/ganglion-scale-to-zero/spec.md
+++ b/.specs/features/ganglion-scale-to-zero/spec.md
@@ -1,0 +1,193 @@
+# ganglion-scale-to-zero — Spec
+
+**Status:** Specified. Not implemented.
+**Date:** 2026-09-10.
+**Spans:** `crab/crab-ganglion-harness` (durability, startup) + `crab-shell-proxy`
+(cron gating, transcript path).
+**Builds on:** `.specs/features/crab-ganglion-harness/spec.md` — read its FR-6 and FR-9
+first; this feature is what makes them survive a stop.
+
+## Problem
+
+Both picoclaw agents in this deployment run `mode: continuous`, for two stated reasons.
+Only one of them still holds.
+
+**"picoclaw loses its memory on a stop" — obsolete.** `internal/history/history.go:96`
+carries a correction dated 2026-08-28: *"v0.3.1 runs the JSONL store by default … and
+`JSONLStore.GetHistory` re-reads the session file on every call — so a restart no longer
+costs the agent its history."* The comment in `crab/crab-shell-proxy/config.yaml` still
+states the old behaviour and is stale. This is the third stale-comment finding in this
+area; it is not evidence that picoclaw should switch, but it removes this reason.
+
+**"scheduled tasks need the container alive" — holds.** picoclaw's cron service keeps its
+schedule **in memory** (`internal/cron/cron.go`: *"picoclaw creates, schedules and deletes
+jobs, and holds the live schedule in memory"*). A stopped container fires nothing. Any
+harness with in-process timers has the same property.
+
+`continuous` costs a container per member, running permanently, whether or not anyone is
+talking to it. Scale-to-zero is what the per-user-container model is supposed to afford,
+and the ganglion is the harness where it can be made safe by design rather than worked
+around.
+
+## What is already true, and what is not
+
+Verified in the current tree, so the work is scoped to the gap and not to what already
+works:
+
+| | State |
+|---|---|
+| `ArmIdle` after every turn | **Works, harness-agnostic** (`handlers.go:766`, `sse.go:318`) — it keys on `agent.Mode`, not on the harness |
+| Idle timer disarmed during a turn | Works — a scale-to-zero stop cannot fire mid-turn |
+| Ganglion cold start | **0.18-0.23s** to health, measured (SZ-3). 21.6MB static binary, no supervisor |
+| Transcript durability | **Gap** — see below |
+| Partial answer during a turn | **Gap** — nothing is written until the stream closes |
+| Proxy reading ganglion transcripts | **Broken** — path mismatch, see H-1 |
+| Cron gated by mode | **Does not exist** |
+
+### The durability gap, stated precisely
+
+`internal/adapter/store/jsonl` does `OpenFile(O_APPEND) → Write → Close` per message, with
+no `fsync`. Being exact about what that costs, because the common claim is too strong:
+**killing the process or the container loses nothing** — the page cache is the kernel's,
+and it outlives the process. `docker stop`, which is what scale-to-zero issues, is
+therefore already safe today. What is lost is the last writes on a **host** crash or power
+loss.
+
+The larger gap is different and it is not about `fsync`: **a turn's answer is written only
+when the stream closes.** A turn interrupted at 59 of 60 seconds loses everything the
+member watched appear on screen, keeping only their question.
+
+---
+
+## Requirements
+
+### Mode
+
+**SZ-1 — A ganglion agent runs in `scale-to-zero` and the deployment may set it.**
+No code change is expected here (`ArmIdle` is already harness-agnostic); the requirement
+exists so the claim is tested rather than assumed.
+
+**SZ-2 — A scale-to-zero agent still LISTS its scheduled tasks, and is told they will
+not fire.**
+
+*Rewritten 2026-09-10, after the first version was implemented and a pre-existing test
+refused it.* The original read: "scheduled tasks are offered ONLY on an agent whose mode
+is `continuous`", with `/v1/cron/*` answering 501. That was aimed at the wrong surface,
+for two reasons the tree already knew:
+
+- **The routes are read-only and need no container.** `internal/cron` "exposes no
+  writer"; the proxy reads `jobs.json` off the volume. There is no create endpoint — the
+  agent makes tasks from inside a conversation, and the proxy never sees it happen. So a
+  501 here prevents nothing.
+- **`cron.go` had already decided that hiding is worse.** Its own comment: *"A job the
+  member cannot see is a job they cannot stop."* On a scale-to-zero agent the tasks are
+  real, listed, and inert; refusing the list leaves the member unable to act on schedules
+  that exist.
+
+What the mode genuinely breaks is the **firing**, and no response code at this endpoint
+fixes that. So the listing reports it: `cronTasksResponse.Fires` is false on a
+scale-to-zero agent, whatever its harness. The member sees their tasks and sees that they
+are not running.
+
+**SZ-3 — Cold start to health-ready is under 1s**, and it is **measured, not asserted**.
+
+Measured 2026-09-10 on the deployment's own NVMe volume, `docker run` to a 200 from
+`/health`, three runs: **0.18s, 0.20s, 0.23s**. The budget is set at 1s — 5x headroom over
+the measurement — rather than at the 3s this requirement originally carried, because a
+budget fifteen times looser than the observed value is not a budget.
+
+For scale, the Hermes harness took **180s** and that is what withdrew it. The difference is
+a static Go binary with no supervisor and no bundled runtime.
+
+### Durability
+
+**D-1 — Every transcript append is `fsync`ed before the call returns.**
+Three per ordinary turn (question, answer, tool result); one LLM call costs seconds, so
+the cost is not observable. This is what makes a host crash lose nothing already
+acknowledged.
+
+**D-2 — A turn's partial answer is checkpointed while it streams.**
+At most every 2 seconds of streaming, the text produced so far is written durably. A turn
+interrupted mid-stream keeps what the member already saw.
+
+**D-3 — A checkpoint is superseded, never duplicated.**
+The final assistant message replaces its checkpoints. A reader must never show the same
+answer twice, and must never show a stale partial next to the complete one. This is the
+requirement that makes D-2 safe rather than merely well-intentioned; how it is achieved is
+design.
+
+**D-4 — A crash between the transcript write and the window write is recoverable.**
+Already true by construction — the window is derived and rebuildable from the transcript —
+but it becomes load-bearing once stops are routine, so it gets a test.
+
+**D-5 — Nothing in D-1..D-3 may block the stream to the member.**
+Durability is on the turn's critical path for correctness, not for latency: a checkpoint
+that stalls delivery trades a visible problem for an invisible one.
+
+### History
+
+**H-1 — The proxy can read a ganglion agent's transcript.**
+Today it cannot, and the durability work is pointless without it:
+
+```
+proxy reads:      <userDir>/<segment>/sessions/      (config.SessionsDir)
+ganglion writes:  <userDir>/sessions/                (GANGLION_DATA_DIR + /sessions)
+```
+
+Reloading a gamma conversation returns an empty history. **Preferred fix: the ganglion
+writes where the proxy already reads** — zero proxy change, and it keeps one path
+convention across harnesses. The alternative (teach the proxy a per-harness path) is more
+code for no gain, and is rejected unless the design finds a reason.
+
+**H-2 — The transcript stays readable by `internal/history`'s existing parser.**
+The ganglion already writes picoclaw's on-disk vocabulary (`role`, `content`,
+`reasoning_content`, `created_at`) for exactly this reason. D-2's checkpoints must not
+break that parser — a reader that predates checkpoints must not crash or show garbage.
+
+---
+
+## Out of scope
+
+- **Switching picoclaw agents to scale-to-zero.** The reason to keep them continuous is
+  gone (see Problem), but picoclaw is what production runs and the change is not needed by
+  this work. Worth its own ticket, with the stale `config.yaml` comment fixed alongside.
+- **Making cron work without a live container.** A durable scheduler that survives
+  scale-to-zero is a real feature and a different one; SZ-2 reports that schedules are
+  inert rather than reimplementing them.
+- **Per-turn model selection, MCP, projects, memory graph** — still DF-1..DF-6.
+
+## Acceptance
+
+| # | Criterion |
+|---|---|
+| AC-1 | A ganglion agent set to `scale-to-zero` answers a turn, is stopped after idle, and answers the next turn with its history intact |
+| AC-2 | Cold start to health-ready **< 1s**, recorded by a test (measured 0.2s) |
+| AC-3 | `/v1/cron/*` LISTS tasks on a scale-to-zero agent with `fires:false`; unchanged, with `fires:true`, on a continuous one |
+| AC-4 | A turn killed mid-stream leaves the partial answer in the transcript, and the next read shows it once |
+| AC-5 | Reloading a ganglion conversation in the webapp shows the transcript |
+
+## Open questions
+
+All three were closed on 2026-09-10; kept with their answers because the numbers are the
+argument.
+
+- **OQ-1 — RESOLVED: no batching.** Measured on the NVMe volume the containers mount:
+  `fsync` costs **887µs** per append (18µs without). Three per ordinary turn is **2.7ms**;
+  a 60-second turn checkpointing every 2s is 30 syncs, **27ms**. Against 1.9–4.0s to the
+  first token alone that is under 0.1%. Batching would be optimising something no member
+  can perceive, at the cost of the guarantee it exists to provide.
+
+  *(Measured at 4.79ms on `/tmp` first — that is the root ext4 volume, not where the data
+  lives. Worth repeating on the Dokploy host before trusting it there.)*
+
+- **OQ-2 — RESOLVED: recovery only.** A checkpoint is written but ordinary readers ignore
+  it while the turn is alive; it becomes visible only when the turn did not finish. The
+  rule that buys is simple — **a live turn has exactly one owner, the stream** — and it
+  keeps this feature out of the way of `turn-stream-continuity`'s re-attach, which is the
+  feature that actually owns "I reloaded mid-turn". Accepted cost: until re-attach ships,
+  a reload during a turn shows less than the stream was showing.
+
+- **OQ-3 — RESOLVED: 120s.** picoclaw's 15m exists because its cold start was expensive;
+  SZ-3 measures the ganglion's at **0.2s**, so that reason is gone. Two minutes is short
+  enough for scale-to-zero to be worth having and long enough not to recreate a container
+  between two messages of one conversation.

--- a/deploy/observability/otel-collector-config.yaml
+++ b/deploy/observability/otel-collector-config.yaml
@@ -11,6 +11,16 @@ receivers:
     protocols:
       grpc:
         endpoint: 0.0.0.0:4317
+      # HTTP, for crab-ganglion-harness.
+      #
+      # It speaks OTLP/HTTP with JSON encoding, which the OTLP spec defines and
+      # this receiver accepts, because that is implementable with the Go
+      # standard library alone. The harness has ZERO third-party dependencies
+      # and the gRPC SDK would be its first -- a large tree, in an image pulled
+      # per user, to emit a token count. The receiver already listens here; the
+      # protocol was simply not declared.
+      http:
+        endpoint: 0.0.0.0:4318
 
 processors:
   batch:

--- a/deploy/standalone/config.standalone.toml
+++ b/deploy/standalone/config.standalone.toml
@@ -418,6 +418,268 @@ secretName = "alpha-authorization-header"
 acceptInsecureRouting = true
 methods = ["GET", "POST", "PUT", "DELETE"]
 
+# ------------------------------------------------------------------------------
+# gamma -- the SECOND HARNESS (crab-ganglion-harness), not picoclaw.
+#
+# Identical routing to alpha on purpose: same host, same paths, same role
+# shape. The ONLY difference is which runtime answers behind crab-shell-proxy,
+# which is what makes a side-by-side comparison mean something (spec D-5).
+#
+# Its agent entry in crab/crab-shell-proxy/config.yaml carries
+# `harness: ganglion` and the same deepseek/deepseek-chat model as alpha, so
+# the harness is the only variable.
+#
+# STILL MANUAL, and nothing here can do it: an account must hold the "gamma"
+# guest-role. The role auto-creates at boot from this declaration, but the
+# Staff -> tenant -> subscription -> guest-invite chain that GRANTS it is a
+# human action -- until then every request 403s. Same as alpha and beta.
+#
+# Some of these paths are refused by the proxy for this harness with 501
+# (projects, personal models -- see the DF-* table in the product repo's
+# .specs/features/crab-ganglion-harness/spec.md). They are declared anyway so
+# the refusal comes from the proxy, which names the harness, rather than from
+# the gateway as a 404 that names nothing.
+# ------------------------------------------------------------------------------
+
+[[gamma]]
+# NOT `proxyAddress`: that field means "route through this generic
+# forward-proxy" (mycelium embeds the real target URL as a path suffix on
+# it -- see Service::proxy_address's own doc comment and
+# ports/api/src/router/initialize_downstream_request.rs), a different
+# concept from "this is my sidecar, send requests to it directly".
+# crab-shell-proxy is a plain HTTP service (not a path-embedding forward
+# proxy), so it must be `host`, not `proxyAddress` -- confirmed empirically:
+# `proxyAddress` produced "invalid format" 500s on every
+# /v1/chat/completions call.
+host = "crab-shell-proxy:8080"
+protocol = "http"
+healthCheckPath = "/healthz"
+discoverable = true
+serviceType = "rest-api"
+isContextApi = false
+openapiPath = "/doc/openapi.json"
+capabilities = ["chat"]
+description = "crab-ganglion-harness agent 'gamma' - an OpenAI-compatible personal chat agent. Each user gets an isolated container; send chat via POST /v1/chat/completions."
+
+[[gamma.secret]]
+name = "gamma-authorization-header"
+authorizationHeader = { headerName = "Authorization", prefix = "Bearer", token = { env = "MYC_GANGLION_TOKEN" } }
+
+[[gamma.path]]
+group = { protectedByRoles = [{ name = "gamma", permission = "write" }] }
+path = "/v1/chat/completions"
+secretName = "gamma-authorization-header"
+acceptInsecureRouting = true
+methods = ["POST"]
+
+[[gamma.path]]
+group = { protectedByRoles = [{ name = "gamma" }] }
+path = "/v1/models"
+secretName = "gamma-authorization-header"
+acceptInsecureRouting = true
+methods = ["GET"]
+
+[[gamma.path]]
+# user-owned-models: a member registering their own model, testing it, and
+# choosing between it and the one their administrator provides.
+#
+# ONE wildcard block (mycelium matches with the wildmatch crate, so `*` spans
+# `mine`, `mine/test` and `mine/selection`), gated on the role NAME only —
+# /v1/models above already has its own block, so there is no route conflict.
+# GET needs only read; every mutation must require write, and that is enforced
+# in-proxy by the same profile chain /v1/secrets uses.
+#
+# A personal model IS a picoclaw model_list entry, written into the user's
+# config.json — so this route only means anything for an agent that reads it.
+group = { protectedByRoles = [{ name = "gamma" }] }
+path = "/v1/models/*"
+secretName = "gamma-authorization-header"
+acceptInsecureRouting = true
+methods = ["GET", "POST", "PUT", "DELETE"]
+
+[[gamma.path]]
+group = { protectedByRoles = [{ name = "gamma" }] }
+path = "/v1/sessions/history"
+secretName = "gamma-authorization-header"
+acceptInsecureRouting = true
+methods = ["GET"]
+
+[[gamma.path]]
+# Session linkage (conversation-enrichment feature): resolves the sessionKey +
+# picoclaw on-disk file basename for a conversation. Read-only metadata, gated
+# like /v1/sessions/history (role name, no write permission).
+group = { protectedByRoles = [{ name = "gamma" }] }
+path = "/v1/sessions/resolve"
+secretName = "gamma-authorization-header"
+acceptInsecureRouting = true
+methods = ["GET"]
+
+[[gamma.path]]
+# Discovery (workspace-selection feature) is agent-agnostic: it returns ALL of
+# the caller's licensed subscriptions (across roles), and the client must reach
+# it BEFORE it knows which role it holds -- so it is `protected` (any resolvable
+# member), NOT role-gated. The proxy ignores the injected service-name here and
+# returns only the caller's own licensed_resources. Registered under both agents
+# for symmetry; either works for any member.
+group = "protected"
+path = "/v1/subscriptions"
+secretName = "gamma-authorization-header"
+acceptInsecureRouting = true
+methods = ["GET"]
+
+[[gamma.path]]
+# Secret injection (agent-customization feature): per-(user, agent), role-gated
+# with write (injecting is a write; GET/DELETE also gated the same, a member only
+# ever touches their own store). Values are write-only over the API.
+group = { protectedByRoles = [{ name = "gamma", permission = "write" }] }
+path = "/v1/secrets"
+secretName = "gamma-authorization-header"
+acceptInsecureRouting = true
+methods = ["GET", "POST", "DELETE"]
+
+[[gamma.path]]
+# Media upload (media-upload feature): stores a file in the caller's workspace,
+# role-gated with write (same chain as chat). POST multipart only.
+group = { protectedByRoles = [{ name = "gamma", permission = "write" }] }
+path = "/v1/media"
+secretName = "gamma-authorization-header"
+acceptInsecureRouting = true
+methods = ["GET", "POST", "DELETE"]
+
+[[gamma.path]]
+# Uploads-tree organisation (create folder, move/rename, delete folder). ONE
+# wildcard block: `*` matches the following segment, and /v1/media itself already
+# has its own block above, so there is no "Multiple routes found" conflict.
+#
+# Same write gate as /v1/media, because these write into the same directory an
+# upload does. DELETE here is a RECURSIVE folder delete — the proxy refuses the
+# uploads root, and the interface names the file count before the member confirms.
+group = { protectedByRoles = [{ name = "gamma", permission = "write" }] }
+path = "/v1/media/*"
+secretName = "gamma-authorization-header"
+acceptInsecureRouting = true
+methods = ["POST", "DELETE"]
+
+[[gamma.path]]
+# Projects (agent-projects): a member carving their own agent into Claude-style
+# projects, each backed by its own picoclaw agent, workspace and AGENT.md.
+#
+# ONE block per path shape, gated on the role NAME only, because the gateway
+# matches routes by path alone and rejects two blocks sharing one path -- the
+# same constraint /v1/restart documents. GET needs only read; POST must require
+# write, and that is enforced in-proxy by the same profile chain /v1/secrets
+# uses. A read-only member reaching a mutation gets a 403 there.
+#
+# A project IS a picoclaw agents.list entry plus a dispatch rule, written into
+# the user's config.json — so this route only means anything for an agent that
+# reads it.
+group = { protectedByRoles = [{ name = "gamma" }] }
+path = "/v1/projects"
+secretName = "gamma-authorization-header"
+acceptInsecureRouting = true
+methods = ["GET", "POST"]
+
+[[gamma.path]]
+# Per-project mutations: /v1/projects/<id>. Wildcard because the id is a path
+# segment, mirroring /v1/media/* and /v1/memory-graph/*.
+group = { protectedByRoles = [{ name = "gamma" }] }
+path = "/v1/projects/*"
+secretName = "gamma-authorization-header"
+acceptInsecureRouting = true
+methods = ["PATCH", "DELETE"]
+
+[[gamma.path]]
+# Workspace memory (conversation-enrichment): the user edits MEMORY_CUSTOM.md at
+# the workspace root, write-gated like /v1/media. GET reads it, PUT replaces it.
+group = { protectedByRoles = [{ name = "gamma", permission = "write" }] }
+path = "/v1/memory"
+secretName = "gamma-authorization-header"
+acceptInsecureRouting = true
+methods = ["GET", "PUT"]
+
+[[gamma.path]]
+# Knowledge-graph memory (memory-graph-mcp): READ-ONLY views of the graph the
+# agent builds through its own native MCP server inside crab-shell-proxy.
+#
+# TWO blocks: mycelium's `*` matches a following segment, so it covers
+# /nodes, /search and /recent but not the bare /v1/memory-graph.
+#
+# Gated `write` like /v1/memory even though every method here is GET. The proxy
+# authorizes these with authorizeSecret -- the same write-access chain -- so a
+# read-only member is refused in-proxy regardless; gating lower here would only
+# move the 403 from the gateway to the proxy.
+#
+# There is deliberately NO /v1/mcp route: the agent reaches that endpoint
+# directly on the container network, never through the gateway.
+path = "/v1/memory-graph"
+group = { protectedByRoles = [{ name = "gamma", permission = "write" }] }
+secretName = "gamma-authorization-header"
+acceptInsecureRouting = true
+methods = ["GET"]
+
+[[gamma.path]]
+path = "/v1/memory-graph/*"
+group = { protectedByRoles = [{ name = "gamma", permission = "write" }] }
+secretName = "gamma-authorization-header"
+acceptInsecureRouting = true
+methods = ["GET"]
+
+[[gamma.path]]
+# Self-service restart (restart-control): GET reports whether this member's
+# instance still needs a bounce (and when an admin scheduled one); POST performs
+# it for the caller's OWN container only.
+#
+# ONE block covering both methods, gated on the role NAME (read), even though
+# POST must require write. The gateway matches routes by path alone and errors
+# with "Multiple routes found for the specified path" when two blocks share one
+# path -- so GET and POST cannot be gated differently here. The write requirement
+# for POST is enforced in-proxy instead, by the same profile chain /v1/secrets
+# uses; a read-only member reaching POST gets a 403 from the proxy.
+group = { protectedByRoles = [{ name = "gamma" }] }
+path = "/v1/restart"
+secretName = "gamma-authorization-header"
+acceptInsecureRouting = true
+methods = ["GET", "POST"]
+
+[[gamma.path]]
+# Scheduled tasks (scheduled-tasks): READ-ONLY views of picoclaw's own cron jobs
+# and the per-run transcripts each execution leaves in the sessions dir.
+#
+# ONE wildcard block: mycelium's `*` matches the following segment, which covers
+# both /v1/cron/tasks and /v1/cron/runs. There is deliberately no bare /v1/cron
+# route, because the proxy exposes none — so no "Multiple routes found" conflict.
+#
+# Gated on the role NAME (read), matching /v1/restart: the proxy authorizes these
+# with its read chain, so a member holding only read on the agent can still see
+# what is scheduled and what it produced.
+#
+# GET only, and that is the whole surface: nothing here writes the job store.
+# picoclaw holds the live schedule in memory, so an externally edited store could
+# silently disagree with the timers actually running.
+group = { protectedByRoles = [{ name = "gamma" }] }
+path = "/v1/cron/*"
+secretName = "gamma-authorization-header"
+acceptInsecureRouting = true
+methods = ["GET"]
+
+# admin-shared-content (admin-shared-content feature): hierarchical
+# authority-over-target ops. Registered as `protected` (any resolvable member) —
+# NOT role-gated — because the caller's ADMIN tier (tenant/subscription/instance)
+# is resolved in-proxy from the injected profile, not from a guest role. The
+# secretName injects the bearer token so the proxy's resolveAgent anti-bypass
+# still applies. There is deliberately NO /v1/admin/users/files/content route and
+# no user-file write route (FR-7 privacy invariant).
+
+[[gamma.path]]
+# All /v1/admin/* endpoints share group=protected + this secret; the
+# proxy enforces the exact path+method per route. Collapsed to one
+# wildcard (mycelium matches via the wildmatch crate).
+group = "protected"
+path = "/v1/admin/*"
+secretName = "gamma-authorization-header"
+acceptInsecureRouting = true
+methods = ["GET", "POST", "PUT", "DELETE"]
+
 [[beta]]
 host = "crab-shell-proxy:8080"
 protocol = "http"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -171,6 +171,20 @@ services:
       # Set it back to docker.io/sipeed/picoclaw:latest to run stock picoclaw
       # (projects stop working; nothing else changes).
       CRAB_PICOCLAW_IMAGE: ${CRAB_PICOCLAW_IMAGE:-zombie-crab/picoclaw:0.3.1-glob}
+      # Imagem do segundo harness (crab-ganglion-harness), com o MESMO padrão de
+      # fallback que CRAB_PICOCLAW_IMAGE acima: default para a build local.
+      #
+      # O `:-` substitui quando a variável está ausente OU VAZIA, e isso importa
+      # aqui: o Compose dá precedência ao ambiente do shell sobre o .env, e uma
+      # variável exportada vazia conta como definida. Sem o default, um
+      # `export CRAB_GANGLION_IMAGE=` esquecido num terminal vence um .env
+      # correto e o agente se desabilita sem causa visível de dentro do container.
+      #
+      # Isto vale só para o compose de DESENVOLVIMENTO. O deploy do dokploy
+      # continua sem default, e o proxy também: lá a referência tem que ser uma
+      # decisão explícita e imutável, porque uma tag móvel já deixou aquele host
+      # três semanas com o binário errado.
+      CRAB_GANGLION_IMAGE: ${CRAB_GANGLION_IMAGE:-zombie-crab/crab-ganglion:dev}
       # Shared secret authenticating POST /v1/accounts (the mycelium
       # subscriptionAccount.created webhook). Register the webhook in mycelium
       # with an Authorization: Bearer <this> header -- see README/STATE.
@@ -208,6 +222,16 @@ services:
       # model.apiKeyEnv). Real values live only in .env (gitignored) or your
       # secrets manager -- never in config.yaml or the image.
       PICOCLAW_ALPHA_API_KEY: ${PICOCLAW_ALPHA_API_KEY}
+      MYC_GANGLION_TOKEN: ${MYC_GANGLION_TOKEN:-}
+      # FR-10. O proxy repassa para o container do harness; vazio desliga a
+      # exportacao sem logar erro por turno.
+      GANGLION_OTLP_ENDPOINT: ${GANGLION_OTLP_ENDPOINT:-http://otel-collector:4318}
+      # Cai na chave do alpha por padrão. O agente gamma existe para comparar os
+      # dois harnesses com o MESMO provider e o MESMO modelo, então usar a mesma
+      # chave é o que isola o harness como a única variável -- e evita que um
+      # `export GANGLION_API_KEY=` esquecido desabilite o agente sem causa
+      # visível (o `:-` também substitui quando a variável está vazia).
+      GANGLION_API_KEY: ${GANGLION_API_KEY:-${PICOCLAW_ALPHA_API_KEY}}
       PICOCLAW_BETA_API_KEY: ${PICOCLAW_BETA_API_KEY}
     # TEMPORARY (direct-to-proxy testing of tenant-scoped-workspaces): the proxy
     # normally publishes no host port (mycelium-gateway is the only entry). This
@@ -262,6 +286,8 @@ services:
       # only in .env (gitignored), never in the committed TOML.
       MYC_PICOCLAW_ALPHA_TOKEN: ${MYC_PICOCLAW_ALPHA_TOKEN}
       MYC_PICOCLAW_BETA_TOKEN: ${MYC_PICOCLAW_BETA_TOKEN}
+      # TESTE LOCAL: o mesmo bearer que o agente gamma do proxy valida.
+      MYC_GANGLION_TOKEN: ${MYC_GANGLION_TOKEN:-}
       MYC_STANDALONE_BOOTSTRAP_SECRET: ${MYC_STANDALONE_BOOTSTRAP_SECRET}
     volumes:
       - mycelium-data:/data


### PR DESCRIPTION
Adds the new harness as a submodule, its specs, and the one observability
change it needs.

**Pointer status, per `.claude/rules/submodule-pointers.md`:** the
`crab/crab-ganglion-harness` pointer names `2fd0348`, which is on that repo's
`main` — the check will pass. This PR does **not** bump `crab-shell-proxy` or
`crab-exoskeleton-webapp`; both have their own open PRs, and a follow-up
commit bumps those pointers once they merge.

## Specs

- `crab-ganglion-harness/` — spec + design + the declined Clean Architecture
  proposal, kept with its reasoning rather than deleted
- `ganglion-scale-to-zero/` — spec + design, with the measurements that closed
  its open questions (cold start 0.2s, `fsync` 887µs, listing 600 conversations
  in 3.0ms)
- `ganglion-conversation-metadata/` — spec only, no code yet

Two of those specs correct a premise the requester and I both started from,
and say so in the text rather than quietly: the proxy stores no chat metadata
(the webapp's Postgres does), and picoclaw's *"loses memory on restart"* has
been false since v0.3.1 — `internal/history/history.go:96` carries the dated
correction, while `config.yaml`'s comment still asserts the old behaviour.

## Observability

The collector spoke gRPC only, because harness-sphere's exporter is built with
tonic and was the only producer. The ganglion speaks OTLP/HTTP with JSON,
which is what a producer can implement with the Go standard library alone —
and the reason that harness still has zero third-party dependencies. Port 4318
was already exposed; only the protocol was undeclared.

Verified rather than assumed: a probe came back out of Prometheus as
`ganglion_tokens_total{conversation_id="probe"} = 42`.

## Language rule

`.claude/rules/language.md`, as requested: everything here and below is
written in English — code comments, commits, PRs, issues, specs. Only the
parent `zombie-crab-project-mkt` writes Portuguese, and moving a document
across that boundary means translating it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)