### PR TITLE
Specs: agent confinement and the per-instance lifecycle mode

### DIFF
--- a/.specs/features/crab-ganglion-harness/spec.md
+++ b/.specs/features/crab-ganglion-harness/spec.md
@@ -224,6 +224,36 @@ gets a requirement ID so the gap is tracked.
 | DF-5 | Scheduled tasks / cron sessions | proxy-side; no harness surface in v1 |
 | DF-6 | Built-in `web_search` / `web_fetch` | first target is tool-light; adding a tool is one `Tool` adapter (AR-3) |
 
+### NOT a gap: persona
+
+Reported in use — *"quando entro na area de admin do gamma não vejo a aba de config, só no
+picoclaw"*. Two of the three withheld admin sections were withheld correctly; the third
+was a regression this feature introduced and nobody noticed.
+
+| Section | Withheld from a ganglion agent? | Why |
+|---|---|---|
+| `config` | **correctly** | `config.json` is picoclaw's file. `provisionGanglion` writes no config at all — the harness reads its whole configuration from the environment — so a key edited here would mean nothing to it. |
+| `model` | **correctly** | the registry materializes into `.security.yml` and `config.json`, and the proxy REFUSES an assignment for any other harness (`rejectNonPicoclawAgent`), naming the reason. A form here would post a write the proxy 400s. |
+| `persona` | **wrongly** | fixed |
+
+The webapp's `PICOCLAW_ONLY` list justified hiding persona with *"the identity files are
+picoclaw's workspace layout, delivered on the picoclaw create path"*. That was true when
+it was written and stopped being true when `createGanglion` grew `personaBindStrings`:
+a ganglion container mounts `AGENT.md`, `SOUL.md` and `HEARTBEAT.md` read-only over its
+workspace, and `GANGLION_SYSTEM_FILE` points the harness at `AGENT.md`, re-read every
+turn. The proxy's persona routes were never harness-gated either — `picoclawOnly` lists
+projects, personal models and the memory graph, never persona.
+
+So the **one screen that edits a ganglion agent's identity was unreachable**, for agents
+whose identity this feature had wired the cascade up to deliver. The gate was a webapp
+list that nothing kept in agreement with the create path it described.
+
+Removing persona from `PICOCLAW_ONLY` surfaced a second dependency: the legacy all-agents
+entry had been losing persona for free through that list, and its reason is different —
+the proxy refuses an agent-less persona write, which is about the ADDRESS, not the
+harness. It is now excluded where that argument actually applies. Caught by
+`agent-scope.test.ts`, not by review.
+
 **A deferred feature must answer `501` with the harness named.** Storing a setting that has no
 effect is the failure mode this table exists to prevent.
 

