### PR TITLE
Specs: four harness-parity features, three built and one argued

### DIFF
--- a/.specs/features/ganglion-evolution/spec.md
+++ b/.specs/features/ganglion-evolution/spec.md
@@ -1,0 +1,185 @@
+# ganglion-evolution — Specification (authoritative)
+
+**Status:** SPECIFIED, NOT STARTED. Zero lines of code. See "Why this one is
+not built" below before picking it up.
+**Date:** 2026-09-10.
+**Spans:** `crab-ganglion-harness`, `crab-shell-proxy`, `crab-exoskeleton-webapp`.
+**Depends on:** `ganglion-model-registry` FR-1 (the config file).
+
+## What picoclaw's evolution actually is
+
+Measured, not assumed: `pkg/evolution/` is 34 files and roughly 12 500 lines
+including tests, shipped and inert by default (`enabled: false`, `mode: observe`).
+
+It is **not** a tool the model can call, and it does not rewrite the harness. It
+is a background listener on turn-end events with two paths:
+
+- **hot** — every turn end appends a `LearningRecord` to
+  `state/evolution/task-records.jsonl` and updates per-skill usage stats.
+- **cold** — triggered `after_turn`, on a schedule, or manually; reads the
+  records, judges success, clusters repeated successful patterns once
+  `min_task_count` (2) and `min_success_ratio` (0.7) are met, and generates
+  **skill drafts**.
+
+In `apply` mode, and only there, an accepted draft is written to
+`workspace/skills/<name>/SKILL.md` — with a structural and secret scan before the
+write, an atomic write, a timestamped backup of whatever it overwrote, and a
+rollback closure on downstream failure. `AGENT.md` and `SOUL.md` are **never**
+touched by it.
+
+So the honest summary is: **it evolves the agent's skill library.**
+
+## The prerequisite nobody would notice until it shipped
+
+`grep -rn skill --include='*.go'` in `crab-ganglion-harness` returns **nothing**.
+The harness has no skills: it does not read `workspace/skills/`, it does not put
+skill content in the system prompt, and `ganglionBinds` (workspace + credential
+key + the persona cascade) mounts no skills root — the proxy's shared-skills
+machinery reaches picoclaw agents only.
+
+Evolution in `apply` mode would therefore write `SKILL.md` files **into a void**.
+That is precisely the failure the `crab-ganglion-harness` spec's deferred table
+exists to prevent: *"A deferred feature must answer 501 with the harness named.
+Storing a setting that has no effect is the failure mode this table exists to
+prevent."*
+
+**So this feature is two, and it says so:** a skills loader, then evolution on top
+of it. `apply` mode is not shipped without the loader.
+
+## Part 1 — skills
+
+**R1 — load `workspace/skills/*/SKILL.md`.** Each is YAML frontmatter
+(`name`, `description`) plus a body, picoclaw's format unchanged, so a skill
+written for one harness works on the other.
+
+**R2 — the system prompt gets a skills index**, not every body: name and
+description per skill, under a budget (**R2.1**: 8 KiB total, oldest-by-mtime
+dropped first, and the drop is logged). Bodies are read on demand by the agent
+through the shell tool, which already reaches the workspace.
+
+**R3 — precedence.** The persona (`GANGLION_SYSTEM_FILE` → `AGENT.md`) comes
+first and is never displaced; the skills index is appended below it. A skill can
+add capability, never overwrite identity.
+
+**R4 — reload per turn**, the same cadence `AGENT.md` is already re-read at.
+
+**R5 — OPEN, and put to the owner rather than assumed:** whether the proxy's
+admin-managed shared skills should mount into ganglion containers at all.
+Evolution-authored skills live inside the workspace bind and persist without any
+proxy change; admin-authored ones would need a new bind. See OQ-1.
+
+## Part 2 — evolution
+
+**R6 — picoclaw's config block, keys unchanged**
+(`pkg/config/config.go:58-70`), read from the config file:
+
+```jsonc
+{ "evolution": {
+    "enabled": false, "mode": "observe",
+    "state_dir": "", "min_task_count": 2, "min_success_ratio": 0.7,
+    "cold_path_trigger": "after_turn", "cold_path_times": [] } }
+```
+
+`mode ∈ observe | draft | apply`; `cold_path_trigger ∈ after_turn | scheduled | manual`.
+Same defaults, so a picoclaw `config.json` dropped in behaves the same.
+
+**R7 — the hot path.** At turn end, one `LearningRecord` per turn appended to
+`state/evolution/task-records.jsonl`: the input, the tools invoked and their
+outcomes, token usage (which ganglion has and picoclaw does not — FR-8 of the
+harness spec accumulates it), duration, and whether the turn ended cleanly.
+Append-only, `fsync`'d, same durability contract as the transcript.
+
+**R8 — the cold path.** Cluster records into patterns; a pattern with at least
+`min_task_count` occurrences and at least `min_success_ratio` success generates a
+draft through the model itself, using the same candidate chain the turn uses.
+
+**R9 — the safety ladder, ported in full.** `observe` records only; `draft`
+generates and stores drafts, writing no skill; `apply` may write. Before any
+write: frontmatter validation, skill-name validation against path traversal, the
+secret scan for `sk-live-`, `sk_test_`, `api_key=` and PEM private-key headers,
+a timestamped backup of the overwritten file, an atomic write, and rollback on
+failure. picoclaw's own documentation calls this scanner *"a narrow guardrail,
+not a complete safety boundary"* and that assessment is carried over verbatim
+rather than quietly upgraded.
+
+**R10 — `apply` requires the loader.** Selecting `apply` while Part 1 is absent is
+a **boot failure naming the reason**, not a silent downgrade.
+
+**R11 — scale-to-zero honesty.** `cold_path_trigger: scheduled` on an agent in
+`scale-to-zero` is refused at load with the mode named — a stopped container fires
+no timers, and this stack has already made exactly this decision once, for cron
+(`/v1/cron/*` answers `501` naming the mode). `after_turn` and `manual` are
+unaffected and are the modes a scale-to-zero agent uses.
+
+**R12 — a member-visible surface.** Drafts are the interesting artefact and today
+they would be invisible. A read-only Evolution panel lists drafts with their
+status (candidate / quarantined / accepted / applied) and the pattern that
+produced them, so `draft` mode is a usable review workflow rather than a folder
+nobody opens.
+
+## Acceptance criteria
+
+- **AC-1** With `enabled: false` (the default), nothing is written and no turn is
+  measurably slower. The hot path is off, not merely quiet.
+- **AC-2** A skill written by picoclaw's evolution loads in ganglion unchanged.
+- **AC-3** `apply` mode with no skills loader refuses to boot, naming the reason.
+- **AC-4** A draft containing an API-key-shaped string is quarantined, never
+  written.
+- **AC-5** An applied skill that breaks its own frontmatter validation is rolled
+  back and the previous file restored from the backup.
+- **AC-6** `scheduled` on a scale-to-zero agent is refused at load.
+
+## Out of scope
+
+The lifecycle maintenance half — picoclaw's decay scoring that eventually
+**deletes** a stale `SKILL.md`. Automated deletion of agent-authored content needs
+an operator story this feature does not have.
+
+`pattern-records.jsonl` clustering by LLM in v1 uses a deterministic clusterer;
+picoclaw's `LLMDraftGenerator` prompt-based clustering is the second cut.
+
+## Open questions
+
+- **OQ-1 — R5.** Do admin-managed shared skills apply to ganglion agents? This is
+  a product decision, not a technical one: `ganglion.go` deliberately mounts a
+  narrow bind set, and adding a skills root widens it. **To the owner.**
+- **OQ-2** — Should `apply` require an approval hop through the `Approver` port
+  that already exists for tool gating? It would make evolution the second consumer
+  of the mechanism the harness was built for, at the cost of a proxy endpoint that
+  is itself still unbuilt (harness spec OQ-3).
+
+---
+
+## Why this one is not built (2026-09-10)
+
+The other three features of this round shipped; this one did not, and the reason
+is worth writing down rather than leaving as an empty directory.
+
+**It is two features, and the first one is invisible from the outside.** The
+skills loader is the prerequisite established above — `grep -rn skill
+--include='*.go'` in the harness still returns nothing — and without it `apply`
+mode writes `SKILL.md` files nothing reads. Shipping only the evolution half
+would have been the exact failure the harness spec's deferred table exists to
+prevent: a setting that stores something and changes nothing.
+
+**Its size is measured, not guessed.** picoclaw's `pkg/evolution` is 34 files and
+roughly 12 500 lines including tests. A faithful port of the ladder, the
+clustering, the draft review and the rollback is the largest single piece of the
+four, and it is the only one with no user-visible surface until the last step.
+
+**Two of its decisions are still open**, and both are the owner's rather than an
+implementer's:
+
+- **OQ-1** — whether admin-managed shared skills mount into ganglion containers
+  at all. `ganglionBinds` is deliberately narrow; adding a skills root widens it,
+  and evolution-authored skills need no such widening. This changes what Part 1
+  is for.
+- **OQ-2** — whether `apply` should go through the `Approver` port, which would
+  make evolution the second consumer of the mechanism the harness was built for,
+  at the cost of a proxy endpoint that is itself still unbuilt.
+
+**Build order when it is picked up:** Part 1 alone first, shipped and used —
+skills that a member or an admin wrote, loaded into the prompt, with the budget
+and the precedence in R2 and R3. Only then Part 2, starting at `observe`, which
+writes records and changes nothing. `draft` and its review panel (R12) come
+before `apply` ever ships.