--- a/.specs/features/ganglion-agent-confinement/design.md
+++ b/.specs/features/ganglion-agent-confinement/design.md
@@ -1,0 +1,151 @@
+# ganglion-agent-confinement — Design (Phase 2)
+
+**Status:** Implemented. Date: 2026-09-10. Reads `spec.md`.
+
+Phase 1's three changes are described in `spec.md` and need no design. These two do.
+
+## D-1 — how Landlock reaches the child
+
+Landlock restricts the **calling thread** and everything it later forks or execs. The
+harness must NOT be restricted: it writes transcripts under a directory the agent may not
+reach. So the domain has to be applied between fork and exec, and `os/exec` offers no
+hook there.
+
+**Chosen: the binary re-execs itself.**
+
+```
+crab-ganglion __sandbox_exec <workspace> /bin/sh -c <the agent's command>
+        │
+        └─ main() branches on argv[1] BEFORE reading any configuration
+           ├─ landlock.ABI()      — fail closed if absent
+           ├─ landlock.Restrict() — the domain
+           └─ syscall.Exec("/bin/sh", …) — replaces this process entirely
+```
+
+Rejected alternatives:
+
+- **`runtime.LockOSThread` + restrict + fork from that thread.** Works in principle, but
+  it permanently sacrifices a runtime thread and couples the confinement to Go's
+  scheduler internals. A future Go release could move where `forkAndExecInChild` runs.
+- **A separate helper binary.** A second artefact to build, ship, version and keep in
+  step with the ruleset. The re-exec is the same bytes by construction.
+
+### Why an argv-reachable mode is not a hole
+
+The sandboxed shell can execute `/usr/local/bin/crab-ganglion` — `/usr` is in the
+ruleset. So an agent can invoke the helper itself, with any root it likes.
+
+**Landlock domains only ever narrow.** A thread already inside a domain that restricts
+itself again gets the *intersection*, never a replacement. Tested, not assumed: re-running
+the helper with root `/` from inside the sandbox still cannot read a file the first domain
+denied.
+
+That property is what makes the design safe, so it is asserted by
+`TestReinvokingTheSandboxCannotWidenIt` rather than left as a comment.
+
+## D-2 — the ruleset
+
+| Hierarchy | Access | Why |
+|---|---|---|
+| the workspace | everything the ABI offers | it must behave like an ordinary filesystem |
+| `/usr` `/bin` `/sbin` `/lib` `/etc` | read + execute | run `grep`, read a library; never write |
+| `/dev` | read + write | `> /dev/null`, `/dev/urandom` |
+| **everything else** | denied | `/proc` above all |
+
+`/proc` is the one that matters and the one that would have been forgotten: it is not a
+place anybody thinks of as a secret store, and `/proc/1/environ` is the whole of F-4.
+
+### `/tmp` is deliberately absent
+
+It was granted at first, and a test caught what that means: granting `/tmp` grants
+everything any other process left in `/tmp`. The container's `/tmp` happens to be empty,
+which is precisely the reasoning that ages badly.
+
+Tools that want scratch space get `TMPDIR=<workspace>/.tmp` instead. "Restricted to the
+workspace" then means what it says, with no second writable hierarchy to remember.
+
+Two consequences, both checked rather than assumed:
+
+- **No reader sees it.** `internal/history` opens `<workspace>/sessions` and looks up
+  files inside it *by name*; nothing in the proxy walks the workspace root. `.tmp` is a
+  sibling of `sessions/`, one level above anything that enumerates.
+- **It is cleared at boot**, beside the partial recovery. Nothing else removes what a
+  command leaves there, and the volume survives scale-to-zero — so without this it grows
+  for the life of the agent. Boot rather than per-turn: a scale-to-zero agent boots
+  often, and a running one keeping its scratch for the length of a session is what a
+  `/tmp` does anyway.
+
+### ABI negotiation
+
+Access-right bits and the attribute struct size both grew across ABI versions 1–6.
+Requesting a bit the kernel does not know fails the whole `create_ruleset` with `EINVAL`,
+which would read as *"Landlock is missing"* on a kernel that has it. So the mask and the
+struct size are both derived from the version the kernel reports.
+
+Zero dependencies: three syscalls in the architecture-independent range (444–446), raw,
+no `golang.org/x/sys`.
+
+## D-3 — failing closed, at boot
+
+"No option" means there is no setting that disables the sandbox. That makes an
+unavailable Landlock a deployment that must not serve turns.
+
+**Checked in `main`, not at the first tool call.** This stack has repeatedly paid for the
+other choice — a persona path pointing at nothing, three unset variables — each surfacing
+mid-conversation as behaviour nobody could attribute. The harness now logs
+`sandbox: landlock ABI 8` at startup, or exits naming the cause.
+
+The composition root is also the only place the shell tool is built, and it always sets
+`Self`. There is no branch and no configuration reaching it — `TestTheShellToolIsAlwaysSandboxed`
+guards that, because every other sandbox test builds its own `Tool` and would keep passing.
+
+## D-4 — enc:// , and why two factors of different kinds
+
+```
+enc://base64( salt[16] || nonce[12] || AES-256-GCM ciphertext )
+
+fileHash = SHA256(key file)
+ikm      = HMAC-SHA256(key: fileHash, message: passphrase)
+aesKey   = HKDF-SHA256(ikm, salt, "ganglion-credential-v1", 32)
+```
+
+Deliberately the same shape as picoclaw's, so the two harnesses do not need two mental
+models. `crypto/hkdf` is in the standard library as of Go 1.24, so this stays
+dependency-free.
+
+**The two factors are of different kinds on purpose:**
+
+| Factor | Where | Reached by |
+|---|---|---|
+| passphrase | `GANGLION_KEY_PASSPHRASE` | reading the environment |
+| key file | a read-only bind at `<mountDest>/credential.key` | reading the volume |
+
+Both as environment variables would mean one `docker inspect` yields the plaintext, and
+the encryption would be decoration. The key file is bound **beside** the workspace, not
+inside it — the workspace is the only hierarchy the Landlock ruleset grants, so the agent
+can reach neither factor. `TestTheCredentialKeyFileIsOutOfTheAgentsReach` asserts the
+placement, since that is what the whole scheme rests on.
+
+### Resolved at load, fatal on failure
+
+Same reasoning as `GANGLION_BASE_URL`: a wrong passphrase should be a boot failure naming
+the variable, not a 401 from the provider on some member's first message. The proxy needs
+no decryption at all — an agent's `apiKeyEnv` is an opaque string to it, so ciphertext
+travels through unchanged.
+
+### The proxy side
+
+Two additions, and a third drift case:
+
+- `CRAB_GANGLION_KEY_PASSPHRASE` — environment only, never `config.yaml`, which is in git.
+- `ganglionKeyFile` — a host path; empty means encryption is not in use and nothing is
+  bound or forwarded.
+- `ganglionBindDrift` gains the key file, so switching encryption on reaches members
+  already on the harness instead of leaving them booting against a value they cannot
+  resolve.
+
+## What is still true from Phase 1
+
+The container is still the outer boundary and the narrowed bind still matters: Landlock
+confines the *shell tool*, not the harness, and the harness is what must not have the
+proxy's state within reach. The two controls are layered, not alternatives.

--- a/.specs/features/ganglion-agent-confinement/spec.md
+++ b/.specs/features/ganglion-agent-confinement/spec.md
@@ -1,0 +1,369 @@
+# ganglion-agent-confinement
+
+**Status:** Specified. Date: 2026-09-10. Size: Medium — design is inline, no `tasks.md`.
+
+## Why
+
+picoclaw confines its agent to the workspace and keeps credentials where the agent
+cannot read them. The ganglion harness was built for streaming, durability and token
+accounting, and **shipped without an equivalent**. This spec states exactly what the gap
+is, which parts of it can be closed, and which part of picoclaw's mechanism is
+structurally unavailable here and must be replaced rather than copied.
+
+Nothing here is cross-tenant. The container boundary holds: one per-user directory, uid
+1000, no docker socket. What is exposed is exposed to the member who owns the container —
+and, through the agent, to anyone who can talk that agent into printing it.
+
+## What picoclaw does, verified
+
+Three layers, and the second only works because of the first.
+
+**1. `restrict_to_workspace`.** `defaulttemplate/picoclaw/config.json`:
+
+```json
+"restrict_to_workspace": true,
+"allow_read_outside_workspace": false
+```
+
+picoclaw's tools take path arguments, resolve them, and refuse anything outside
+`<mount>/workspace`.
+
+**2. Credentials sit one level above `workspace/`,** and layer 1 is what hides them.
+`.security.yml` holds `model_list.<model>.api_keys` and the pico channel token at
+`<mount>/.security.yml`. So does the rest of the proxy's control plane —
+`.projects.json`, `.crab-owner.json`, `config.json`. `agent-projects/context.md` is
+explicit that this is deliberate: an agent that could edit `.projects.json` could route a
+peer's conversations to itself.
+
+**3. The container environment carries no secret at all.** Verified on the live alpha
+container:
+
+```
+PICOCLAW_GATEWAY_HOST=0.0.0.0
+HOME=/data
+PATH=...
+```
+
+Three variables. The deploy-level key `PICOCLAW_ALPHA_API_KEY` is read by the proxy and
+written into `.security.yml` — it never enters the container as environment.
+
+## What ganglion does today, verified
+
+### F-1 — The provider key and the bearer are in the container environment
+
+`docker inspect` of the live gamma container:
+
+```
+GANGLION_TOKEN=pico-d…
+GANGLION_API_KEY=sk-0b2…
+GANGLION_BASE_URL=https://api.deepseek.com/v1
+```
+
+`internal/adapter/tool/exec` builds `exec.Command("/bin/sh", "-c", …)` and never sets
+`cmd.Env`. Go's contract: *"If Env is nil, the new process uses the current process's
+environment."* So `env` inside the shell tool prints both. Confirmed with a probe binary
+reproducing the exact construction, not only by reading the stdlib doc.
+
+`GANGLION_API_KEY` resolves from `apiKeyEnv` in the proxy's `config.yaml`, which is
+**per agent, not per user**. Every member on `gamma` shares one DeepSeek key, and it is
+sitting in each of their containers' environment. picoclaw has the same shared key with
+the same blast radius — the difference is entirely in where it is put.
+
+### F-2 — There is no path confinement, and the code says there is
+
+`exec.Tool` sets `cmd.Dir = t.Workdir`. That is the working directory, not a boundary:
+`cat /etc/hostname`, `ls /`, `cd ..` all succeed. Confirmed with the same probe.
+
+The package doc comment claims otherwise:
+
+> What this package still owns is keeping a command from reaching outside the workspace
+> root, because a tool that can be talked into reading /proc or the mounted secrets is a
+> tool that eventually will be.
+
+**It owns no such thing.** This is the single worst line in the harness: this project's
+recurring failure is contracts nobody can verify from where they are written, and this
+one asserts a control that does not exist, to a reader with no way to notice.
+
+### F-3 — The bearer token file is inside the mount, above the workdir
+
+`provisionGanglion` writes `<userDir>/.crab-ganglion.json` (0600, chowned to the agent's
+own uid), and the bind is `hostDir:/data/.ganglion` read-write. The workdir is
+`/data/.ganglion/workspace`. So `cat ../.crab-ganglion.json` reads it.
+
+That path — proxy-owned state one level above `workspace/` — is *exactly* the slot
+picoclaw's `restrict_to_workspace` protects. Ganglion adopted the layout without the
+mechanism that made it safe.
+
+## Not regressions — parity with picoclaw, out of scope
+
+Recorded so a later reader does not re-open them as findings:
+
+- **The agent can rewrite its own transcript.** `sessions/*.jsonl` and `windows/` live
+  under `workspace/`, so the shell tool can edit them and defeat the append-only
+  invariant. picoclaw's sessions are under its workspace too.
+- **The agent can reach the proxy over the network.** Both harnesses join
+  `m.cfg.Network`. Reachability is not authorization; F-1 is what would turn it into one,
+  and F-1 is fixed here.
+
+## Prospective, not live — a constraint on FR-7
+
+`GANGLION_TOKEN` is used twice: the ingress bearer the proxy presents to the harness, and
+the outbound bearer the approver presents to `GANGLION_APPROVAL_ENDPOINT`. With F-1 the
+agent can read it, so an agent could dial the approval endpoint itself.
+
+**This is not exploitable today** — the proxy-side endpoint does not exist (FR-7, OQ-3
+open) and `GANGLION_GATED_TOOLS` is empty, so `Request` short-circuits with
+`Allowed: true, "not gated"` and never dials out. Fixing F-1 also closes this. It is
+recorded as a **design constraint**, not a vulnerability:
+
+> **DC-1.** The approvals endpoint must not treat a harness-presented bearer as
+> authorization for a decision. The harness presents *identity*; the proxy decides from
+> its own state and mycelium's account id. A token the agent can read is not an
+> authorization token.
+
+## Requirements
+
+| ID | Requirement |
+|---|---|
+| FR-1 | The shell tool runs with an explicit environment allowlist. No provider key, no bearer. |
+| FR-2 | The `exec` package doc describes what it actually enforces. |
+| FR-3 | Proxy-owned per-user state is not reachable from inside the container. |
+| FR-4 | An existing container created with the old bind is recreated, not left running. |
+| NFR-1 | No change to picoclaw's container path. |
+
+## AC
+
+- **AC-1** — `env` in the shell tool prints neither `GANGLION_API_KEY` nor
+  `GANGLION_TOKEN`; the harness itself still reaches the provider.
+- **AC-2** — A test asserts the allowlist by name, so adding a variable to `ganglionEnv`
+  does not silently widen the tool's view.
+- **AC-3** — `cat ../.crab-ganglion.json` from the workdir finds nothing.
+- **AC-4** — A container carrying the old bind is recreated on the next turn.
+
+> **Superseded in part by Phase 2 (below).** The section that follows concluded
+> that no confinement was achievable and that the container was the only boundary.
+> That was wrong in one specific way: it considered only tool-layer path checks.
+> Landlock is a kernel mechanism an unprivileged process can apply to itself, and
+> it makes a real confinement possible. The reasoning about *path checks* stands
+> and is why one was not built; the conclusion drawn from it did not.
+
+## Design — why the picoclaw mechanism cannot be copied
+
+`restrict_to_workspace` is a **tool-layer path check**. It works because picoclaw's tools
+take a path argument to resolve and refuse.
+
+**Ganglion's only tool is `/bin/sh -c <arbitrary string>`. There is no path argument to
+check.** Any blocklist of `..`, `/etc`, `/proc` is defeated by
+`$(echo L2V0Yw== | base64 -d)`, and shipping one would produce something that reads like
+security and is not. Parity is not a matter of porting the flag, and the next reader must
+not assume it is.
+
+What replaces it is **the container boundary itself** — which is what `exec`'s own first
+paragraph already, correctly, says:
+
+> The container is per-user and holds only that member's workspace, so the isolation
+> boundary is the container itself -- not a sandbox inside it.
+
+That sentence is true, and F-1 and F-3 are the two places the deployment broke it by
+putting things inside the container that the boundary was supposed to keep out. The fix
+is to make the statement true again, not to build a second boundary inside the first.
+
+### Three changes
+
+1. **`cmd.Env` allowlist** (`exec.go`) — `PATH`, `HOME`, `TERM`, and nothing else. One
+   field. Closes F-1 and DC-1 together. Independent of the rest.
+2. **Bind `workspace/` instead of the user dir** (`ganglion.go`) — the token file then
+   stays on the host, outside the container. Closes F-3.
+3. **The doc comment** — closes F-2, and is the change most likely to matter in a year.
+
+Change 2 needs the drift check (FR-4): bind sets are fixed at create time, so the running
+gamma container keeps the old wide mount until something recreates it. `personaBindDrift`
+already exists for precisely this class of bug and the workspace bind joins it.
+
+### Do not "restore parity" by moving the secrets into a file
+
+picoclaw's answer to F-1 is *put the credential in a file the agent cannot read*. Copying
+that here would make things **worse**, and the reason is the same one that makes change 1
+possible at all:
+
+- picoclaw can hide a file, because `restrict_to_workspace` refuses the path.
+- ganglion cannot hide anything inside the mount — the shell tool `cat`s whatever the
+  filesystem holds. A `.security.yml` equivalent would be one `cat ..` away, and, unlike
+  an environment variable, **there is nothing to remove it from**.
+
+A secret in the environment is removable from the child process. A secret in a mounted
+file is not. So for this harness the environment is the *safer* channel, and the fix is
+to scrub the child rather than to relocate the secret. A reader chasing parity with
+picoclaw will want to invert this; it would reopen F-1 with no way to close it again.
+
+## Execution
+
+Implemented, uncommitted. Three files changed plus tests.
+
+**`crab-ganglion-harness/internal/adapter/tool/exec/exec.go`** — `cmd.Env = scrubEnv(os.Environ())`
+against a `passThrough` allowlist (`PATH`, `HOME`, `TERM`, `LANG`, `TZ`). An allowlist
+rather than a denylist of secret-looking names: the proxy decides what enters the
+container, so a denylist would need editing in a second repository on every addition, and
+forgetting fails silently. The package doc now states that it does **not** confine, why it
+cannot, and that the container is the boundary.
+
+**`crab-shell-proxy/internal/docker/ganglion.go`** — `ganglionWorkspaceBind` binds
+`<hostDir>/workspace` at `<mountDest>/workspace` instead of the whole user dir;
+`ganglionWorkspaceDrift` joins `personaBindDrift` and `imageDrift` so a container created
+with the old bind is recreated rather than kept forever. The bind set moved into
+`ganglionBinds`, for the reason `ganglionEnv` was split out: the drift checks read it back
+and nothing else can prove the two agree without a daemon.
+
+**`crab-shell-proxy/internal/config/config.go`** — unrelated to this feature, and a broken
+test on `main` from `f4c3183`: `ganglionUnprovisioned` returned "required model API key
+environment variable is unset" without naming the variable, which is the one thing the
+disable-instead-of-exit design exists to say. Now names it. `TestLoadDisablesAGanglionAgentWhoseKeyIsUnset`
+was failing before this change and passes after.
+
+### Evidence
+
+| Claim | How it was checked |
+|---|---|
+| Secrets were in the live container's env | `docker inspect crabshell-gamma-… .Config.Env` — `GANGLION_API_KEY=sk-0b2…`, `GANGLION_TOKEN=pico-d…` |
+| picoclaw's env carries none | same command on `crabshell-alpha-…` — three variables, no secret |
+| `cmd.Env == nil` inherits, `cmd.Dir` does not confine | probe binary reproducing `exec.go`'s exact construction |
+| The fix works and the test would catch its removal | `TestSecretsAreNotVisibleToACommand` passes; with `cmd.Env` assignment removed it fails naming the secret |
+| No regression | `internal/docker`'s failing set is byte-identical to baseline (10, all `lchown … operation not permitted`, the pre-existing sandbox limit); every other package green in both repositories |
+| The artefact builds | `docker build` green — the Dockerfile runs `go vet` and `go test` |
+| The narrowed mount actually works | `docker run` with only `workspace` bound: the harness reaches `listening on :18800`, and from inside, `/data/.ganglion` is root-owned holding nothing but a writable `workspace` |
+| Narrowing does not cause a recreate every turn | `TestGanglionBindsDoNotLookLikeDrift` — `personaBindDrift` counts persona mounts under the prefix `<mountDest>/workspace/`, and the new bind's destination has no trailing slash, so it is not counted. Asserted against the exact list `createGanglion` builds, not a hand-written one |
+
+### Not verified live
+
+**The scrub** is proven by unit test and by the probe, **not** by a turn on a running
+container: that needs a rebuilt proxy image so the drift check fires and recreates gamma.
+The harness dev image is rebuilt; the proxy is not.
+
+**AC-4** is the predicate, not the path. `ganglionWorkspaceDrift` is tested directly and
+against the real bind set, but the composite recreate in `ensureGanglionRunning` runs only
+in `TestEnsureRunningRecreatesOn…`, which is inside the pre-existing `lchown` failure set
+and does not execute in this environment. What is proven is that the predicate answers
+true for the old bind and false for the new one.
+
+### Still open
+
+**DC-1** — carried into `crab-ganglion-harness` FR-7 / OQ-3, which has no code yet.
+
+
+---
+
+# Phase 2 — real confinement, and encrypted credentials
+
+**Status:** Specified and implemented. Date: 2026-09-10. Size: Large.
+
+Requested directly: *"Implemente a restrição de workspace como padrão, sem outra opção
+e a encriptação das variáveis."*
+
+## What changed the answer
+
+Phase 1 said a workspace restriction was unavailable to this harness. Two findings
+overturned that.
+
+### F-4 — the environment scrub did not close F-1
+
+Phase 1's fix keeps the provider key out of a command's own environment. It does not
+keep the command from reading it. PID 1 is the harness, it holds the key, and it runs as
+the same uid:
+
+```
+$ env -i PATH=... /bin/sh -c 'cat /proc/1/environ | tr "\0" "\n" | grep GANGLION'
+GANGLION_API_KEY=sk-secret-in-pid1
+```
+
+Run in the real image, with a genuinely empty child environment. **F-1 was not closed by
+Phase 1**, and nothing in Phase 1's test suite could have said so — every test asserted
+the child's *own* environment.
+
+### F-5 — a kernel mechanism exists that an unprivileged process may use
+
+Landlock. Confirmed in the deployment's own container: **ABI version 8**, no
+`CAP_SYS_ADMIN`, no privileged flag, no change to Docker's seccomp profile. The harness
+runs as uid 1000 and could not `chroot` or `unshare`; it can Landlock itself.
+
+## Requirements
+
+| ID | Requirement |
+|---|---|
+| FR-5 | Every shell command runs inside a Landlock domain. No configuration disables it. |
+| FR-6 | `/proc` is denied, closing F-4. |
+| FR-7 | The workspace is fully usable — create, read, edit, rename, delete. |
+| FR-8 | Landlock unavailable is a **boot** failure, not a per-turn one. |
+| FR-9 | A credential may be written `enc://…`; a plain value still works. |
+| FR-10 | Resolving `enc://` requires **two factors of different kinds** — one environment, one file. |
+| FR-11 | The key file is unreachable from the agent. |
+| FR-12 | A failed decryption is a boot failure naming what to fix. |
+
+## AC
+
+- **AC-5** — `cat /proc/1/environ` from a command returns permission denied.
+- **AC-6** — `cat $(echo <base64 path> | base64 -d)` fails too: the mechanism is not a
+  string check.
+- **AC-7** — Re-invoking the sandbox helper with root `/` does not widen the domain.
+- **AC-8** — `echo > a.txt`, `mkdir`, `mv`, `rm` all work in the workspace.
+- **AC-9** — Sealing the same plaintext twice yields different ciphertext.
+- **AC-10** — Either factor alone decrypts nothing.
+- **AC-11** — The agent can reach neither factor.
+
+## Why not picoclaw's mechanism, restated now that both exist
+
+picoclaw's `restrict_to_workspace` is tool-layer path validation. Its own documentation:
+
+> "There's no indication of kernel-level isolation (chroot, namespaces, seccomp,
+> landlock) — the sandbox relies entirely on application-level validation within
+> PicoClaw itself."
+
+and its `exec` tool is additionally guarded by *"41 dangerous command patterns"* as
+regexes. For tools that take a path argument, that is reasonable. For
+`/bin/sh -c <arbitrary string>` it is not: `$(echo L2V0Yw== | base64 -d)` is `/etc`.
+
+**What ganglion now runs is stronger than the mechanism it was asked to reach parity
+with.** Recorded plainly so nobody later reads "ganglion has no `restrict_to_workspace`"
+and adds the weaker check beside the stronger one.
+
+## Evidence — Phase 2
+
+All of it in the real image, with the harness as PID 1.
+
+| Claim | Result |
+|---|---|
+| Landlock is available in this container | ABI 8; harness logs `sandbox: landlock ABI 8` at boot |
+| `/proc/1/environ` before | `GANGLION_API_KEY=sk-secret-pid1` |
+| `/proc/1/environ` through the sandbox | `Permission denied` |
+| A volume outside the workspace | `Permission denied` |
+| The same path, base64-obfuscated | `Permission denied` — no string was inspected |
+| Re-invoking the helper with root `/` | still `Permission denied`; Landlock domains only narrow |
+| The workspace | write, `mkdir`, `mv`, read, `rm` all succeed |
+| `/dev/null` and a system binary | work |
+| enc:// with both factors | boots |
+| enc:// with the passphrase only | `read the credential key file …: no such file or directory` |
+| enc:// with the key file and a wrong passphrase | `did not decrypt: wrong passphrase, wrong key file, or the value was altered` |
+| The agent going after factor 1 | `/data/.ganglion/credential.key` → `Permission denied` |
+| The agent going after factor 2 | `/proc/1/environ` → `Permission denied` |
+| The agent going after the plaintext in memory | `/proc/1/maps` → `Permission denied` |
+
+## What the sandbox does NOT protect
+
+**The transcript.** `sessions/*.jsonl`, `windows/` and the scale-to-zero sidecar all live
+under `workspace/`, so a command has full write access to them and can still defeat the
+append-only invariant. That was true in Phase 1, it is picoclaw parity, and it stays
+scoped out — but "restricted to the workspace" invites the opposite assumption, so it is
+stated here. Protecting the transcript would mean moving it out of the workspace, which
+is a different feature with a reader on the other side of it.
+
+## Two things this does NOT do
+
+**Encryption does not hide the key from the harness.** The process presents it to the
+provider, so it holds plaintext in memory for as long as it runs. What encryption
+protects is the credential *at rest* — dokploy's environment editor, `deploy/*/.env`,
+`docker inspect`, backups of any of them. What keeps it from the **agent** is the scrub
+and the Landlock domain, not the cipher.
+
+**One factor is not encryption.** A passphrase in the environment beside the ciphertext
+in the environment is ceremony: one `docker inspect` yields both. The key file exists to
+be a different *kind* of thing, and it is bound outside the workspace so the agent cannot
+turn it back into one.