--- a/.specs/features/ganglion-model-registry/spec.md
+++ b/.specs/features/ganglion-model-registry/spec.md
@@ -1,0 +1,258 @@
+# ganglion-model-registry — Specification (authoritative)
+
+**Status:** Implemented across all three repositories. See "Implementation status" below.
+**Date:** 2026-09-10.
+**Spans:** `crab-ganglion-harness`, `crab-shell-proxy`, `crab-exoskeleton-webapp`.
+**Closes:** `crab-ganglion-harness` spec DF-4 ("personal model overrides — answers 501").
+
+## Problem
+
+The stack already owns a full model inventory: `model-registry-source-of-truth`
+built a bbolt-backed registry with CRUD, a five-level resolution cascade
+(personal model > user pin > subscription > tenant > agent > global), deprecation
+with a named replacement, usage tracking that blocks deletion, and per-model
+fallback chains. `user-owned-models` added member-registered models on top, with
+a connectivity probe and admin policy locks.
+
+**None of it reaches a ganglion agent.** A ganglion container's model comes from
+one static field in the proxy's own `config.yaml` — `agent.Model` — shipped as
+three environment variables at container create:
+
+```
+GANGLION_MODEL, GANGLION_BASE_URL, GANGLION_API_KEY
+```
+
+The harness reads exactly one model, one endpoint, one key
+(`internal/config/config.go`), and `runtime.Loop.Model` overrides every turn's own
+`Model` field (`loop.go:412-420`), so even the per-turn seam the domain already
+has is inert.
+
+Three gates enforce that today, and each is correct **only while the harness
+cannot read a registry**:
+
+| Gate | Effect |
+|---|---|
+| `rejectNonPicoclawAgent` (`admin_model_scopes.go:37`) | `400` on per-user model assignment for a ganglion agent |
+| `picoclawOnly[featurePersonalModel]` (`harness_gate.go`) | `501` on the whole member-facing `/v1/models/mine` surface |
+| `PICOCLAW_ONLY = ["model", "config"]` (webapp `agent-scope.ts`) | the Model tab is absent for a ganglion agent |
+
+The proxy's own comment states the reason, and it is a good one: *"A harness that
+read its model from somewhere else would take an assignment nothing ever
+consults: the write restarts the container for nothing and leaves a phantom
+workspace referrer that blocks delete and disable of that model forever."*
+
+So this feature is not "build a registry". It is **teach the harness to read one,
+then remove the three gates that exist because it could not.**
+
+## Compatibility — what the word means here
+
+The requirement is *"compatível com o picoclaw para permitir que o webapp e proxy
+e tudo mais permita eu gerenciar usando as mesmas ferramentas"*.
+
+**Compatible means the same configuration format drives both harnesses. It does
+not mean identical runtime behaviour.** Written down once, because it will
+otherwise be re-argued at every divergence: picoclaw's fallback engine consults a
+cooldown tracker and a rate-limiter registry (`pkg/providers/fallback.go`);
+ganglion's will not in v1. Both read the same `model_list`.
+
+Concretely, ganglion adopts picoclaw's schema, verified against
+`pkg/config/config.go:760-798`:
+
+```jsonc
+{
+  "model_list": [
+    { "model_name": "primary",       // the alias the rest of the config names
+      "provider": "deepseek",        // routes to a protocol adapter
+      "model": "deepseek-chat",      // the id sent on the wire
+      "api_base": "https://api.deepseek.com/v1",
+      "enabled": true,
+      "fallbacks": ["backup"],       // other model_name entries
+      "extra_body": {},
+      "custom_headers": {},
+      "request_timeout": 0,
+      "api_keys": ["enc://…"] }      // OPTIONAL here — see FR-4
+  ],
+  "agents": { "defaults": {
+      "model_name": "primary",
+      "model_fallbacks": ["backup"] } }
+}
+```
+
+## Functional requirements — the harness
+
+**FR-1 — a config file, read-only, outside the workspace.** The harness reads
+structural configuration from a JSON file at `GANGLION_CONFIG_FILE` (default
+`/data/.ganglion/config.json`). It is mounted read-only and **must live outside
+the workspace bind**, exactly as `credential.key` already does — otherwise the
+shell tool could rewrite the model list, and a tool steered by untrusted natural
+language would be choosing its own provider endpoint.
+
+**FR-1.1** — absence of the file is not an error. A deployment that sets only the
+three environment variables keeps working unchanged; they synthesize a
+single-entry `model_list` named `default`. This is the back-compatibility floor
+and it has a test.
+
+**FR-1.2** — decoding is **lenient**. picoclaw's real `config.json` carries
+`channel_list`, `cron`, `heartbeat`, `agents.dispatch`, `tools.*` and much more
+ganglion has no types for. Unknown keys are ignored, never rejected.
+
+**FR-1.3** — an `api_keys` value equal to picoclaw's `[NOT_HERE]` sentinel
+(written by its `SecureString.MarshalJSON`) is treated as absent, not as a key.
+
+**FR-2 — a model registry in the harness.** `model_list` resolves into an ordered
+candidate chain: `agents.defaults.model_name`, then
+`agents.defaults.model_fallbacks`, then the primary entry's own `fallbacks`,
+de-duplicated, `enabled: false` skipped. Every candidate carries its own
+`provider`, `model`, `api_base`, key and `extra_body`.
+
+**FR-3 — per-turn selection.** `domain.Turn.Model` is honoured. A turn naming a
+`model_name` in the list runs on it; a turn naming nothing runs on the default
+chain; a turn naming an unknown model runs on the default chain **and says so in
+a `Progress` frame** rather than failing — a member should not lose a turn to a
+stale client.
+
+**FR-4 — keys.** Two sources, in order:
+
+1. `GANGLION_MODEL_KEY_<SLUG>`, where `<SLUG>` is `model_name` upper-cased with
+   every character outside `[A-Z0-9]` replaced by `_`. This is the path the proxy
+   uses. Values may be `enc://`.
+2. An inline `api_keys[0]` in the file, `enc://` or plaintext.
+
+`GANGLION_API_KEY` remains the key for the synthesized `default` entry (FR-1.1).
+A candidate resolving to no key is **skipped with a named log line**, never
+attempted — an unauthenticated call wastes a turn and returns a provider error
+that reads like a model problem.
+
+**FR-4.1 — `enc://` accepts picoclaw's domain too.** The two schemes are
+byte-identical but for the HKDF `info` string (`picoclaw-credential-v1` against
+`ganglion-credential-v1`); both are `salt(16)‖nonce(12)‖ciphertext`,
+AES-256-GCM, `ikm = HMAC-SHA256(SHA256(keyfile), passphrase)`, `HKDF-SHA256` to
+32 bytes. Decryption tries the ganglion domain first and picoclaw's second, so a
+value produced by picoclaw's own `credential.Encrypt` — same passphrase, same key
+file — resolves here. **Sealing always uses the ganglion domain.** The trade-off
+is deliberate and stated: domain separation is given up between two contexts that
+already share both factors and one writer, in exchange for one credential format
+across the stack.
+
+**FR-5 — fallback on failure.** When a candidate fails **before any byte of the
+answer has been emitted**, the next is tried. Once content or a tool call has
+reached the sink, the turn is committed to that model and the error surfaces — a
+half-answer must never be silently restarted under a different model, which would
+put two voices in one bubble.
+
+**FR-5.1** — every hop emits a `Progress` frame naming the model that failed and
+the one being tried; exhausting the chain returns the **last** provider error,
+not a synthetic one.
+
+**FR-6 — reload without recreate.** The file is re-read when its mtime changes,
+checked at turn start. A model change must not require destroying the container —
+that is what makes an admin edit feel instant. A malformed file on reload is
+**rejected and logged, the previous configuration kept**: a running agent never
+degrades because of a bad edit.
+
+## Functional requirements — the proxy
+
+**FR-7 — materialize for ganglion.** `resolveAndMaterialize` gains a ganglion
+branch: the same `registry.Resolve` result that produces picoclaw's `config.json`
++ `.security.yml` produces `<userDir>/.ganglion/config.json` plus the
+`GANGLION_MODEL_KEY_*` variables. **`registry.Resolve` itself is untouched** —
+one resolver, two sinks.
+
+**FR-8 — the config bind.** `ganglionBinds` gains
+`<userDir>/.ganglion/config.json:/data/.ganglion/config.json:ro`, and
+`ganglionBindDrift` learns it, so an existing container is recreated once and
+never again for this reason.
+
+**FR-9 — remove the three gates.**
+- `rejectNonPicoclawAgent` stops refusing a ganglion agent.
+- `picoclawOnly[featurePersonalModel]` drops ganglion, closing DF-4.
+- `authorizeScopeDefault`'s asymmetry is fixed in passing: today a
+  tenant/subscription-level scope default on a ganglion agent is **accepted and
+  then never consulted**, which is the precise failure the agent-level gate
+  exists to prevent. It becomes correct rather than being removed.
+
+**FR-10 — a key is a recreate, a model is not.** Env is fixed at create time; the
+config file is not. Changing which model a workspace runs rewrites the file and
+the harness picks it up (FR-6). Introducing a model whose key the container does
+not yet carry requires a recreate, and the proxy must perform it rather than
+leave a candidate that can only ever be skipped.
+
+## Functional requirements — the webapp
+
+**FR-11** — `PICOCLAW_ONLY` becomes `["config"]`. The Config tab addresses
+picoclaw's whole config tree through a bulk key editor; ganglion reads a strict
+subset, so it stays withheld and this feature does not change that.
+
+**FR-12** — the Model tab renders for a ganglion agent with **no new component**.
+The inventory, the cascade ladder and the fallback chain editor are
+harness-agnostic already; what changed is that the proxy stopped refusing the
+writes.
+
+**FR-13** — the member-facing personal-model surface appears for ganglion members,
+because the proxy stopped answering `501`.
+
+## Acceptance criteria
+
+- **AC-1** A ganglion agent with no config file behaves exactly as before — same
+  three env vars, same single model. Verified by test, not by inspection.
+- **AC-2** An admin changes a workspace's model; the running ganglion container
+  answers the next turn on the new model **without being recreated**.
+- **AC-3** A primary whose key is revoked falls through to its fallback within one
+  turn, and the member sees which model answered.
+- **AC-4** The shell tool cannot read the config file — asserted the way
+  `TestACommandCannotReadTheHarnessEnvironmentThroughProc` asserts the env: by
+  running a command under the sandbox and checking it is denied.
+- **AC-5** A picoclaw `config.json` copied verbatim into a ganglion agent loads:
+  every key ganglion does not understand ignored, every key it does understand
+  honoured.
+
+## Out of scope
+
+**Provider protocols beyond OpenAI-compatible HTTP.** picoclaw dispatches ~42
+protocol identifiers; ganglion has one adapter and this feature adds none. A
+`provider` naming a non-OpenAI-compatible protocol is accepted, recorded and
+routed through the OpenAI-compatible client — which is what picoclaw itself does
+for 30 of its 42. Anthropic-native, Bedrock, Gemini and the CLI-based providers
+are a separate feature with their own adapter work.
+
+**Cooldown tracking and rate-limiter registries.** picoclaw has them; v1 does not.
+
+## Open questions
+
+- **OQ-1** — Should a ganglion member be allowed a custom endpoint
+  (`ScopePolicy.AllowCustomEndpoint`)? The policy exists and defaults to refused.
+  Nothing here changes it; adopting it for ganglion is a deploy-time decision.
+- **OQ-2** — `model_probe`'s SSRF guard was written for the proxy calling on a
+  member's behalf. The harness now calls member-influenced endpoints too, from
+  inside the agent network. The guard is **not** ported in v1: an endpoint
+  reaching the harness came from an admin, or from a probe the proxy already
+  vetted. Revisit if a member-supplied endpoint can ever bypass the probe.
+
+---
+
+## Implementation status (2026-09-10)
+
+| Requirement | State |
+|---|---|
+| FR-1, FR-1.1, FR-1.2, FR-1.3 | **done** — `internal/config/file.go`, with a real picoclaw `config.json` as a test fixture |
+| FR-2, FR-3 | **done** — `Registry.Chain`, `domain.ModelChain` |
+| FR-4 | **done** — environment first, inline `api_keys` second |
+| FR-4.1 | **done** — and it is the finding that made a single credential format possible. The two schemes differ in one string |
+| FR-5, FR-5.1 | **done** — abandoned only while nothing has reached the member; mutation-checked |
+| FR-6 | **done** — mtime at turn start; a failed reload keeps the running registry |
+| FR-7, FR-8, FR-10 | **done** — `internal/docker/ganglion_config.go`, the config bind, `ganglionSecretDrift` |
+| FR-9 | **done** — `rejectUngovernedAgent` over an allowlist, `alsoServedBy`, and the every-level fix |
+| FR-11, FR-12, FR-13 | **done** — `INVENTORY_ONLY` + `inventoryGovernedAgentKeys` |
+| AC-1, AC-3, AC-4, AC-5 | **asserted by test** |
+| AC-2 | **not measured against a live container.** The mechanism is tested on both sides — the proxy rewrites only on a real change, the router reloads on mtime — but nobody has yet changed a model in the admin screen and watched a running `zcrab-g` answer on it |
+
+**Two things a reviewer should not assume are covered.**
+
+The harness has still never spoken to a real provider: every provider test is
+`httptest` with a recorded stream, which the `crab-ganglion-harness` spec already
+records and this feature does not change.
+
+`internal/docker`'s suite carries **10 pre-existing failures** in this sandbox,
+all `lchown … operation not permitted`. The branch was diffed against `main` by
+failing test NAME and the set is identical — but that means these paths are
+verified by reading and by their pure helpers, not by execution.

--- a/.specs/features/multimodal-with-fallback/spec.md
+++ b/.specs/features/multimodal-with-fallback/spec.md
@@ -1,0 +1,153 @@
+# multimodal-with-fallback — Specification (authoritative)
+
+**Status:** Implemented in the harness. See "Implementation status" below.
+**Date:** 2026-09-10.
+**Spans:** `crab-ganglion-harness`, `crab-shell-proxy`, `crab-exoskeleton-webapp`.
+**Depends on:** `ganglion-model-registry` (the config file, the candidate chain,
+the fallback mechanics this feature reuses in both directions).
+
+## Correcting the premise, because the correction makes the feature better
+
+The request was: *"O picoclaw existe a chave `agents.defaults.image_model` que
+permite registrar modelo para image-to-text. Entretanto essa config não permite
+fallback. Implemente as duas opções ainda com fallback."*
+
+Read against picoclaw v0.3.1, one third of that is wrong and it matters:
+
+| Claim | Reality |
+|---|---|
+| `agents.defaults.image_model` exists for image-to-text | **True** — `pkg/config/config.go:430` |
+| it permits no fallback | **False** — `image_model_fallbacks` is the very next line (`:431`), and `Fallback.ExecuteImage` walks it (`pipeline_llm.go:211-224`) |
+| picoclaw has text-to-image | **False, and stronger than "no fallback"** — there is no image generation anywhere in the tree |
+
+So the gap is not the one named. The three real ones are:
+
+1. **Text-to-image does not exist at all.** Net-new, in both harnesses' worlds.
+2. **The image model is `defaults`-only.** `ImageModel` lives on `AgentDefaults`
+   and never on `AgentConfig` — every agent in a picoclaw instance shares one
+   vision model, with no per-agent override.
+3. **The chain has no terminal behaviour.** When the image candidates are
+   exhausted, `pipeline_llm.go:282-287` returns `ControlBreak` with a user-facing
+   error. No text-only degradation, no retry with the image stripped. And because
+   the media reference stays in the session history, **every later turn in that
+   conversation fails identically** — this stack has already been bitten by
+   exactly that, which is why `deploy/picoclaw-glob/vision-unsupported-glm.patch`
+   exists.
+
+This feature builds against the real gaps.
+
+## The cost that is not obvious
+
+Ganglion has **no concept of an image**. `domain.Message.Content` is a `string`;
+the OpenAI adapter's `wireMessage.Content` is a `string`, not the multi-part
+`content: [{type,text|image_url}]` array; the SSE ingress carries no media field.
+Before one image moves, this feature touches the domain, the provider wire format,
+the HTTP ingress, the proxy's turn forwarding and the webapp's composer. That is
+the bulk of the work; the model selection on top of it is small.
+
+## What is being built
+
+### Image-to-text (vision)
+
+**R1 — an attachment in the domain.** `domain.Message` gains
+`Attachments []Attachment`, where `Attachment{Kind, MIME, Ref, Bytes}`. `Kind` is
+`image` in v1. The domain stays stdlib-only, as `arch_test.go` enforces.
+
+**R2 — multi-part on the wire.** When a completion carries attachments, the
+OpenAI adapter emits the array form with `image_url` parts (`data:` URLs), and the
+plain string form otherwise — so a text-only turn's bytes do not change.
+
+**R3 — a vision chain, per agent.** `agents.defaults.image_model` and
+`agents.defaults.image_model_fallbacks` are read from the config file, picoclaw's
+keys unchanged. **Unlike picoclaw, `agents.list[].model.image_*` overrides them
+per agent** (gap 2). Entries name `model_list` members, exactly as the text chain
+does.
+
+**R4 — routing.** A turn whose messages carry an image runs on the vision chain
+when one is configured. When none is, it runs on the ordinary chain — and if that
+model refuses the image, R5 applies.
+
+**R5 — a terminal behaviour, which is the actual feature.** When the vision chain
+is exhausted, or no vision model is configured and the text model refuses images,
+the turn **does not die**. It retries once with the attachments stripped and a
+system note stating that an image was present and could not be read. The answer
+is degraded and says so. This is the direct fix for gap 3 and for the failure
+`vision-unsupported-glm.patch` documents: the conversation stays usable instead of
+becoming permanently broken by one image in its history.
+
+**R5.1** — "the model cannot see images" is detected by the same error-text
+patterns picoclaw uses (`isVisionUnsupportedError`), **including this stack's own
+GLM case**, which upstream still lacks and which this repository carries as a
+patch. Porting it here means the ganglion path is born with the fix picoclaw
+needed a patch for.
+
+### Text-to-image (generation)
+
+**R6 — a `generate_image` tool.** Arguments `{prompt, size?, n?}`. It calls an
+OpenAI-compatible images endpoint (`POST {api_base}/images/generations`), writes
+each result into the workspace under `media/` and returns the paths in its
+`Result`, so the agent can then deliver them with the ordinary file path it
+already understands.
+
+**R7 — a generation chain.** `agents.defaults.image_gen_model` and
+`image_gen_model_fallbacks`, same shape and same per-agent override as R3. These
+keys are **new** — picoclaw has no equivalent to be compatible with — and are
+named to sit beside its existing ones so a future picoclaw that grows the feature
+has an obvious place to land.
+
+**R8 — the tool is absent when no generation model is configured.** Not present
+and answering "unavailable": absent from `Tools.Available`, so the model is never
+told about a capability it does not have.
+
+## Acceptance criteria
+
+- **AC-1** A turn carrying an image is answered by the configured vision model.
+- **AC-2** With the vision chain exhausted, the member gets a degraded answer that
+  states the image could not be read — and **the next turn in that conversation
+  works** (the regression `vision-unsupported-glm.patch` was written for).
+- **AC-3** A text-only turn's request bytes are unchanged by this feature.
+  Asserted directly against the serialized request, not inferred.
+- **AC-4** `generate_image` writes inside the workspace and nowhere else — it
+  runs in the harness process, but the path it writes is still checked, because a
+  prompt-chosen filename is member-influenced input.
+- **AC-5** With no generation model configured, `generate_image` is not in the
+  tool list at all.
+
+## Out of scope
+
+Audio and video. `Attachment.Kind` is an enum so they are additive, but nothing
+routes them in v1.
+
+Image editing / variations endpoints.
+
+A media store with reference-counting and cleanup policies, as picoclaw's
+`pkg/media` has. v1 writes files into the workspace, which is already the durable,
+per-user, size-bounded place the agent's own outputs live.
+
+---
+
+## Implementation status (2026-09-10)
+
+| Requirement | State |
+|---|---|
+| R1, R2 | **done** — `domain.Attachment`, `wireMessage.Content` as `any`, the string form kept for text-only turns |
+| R3 | **done** — picoclaw's `image_model` / `image_model_fallbacks`. The per-AGENT override of R3 is **not** built: this harness runs one agent per container, so `agents.list[].model.image_*` has nothing to address here. picoclaw's defaults-only limitation is real and is not a limitation of this design |
+| R4 | **done** — routed on the WINDOW carrying an image, not on the last message |
+| R5, R5.1 | **done**, and it is the feature. Mutation-checked twice: removing the degradation, and forgetting to strip |
+| R6 | **done** — `internal/adapter/tool/imagegen` |
+| R7 | **done** — `image_gen_model` / `image_gen_model_fallbacks`, new keys with no picoclaw equivalent |
+| R8 | **done** — absent from the tool list when unconfigured |
+| AC-1, AC-2, AC-3, AC-4, AC-5 | **asserted by test** |
+
+**The inbound path, and why it is not the one the spec assumed.** A member's
+image reaches this stack by being uploaded into their workspace; the proxy's turn
+request carries a plain string and no media. Rather than change the turn format
+picoclaw shares, the image is read from where it already is: `load_image` takes a
+workspace path, and the loop turns the result into a synthetic user message the
+vision chain can see. The harness ingress accepts inline attachments too, so a
+caller that does carry bytes is served — neither path is the other's fallback.
+
+**Not verified against a real provider.** No image has been sent to a real vision
+model from this harness. R5's degradation is exercised against a scripted
+provider returning picoclaw's own refusal strings, which is the right test for
+the routing and is not evidence about a live endpoint.