--- a/.specs/features/per-instance-lifecycle-mode/spec.md
+++ b/.specs/features/per-instance-lifecycle-mode/spec.md
@@ -1,0 +1,169 @@
+# per-instance-lifecycle-mode
+
+**Status:** Specified and implemented. Date: 2026-09-10. Size: Large.
+
+Three asks, in the order they were made:
+
+1. the member must be able to SEE when their scheduled tasks are disabled by scale-to-zero;
+2. the lifecycle mode must be settable **per instance**, with a default for all;
+3. an admin must be able to set it from the admin interface.
+
+## Why it is worth doing
+
+Scheduled tasks fire from timers **inside the container**. A scale-to-zero instance is
+stopped most of the time, so it fires none — its tasks are real, listed, and inert.
+
+Today that is decided for a whole agent. Either every member of `gamma` pays for a
+container that never stops, or nobody on it gets a working schedule. **One member who
+needs a daily report is a reason to keep one container up, not forty.**
+
+## Ask 1 — the member's notice
+
+The proxy has reported `fires` on `GET /v1/cron/tasks` since the scale-to-zero work.
+Nothing read it: `lib/cronTasks.ts` did not declare the field and the panel did not
+render it. So the list was true, and the conclusion a member drew from it was not.
+
+**FR-1.** The scheduled-tasks panel shows a warning when the proxy reports `fires:false`.
+
+**FR-2.** The field is OPTIONAL in the client type. A proxy older than `fires` sends
+nothing, and `undefined` must read as "no claim either way" — treating it as `false`
+would warn every member of an older deployment about a problem they do not have. Only an
+explicit `false` renders the notice.
+
+The notice sits **above** the list and above the empty state, because it describes the
+whole panel: a member with no tasks yet, about to ask the agent for one, still needs to
+know it will not fire.
+
+## Ask 2 — the mode, per instance
+
+**Two layers, and deliberately not three.** `agents.<key>.mode` in `config.yaml` already
+IS "um valor padrão para todos" — for every instance of that agent. This adds the
+exception for one instance. A third, global-across-agents default would have to reconcile
+with the per-agent rule that scale-to-zero requires a positive `idleTimeout`, and nothing
+asked for it.
+
+| ID | Requirement |
+|---|---|
+| FR-3 | An instance may pin `continuous` or `scale-to-zero`; absent, it follows its agent. |
+| FR-4 | Clearing the override returns the instance to the agent default. |
+| FR-5 | **Every** lifecycle branch resolves per instance. |
+| FR-6 | The override is unreachable by the agent. |
+| FR-7 | `scale-to-zero` is refused where the agent declares no `idleTimeout`. |
+
+### FR-5 is the one that matters
+
+There were **five** places branching on `agent.Mode`, plus a sixth reading a container
+label. An override reaching four of them would produce an instance that is scale-to-zero
+for the idle timer and continuous for the reconciler — a container stopped and restarted
+in a loop, with nothing naming the cause. All six now go through `Manager.ModeFor`.
+
+Two of them were wrong in a way the chokepoint exposed:
+
+- `reconcile.go`'s adopt loop skipped any container whose **agent** default was not
+  scale-to-zero, so an overridden instance would never have had its timer armed.
+- `reconcile.go`'s pre-warm loop skipped whole **agents** before ever looking at a
+  workspace, so a single instance overridden to continuous on a scale-to-zero agent would
+  never have been brought up.
+
+### FR-6 — where the file lives
+
+`<userDir>/.crab-mode.json`, beside `.crab-model.json` and `.crab-owner.json` and **above**
+`workspace/`. picoclaw's `restrict_to_workspace` and the ganglion's Landlock domain both
+stop there. This matters more than it does for a model selection: **an agent able to write
+this file could keep its own container alive indefinitely.**
+
+### The transition is the part that fails silently
+
+The store write and the idle-timer move are ONE operation (`Manager.SetMode`). Apart, three
+of the four cases are silent:
+
+| From → to | If the timer is not moved |
+|---|---|
+| continuous → scale-to-zero | no timer armed; the container runs forever and nothing says the setting did not take |
+| scale-to-zero → continuous | a timer is still armed; the container is stopped once more after the admin was told it was done. Reconcile heals it — on the reconcile interval, not now |
+| either, no container | harmless; the only one that is |
+
+### What the chokepoint costs
+
+Two hot-path questions, both checked rather than assumed:
+
+- **`Reconcile` walks every agent now**, where it used to skip whole agents whose default
+  was not continuous. It runs **ONCE, at startup** — `cmd/crab-shell-proxy/main.go` calls
+  it in a single background goroutine, not on a ticker — so this is a bounded one-time
+  cost of (agents x one filesystem glob), and there is no per-tick profile to protect.
+  Had it been on a timer the loop would need inverting: walk workspaces once, resolve per
+  workspace. It is not.
+- **`ArmIdle` now reads the override file**, and it runs after every completed turn — two
+  call sites, `sse.go` and the non-streaming handler, one per turn each. One `os.ReadFile`
+  of a ~20 byte file against a turn that just spent seconds talking to a provider. Left
+  uncached deliberately: a cache would need an invalidation path from the admin write, and
+  the feature does not warrant that machinery. **If `ArmIdle` ever becomes per-delta rather
+  than per-turn, this needs revisiting.**
+
+### `LabelMode` stops being read
+
+The label is stamped at create time, and a mode change never touches an existing
+container — so it goes stale the instant an override is set. `Instances()` now resolves
+instead. The label is still written (it costs nothing and reads well in `docker inspect`),
+and `TestNothingBranchesOnTheModeLabel` scans the package source so a NEW reader cannot
+reintroduce the staleness quietly.
+
+## Ask 3 — the admin interface
+
+`GET`/`PUT /v1/admin/users/mode`, gated exactly like the sibling instance-config editor:
+user-management authority, an explicit `agent` parameter rather than the addressed agent,
+no path or name parameter of any kind.
+
+The view reports four things rather than one, and each has a reason:
+
+| Field | Why it is separate |
+|---|---|
+| `effective` | what the instance runs as; the only field to branch on |
+| `override` | "continuous, inherited" and "continuous, pinned" are identical today and diverge the moment the agent default moves |
+| `agentDefault` | what clearing would leave |
+| `scaleToZeroAllowed` | so the UI disables a choice the write would refuse, instead of offering it |
+| `fires` | the same fact the member's panel shows, so an admin acting on their report sees what they see |
+
+**The control lives on the instance row, not inside the config editor.** This is not part
+of `config.json` — it is proxy-owned state — and an admin following up "my scheduled tasks
+never ran" should not have to open a JSON editor to find it. The row states the
+consequence, not the setting: *"Schedules fire from timers inside the container, so an
+instance that shuts down when idle runs none of them."*
+
+## The notice is as fresh as the last fetch
+
+`fires` is read when the panel loads. An admin flipping an instance to continuous while a
+member has the panel open does not update it — the warning stays until the next fetch,
+which the panel's existing refresh control already triggers.
+
+Recorded so a stale warning is not later read as a bug in the resolver. A push channel for
+this would be more machinery than a setting changed a handful of times a year deserves.
+
+## AC
+
+- **AC-1** — `fires:false` renders the member's notice; `true` and **absent** render nothing.
+- **AC-2** — An override beats the agent default; an empty value clears it.
+- **AC-3** — Setting scale-to-zero arms the idle timer; setting continuous cancels it.
+- **AC-4** — A malformed or unrepresentable override falls back instead of failing.
+- **AC-5** — The override path is outside the agent's workspace.
+- **AC-6** — No source file branches on `Labels[LabelMode]`.
+- **AC-7** — The admin endpoint refuses a non-manager, and surfaces a refusal as a 400 naming the cause.
+- **AC-8** — The control hides scale-to-zero when the agent cannot represent it.
+
+## Evidence
+
+| | |
+|---|---|
+| proxy | `go vet` clean; **10** failures, all the pre-existing `lchown` sandbox limit — **one fewer than baseline**, which still carried `TestLoadDisablesAGanglionAgentWhoseKeyIsUnset` |
+| webapp | 1479 tests pass across 116 files, i18n parity included; `next build` succeeds |
+| AC-1 | mutation-checked — with the notice removed from the panel the positive case fails |
+
+## Deliberately not done
+
+**Members cannot set their own mode.** It decides whether a container runs permanently,
+which is a cost and capacity decision. It stays with whoever already holds user-management
+authority.
+
+**No restart policy on the write.** Unlike `users/config`, the effect is complete on the
+proxy side the moment `SetMode` returns — the timer moves with the write, and there is
+nothing for a bounce to deliver.


### PR DESCRIPTION
**Specs only. No pointer bumps in this PR** — the three child PRs are still open, and a pointer may name only a commit reachable from its child's default branch. The bumps follow as a second commit once they merge, so `submodule-pointers.yml` stays green throughout.

## `ganglion-agent-confinement`

Records **both phases, including the one that was wrong.**

Phase 1 concluded that no workspace confinement was achievable for this harness and that the container was the only boundary. That holds for tool-layer path checks and does not hold in general — Landlock is a kernel mechanism an unprivileged process applies to itself. Worse, the environment scrub Phase 1 shipped did not close what it claimed: `cat /proc/1/environ` read the provider key straight back out of the harness, and no test asserting a command's *own* environment could have said so.

The superseded section is kept rather than rewritten. The reasoning that produced it is the part worth reading.

Phase 2 also records the inversion that a future reader will want to undo: picoclaw's answer is *put the secret in a file the agent cannot read*, and here that is strictly worse — a secret in a mounted file is one `cat` away and has nothing to be removed from, while a secret in the environment can be scrubbed from the child.

## `per-instance-lifecycle-mode`

The feature, and the two `reconcile` bugs the resolver chokepoint exposed on the way — an adopt loop that skipped containers by their *agent's* default, and a pre-warm loop that skipped whole agents before ever looking at a workspace.

Also records what is deliberately not done, and the freshness limit of the member's notice, so a stale warning is not later read as a bug in the resolver.

## `crab-ganglion-harness`

Its feature-gap table gains a row that is **not** a gap: persona.

Two of the three admin sections withheld from a ganglion agent were withheld correctly (`config.json` is a file it does not have; the model registry writes picoclaw's files and the proxy refuses the assignment). The third was hidden on the strength of a comment that this very feature had made false — leaving the one screen that edits a ganglion agent's identity unreachable, for agents whose identity it had wired the cascade up to deliver.

## The chain

| Repo | PR |
|---|---|
| crab-ganglion-harness | #2 |
| crab-shell-proxy | #40 |
| crab-exoskeleton-webapp | #56 |

Siblings — no ordering between them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)