--- a/.specs/features/web-search-providers/spec.md
+++ b/.specs/features/web-search-providers/spec.md
@@ -1,0 +1,158 @@
+# web-search-providers — Specification (authoritative)
+
+**Status:** Harness implemented; the admin surface (R5) is partly built. See "Implementation status" below.
+**Date:** 2026-09-10.
+**Spans:** `crab-ganglion-harness`, `crab-shell-proxy`, `crab-exoskeleton-webapp`.
+**Closes:** `crab-ganglion-harness` spec DF-6 ("built-in `web_search` / `web_fetch`").
+**Depends on:** `ganglion-model-registry` FR-1 (the config file) and FR-4.1 (`enc://`).
+
+## Problem
+
+A ganglion agent has exactly one tool: `shell`. It cannot search the web. picoclaw
+ships ten search providers (`pkg/tools/integration/web.go`) — Brave, Tavily, Kagi,
+Perplexity, SearXNG, GLM, Baidu, Gemini grounding, DuckDuckGo, Sogou — behind one
+`web_search` tool, selected by a fixed priority order.
+
+The ask is *"permita o registro de provedores de busca … O usuário deve conseguir
+registrar igual acontece no picoclaw"*. In picoclaw, "registering" means editing
+`config.json` and `.security.yml` by hand. **In this stack that surface does not
+exist for a member or an admin**: `config.json` is materialized by the proxy and
+`.security.yml` is admin-only by an explicit decision
+(`native-secrets-admin-only`). So "the same as picoclaw" has to mean *the same
+providers and the same configuration keys*, reached through the admin UI.
+
+Half of it is already here and nobody can see it. `lib/secrets.ts` carries:
+
+```ts
+export const WEB_PROVIDERS = ["brave","tavily","kagi","gemini","perplexity","glm_search","baidu_search"];
+```
+
+and the proxy's `validateNativeSlot` accepts `web.<provider>` as a native secret
+slot. So an admin can already store a Brave key for a **picoclaw** agent. What is
+missing is: enabling a provider (as opposed to keying it), choosing which one is
+preferred, and a harness that uses any of it.
+
+## What is being built
+
+**R1 — a `web_search` tool in ganglion**, name and JSON schema byte-compatible
+with picoclaw's (`web.go:1923-1953`):
+
+```json
+{"type":"object",
+ "properties":{
+   "query":{"type":"string","description":"Search query"},
+   "count":{"type":"integer","minimum":1,"maximum":10},
+   "range":{"type":"string","enum":["d","w","m","y"]}},
+ "required":["query"]}
+```
+
+and returning picoclaw's exact result text, so a prompt written for one harness
+reads identically on the other:
+
+```
+Results for: <query>
+1. <title>
+   <url>
+   <snippet>
+```
+
+**R2 — a `web_fetch` tool**, retrieving one URL as text, capped at 50 000
+characters as picoclaw caps it (`defaultMaxChars`).
+
+**R3 — providers, v1 set.** `brave`, `tavily`, `searxng`, `duckduckgo`. The first
+two are the keyed providers this deployment is most likely to buy; `searxng` needs
+only a base URL; `duckduckgo` needs nothing and is the floor so the tool is never
+dead. Provider identifiers, config keys and key names are picoclaw's.
+
+**R4 — configuration**, under picoclaw's own path, read from the config file
+introduced by `ganglion-model-registry` FR-1:
+
+```jsonc
+{ "tools": { "web": {
+    "provider": "auto",              // or a provider name; "auto" walks R6's order
+    "brave":      { "enabled": true, "max_results": 5, "api_keys": ["enc://…"] },
+    "tavily":     { "enabled": true, "base_url": "", "max_results": 5 },
+    "searxng":    { "enabled": true, "base_url": "https://searx.example/" },
+    "duckduckgo": { "enabled": true, "max_results": 5 },
+    "fetch_limit_bytes": 2000000,
+    "proxy": "" } } }
+```
+
+**R4.1 — keys.** As with models: `GANGLION_WEB_KEY_<PROVIDER>` first, inline
+`api_keys[0]` second, both `enc://`-capable. The environment path is what the
+proxy uses, so a key never has to sit in a file the harness can be pointed at by
+mistake.
+
+**R5 — admin surface.** A **Search** section tab, admin-only, listing every known
+provider with an enable switch, its provider-specific fields, and a write-only key
+field. Stored per scope on the proxy beside the model registry, materialized into
+picoclaw's `.security.yml`/`config.json` and into ganglion's config file from the
+same record — the property that makes it "the same tools".
+
+**R6 — selection.** Picoclaw's order, restricted to the v1 set:
+explicit `tools.web.provider` if ready → `brave` → `tavily` → `searxng` →
+`duckduckgo`. "Ready" means enabled **and** carrying whatever credential it needs.
+
+**R6.1 — one deliberate divergence, recorded.** picoclaw picks a provider per
+query and **does not** retry against the next when the call fails
+(`resolveProviderName`; only intra-provider key-pool failover exists). Ganglion
+**does** fall through to the next ready provider on a transport or 5xx failure.
+This is a behavioural difference on purpose, and it is exactly the class of
+difference the `ganglion-model-registry` compatibility note exists to license.
+
+## Where the tool runs, and why it is not the shell
+
+The obvious cheap implementation — let the agent `curl` a search API from the
+shell tool — is refused. The shell tool's environment is scrubbed to
+`PATH HOME TERM LANG TZ` and an agreement test
+(`TestNoConfiguredVariableIsPassedToCommands`) fails the build if any `GANGLION_*`
+variable is added to that allowlist. Handing the shell a search API key would mean
+widening the allowlist, which would mean the key is readable by any command the
+model is talked into running.
+
+So `web_search` is a Go tool making its own HTTP call from the harness process,
+where the key never enters a child environment. Landlock does not restrain it and
+does not need to: Landlock governs the filesystem, and this tool touches none.
+
+## Acceptance criteria
+
+- **AC-1** With no provider configured, `web_search` returns a `Result` saying so.
+  It never fails the turn (DEC-2: a tool-level problem is the agent's to react to).
+- **AC-2** A Brave key set through the admin UI reaches a ganglion agent and a
+  picoclaw agent from the same record.
+- **AC-3** The result text for a given query is byte-identical in shape to
+  picoclaw's, verified against the format quoted in R1.
+- **AC-4** A command run through the shell tool cannot read any search key —
+  the same assertion class as `ganglion-model-registry` AC-4.
+- **AC-5** With `brave` enabled but its key revoked, the turn still gets results
+  from the next ready provider, and a `Progress` frame names the hop (R6.1).
+
+## Out of scope
+
+Kagi, Perplexity, GLM, Baidu, Gemini grounding, Sogou. Each is an adapter with its
+own wire format and its own free-tier; adding one after this feature is a file and
+a registration line, which is the point of building the registry rather than four
+hard-coded calls.
+
+`prefer_native` (letting the provider's own built-in search run instead of the
+tool). It presumes a provider capability probe ganglion does not have.
+
+---
+
+## Implementation status (2026-09-10)
+
+| Requirement | State |
+|---|---|
+| R1, R2 | **done** — `internal/adapter/tool/websearch`, schema and result text pinned to picoclaw's by literal test |
+| R3 | **done** — brave, tavily, searxng, duckduckgo |
+| R4, R4.1 | **done** — read from the shared config file; `GANGLION_WEB_KEY_<PROVIDER>` first |
+| R6, R6.1 | **done** — priority order, cross-provider fallback, a pinned provider used alone |
+| R5 | **PARTLY.** A key stored in the existing `web.<provider>` native secret slot now reaches a ganglion agent as well as a picoclaw one, which is the "same tools" property. What does NOT exist is the **Search section tab**: enabling a provider without keying it, `searxng`'s base URL, and `duckduckgo` (which needs no key, so nothing can infer intent from a stored secret) are unreachable from the admin UI |
+| AC-1, AC-3, AC-4, AC-5 | **asserted by test** |
+| AC-2 | **not exercised against a live deployment** — no Brave key is configured in this stack |
+
+**A bug the tests caught rather than review, worth keeping:** `tools.web` mixes
+scalars (`provider`, `proxy`, `fetch_limit_bytes`) with one object per provider
+in the same JSON object. Decoding it in a single pass into a map of provider
+structs fails on the scalars and silently yields **no providers** — the whole
+block reads as "search is off" while looking perfectly correct in the file.

--- a/.specs/project/STATE.md
+++ b/.specs/project/STATE.md
@@ -1,7 +1,24 @@
 # State
 
-**Last Updated:** 2026-09-07T00:00:00-03:00
-**Current Work:** **M5 observability planned, nothing implemented.** Two specs written for
+**Last Updated:** 2026-09-10T00:00:00-03:00
+**Current Work:** **Three of four harness-parity features implemented; the fourth
+is specified and deliberately not started.** `ganglion-model-registry` (the model
+inventory now governs ganglion agents, end to end across all three repositories),
+`web-search-providers` (`web_search` + `web_fetch` in the harness, four
+providers) and `multimodal-with-fallback` (images in through `load_image` or the
+ingress, images out through `generate_image`, each with a chain and a defined
+terminal behaviour). `ganglion-evolution` is specified with its prerequisite and
+its two open questions stated, and has zero lines of code — see AD-024.
+
+**The finding that shaped all of it:** picoclaw's `enc://` and this harness's are
+the SAME construction — `salt(16)‖nonce(12)‖ciphertext`, AES-256-GCM,
+`ikm = HMAC-SHA256(SHA256(key file), passphrase)`, `HKDF-SHA256` to 32 bytes.
+They differ in one string, the HKDF domain (`picoclaw-credential-v1` against
+`ganglion-credential-v1`). The harness now accepts picoclaw's domain on decrypt
+and still seals in its own, which is what makes one credential format across the
+stack real rather than aspirational.
+
+**Previously:** **M5 observability planned, nothing implemented.** Two specs written for
 adopting `harness-sphere` as a third submodule and repurposing it to work exclusively for
 this stack: `harness-sphere-integration` (land it, no Rust changed) and
 `harness-sphere-zombie-crab-scope` (cut the scope, teach it dynamic instances). Four
@@ -61,6 +78,64 @@ still operator-gated (needs the backend stack). M4 (crab-shell-proxy) live-conta
 ---
 
 ## Recent Decisions (Last 60 days)
+
+### AD-024: the model inventory governs ganglion; evolution is deferred with its reason (2026-09-10)
+
+**Four features were asked for. Three shipped and one did not, on purpose.**
+
+**What made the first three possible was not new machinery, it was removing a
+gate whose premise had expired.** `rejectNonPicoclawAgent` said a non-picoclaw
+harness "reads its model from the proxy configuration", and it was right: a
+ganglion container took its model from one static `config.yaml` field as three
+environment variables. The fix was to give the harness a sink — a picoclaw-shaped
+`config.json` written by the proxy from the SAME `registry.Resolve`, bound
+read-only above the workspace — and then the gate had nothing left to protect.
+`registry.Resolve` itself is untouched: one resolver, two sinks.
+
+**Three defects surfaced as consequences rather than as goals.**
+
+1. `authorizeScopeDefault` checked the harness only at the AGENT level. A tenant-
+   or subscription-level default on an ungoverned agent was accepted and then
+   never consulted — the precise failure the agent-level check exists to prevent,
+   one scope up. Now checked at every mutating level.
+2. Dropping `model` from the webapp's `PICOCLAW_ONLY` leaked it to the legacy
+   all-agents store — **the same regression this repository already caught once
+   for `persona`**. A model assignment resolves for a workspace; the legacy entry
+   is an address for shared content and has no workspace. Caught by
+   `agent-scope.test.ts`, not by review, for the second time.
+3. `tools.web` mixes scalars with one object per provider in the same JSON
+   object. A single-pass decode into a map of provider structs fails on the
+   scalars and silently yields no providers — the whole block reads as "search is
+   off" while looking correct in the file. Caught by a test written before the
+   code was trusted.
+
+**The premise of the image request was one-third wrong, and saying so improved
+the feature.** `agents.defaults.image_model` DOES permit fallback —
+`image_model_fallbacks` is the next line of picoclaw's struct. The three real
+gaps are that text-to-image does not exist at all, that the image model is
+defaults-only, and that an exhausted chain ends the turn with an error — and
+because the media reference stays in the session history, **every later turn in
+that conversation fails identically**. That last one is the production failure
+`deploy/picoclaw-glob/vision-unsupported-glm.patch` exists for. The harness now
+degrades instead: strips the image from a COPY of the window, tells the model
+what happened, retries once, and says so to the member.
+
+**Why evolution is not built.** It is two features — a skills loader, then
+evolution on top — and `grep -rn skill --include='*.go'` in the harness returns
+nothing, so `apply` mode would write `SKILL.md` files nothing reads. That is the
+"stores a setting that changes nothing" failure the harness spec's deferred table
+exists to prevent. picoclaw's own `pkg/evolution` is 34 files and ~12 500 lines.
+Two of its decisions are the owner's, not an implementer's: whether admin-managed
+shared skills should mount into ganglion containers at all, and whether `apply`
+should go through the `Approver` port. Spec written, build order recorded, zero
+code.
+
+**What is NOT verified.** The harness has still never spoken to a real provider —
+every provider test is `httptest` with a recorded stream. No image has been sent
+to a real vision model. No Brave key exists in this deployment. AC-2 of
+`ganglion-model-registry` (an admin changes a model and a RUNNING container
+answers on it) is tested on both sides of the mechanism and has not been watched
+happen.
 
 ### AD-023: harness-sphere runs as a privileged daemon; FR-C2's "non-root" is withdrawn (2026-09-08)
 


### PR DESCRIPTION
Authoritative cross-repo specs for this round, plus AD-024 in `STATE.md`.

**Specs only — no submodule pointers move in this PR.** The three child PRs are open and a pointer bump follows once they merge.

| Feature | State |
|---|---|
| `ganglion-model-registry` | implemented across all three repositories |
| `web-search-providers` | harness implemented; the admin Search tab (R5) is not |
| `multimodal-with-fallback` | implemented in the harness |
| `ganglion-evolution` | specified, **zero lines of code**, with the reason written down |

## Three things the specs record that the code alone would not say

**The premise of the image request was one-third wrong.** `agents.defaults.image_model` *does* permit fallback — `image_model_fallbacks` is the very next line of picoclaw's struct and `Fallback.ExecuteImage` walks it. The three real gaps are larger: text-to-image does not exist in picoclaw at all, the image model is defaults-only, and an exhausted chain ends the turn with an error that **then repeats on every later turn in that conversation** — the production failure `deploy/picoclaw-glob/vision-unsupported-glm.patch` exists for. Correcting the premise produced a better feature than building the one that was asked for.

**"Compatible with picoclaw" is defined once.** The same configuration format drives both harnesses; it does **not** mean identical runtime behaviour. Written down so it is not re-argued at every divergence — and each deliberate divergence is then licensed against that sentence rather than defended on its own.

**Evolution is two features, and the first is invisible from outside.** `grep -rn skill --include='*.go'` in the harness returns nothing, so `apply` mode would write `SKILL.md` files nothing reads — the exact *"stores a setting that changes nothing"* failure the harness spec's deferred table exists to prevent. picoclaw's own `pkg/evolution` is 34 files and ~12 500 lines, and two of its decisions are the owner's rather than an implementer's. Spec, prerequisite, measured size, open questions and build order are recorded instead of an empty directory.

## What is not verified

Stated in each implementation-status table rather than left to be discovered: the harness has still never spoken to a real provider, no image has been sent to a real vision model, no Brave key exists in this deployment, and `internal/docker`'s 10 pre-existing `lchown` failures mean those paths are verified by reading and by their pure helpers rather than by execution.

Children: `crab-ganglion-harness#3`, `crab-shell-proxy#41`, `crab-exoskeleton-webapp#57`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)