### PR TITLE
Round 3: reasoning depth, sub-agents, and projects

### DIFF
--- a/.specs/features/ganglion-projects/spec.md
+++ b/.specs/features/ganglion-projects/spec.md
@@ -267,14 +267,31 @@ added: `project`.
 is running** — waking a `scale-to-zero` agent — and delivers the job's message as
 an ordinary turn on the job's project.
 
-**FR-B4** — A fired job's turn is written into a **real conversation**, not a
-throwaway session. Which conversation is FR-B5. picoclaw's `agent:cron-<id>-<uuid>`
-sessions are why a member can never see what their schedule did; this is the
-second half of the different mechanism.
+**FR-B4** — A fired job **delivers to nobody**. Its run is stored and read from
+the Tasks panel, exactly as a picoclaw run is today. *(Owner's decision,
+2026-09-10: "a tarefa não responde a ninguém. Elas ficam salvas e posso
+visualizar na sidebar igual no picoclaw.")*
 
-**FR-B5** — A job carries the conversation it belongs to. Its output lands there,
-so the member opens the chat and finds it. A job with no conversation creates one
-named after the job, once, and reuses it.
+This is smaller than what this spec first proposed and it is better, because the
+whole read surface already exists and is harness-blind:
+`history.CronRuns(sessionsDir)` discovers runs, `history.ReadCronRun` serves one
+transcript, `/v1/cron/runs` exposes both, and the webapp's Tasks panel renders
+them. Nothing on that path needs to change.
+
+**FR-B5** — A run is written where that reader already looks. The proxy runs the
+turn with the conversation id `agent:cron-<jobID>-<runID>` — picoclaw's own
+shape, so `splitCronKey` reads it unchanged — and the harness writes
+`<sessionsDir>/<basename>.jsonl` as it does for any conversation.
+
+**FR-B5a** — The **proxy** writes the run's `<basename>.meta.json`, because it
+is the only participant that knows the job, the run and the originating scope,
+and because the ganglion has no concept of a scheduled turn at all. This is the
+one piece of the reader's contract the harness does not already satisfy: it
+writes transcripts, never metas.
+
+**FR-B5b** — A run belongs to its project's sessions directory, so a project's
+schedules are listed under that project and the main workspace's under none. This
+is the part picoclaw structurally cannot do (T-1).
 
 **FR-B6** — `lastStatus` and `lastError` are written on every run. The webapp's
 Tasks panel already renders them and `agent-projects-scope-fixes` records that
@@ -290,9 +307,10 @@ cron, because moving it would mean two schedulers racing over one `jobs.json`.
 The spec records that unifying them later is the obvious follow-up and that B1
 would be fixed for picoclaw too by the same code.
 
-**FR-B9** — A schedule that fires while a turn is already running on that
-conversation is **queued, not dropped and not interleaved**. Two turns on one
-conversation would corrupt the window.
+**FR-B9** — A schedule that fires while a turn is already running is **queued,
+not dropped and not interleaved**. A run has its own conversation id (FR-B5), so
+it cannot corrupt a member's window — but two turns at once in one container
+share a workspace, and the ganglion's own single-flight is per conversation.
 
 ---
 
@@ -331,6 +349,11 @@ be possible.
 **FR-C6** — An MCP call that fails returns a `domain.Result` describing the
 failure. It never fails the turn, and it never fails boot after boot succeeded —
 if the graph is unreachable mid-turn the agent is told and carries on.
+
+**FR-C6a** — The graph is scoped per member and spans that member's projects
+(OQ-1). No tool parameter names a project, and the bearer's payload is unchanged,
+so a ganglion container reaches exactly the graph a picoclaw container in the
+same workspace would.
 
 **FR-C7** — The proxy's per-workspace MCP writer runs for ganglion workspaces too,
 writing the block into the ganglion `config.json` via `ganglionConfigDoc`. The
@@ -397,11 +420,14 @@ exists for.
 **AC-B2** — Two projects each with a schedule produce two jobs whose runs write
 into their own project's transcript — the case picoclaw structurally cannot serve.
 
-**AC-B3** — A fired job's output is readable through
-`GET /v1/sessions/history` for the conversation it names (FR-B4, FR-B5).
+**AC-B3** — A fired job's run appears in `GET /v1/cron/runs` and its transcript
+is served by the existing run endpoint, with **no** new conversation in
+`GET /v1/sessions/history` (FR-B4, FR-B5). The second half is the assertion that
+discriminates: a run that also created a conversation would still pass a test
+that only checked the panel.
 
-**AC-B4** — A job that fires while a turn is running on the same conversation runs
-**after** it, and the window contains both turns in order (FR-B9).
+**AC-B4** — A job that fires while a member's turn is running on the same
+project runs **after** it, and neither window is corrupted (FR-B9).
 
 **AC-C1** — With the MCP block present, `tools/list` results appear in the tool
 schemas the model sees, and a `tools/call` round-trips against a fake MCP server.
@@ -439,30 +465,27 @@ authenticates a ganglion workspace's MCP calls, from the same secret (FR-C7).
 
 ## Open questions
 
-**OQ-1 — Is the memory graph scoped per project or per member?**
+**OQ-1 — RESOLVED. The graph matches picoclaw's scope.** *(Owner, 2026-09-10:
+"igual no picoclaw, global ou por projeto.")*
 
-The MCP bearer's payload is `tenantID/subsAccID/role/userAccID` — there is **no
-project dimension** — and `memory-graph-mcp` FR-4.2 requires the payload→Scope
-mapping to stay injective, with `Mint` rejecting any field containing the
-delimiter. Adding a project field means changing a security-critical path that was
-specified carefully and is shared with picoclaw.
+picoclaw's graph — which is ours, hosted by the proxy — is scoped per MEMBER:
+the MCP bearer's payload is `tenantID/subsAccID/role/userAccID` and carries no
+project dimension. So matching picoclaw means **per member, spanning a member's
+projects**, and slice C needs no change to a security-critical path that
+`memory-graph-mcp` FR-4.2 specified carefully and that both harnesses share.
 
-**Recommendation: per member, shared across projects, in v1.** It is the cheap
-answer, it needs no proxy security change, and a graph that spans a member's
-projects is arguably the more useful one — "what do I know about this supplier"
-does not stop at a project boundary. If per-project is wanted, it is a token
-payload change with its own injectivity argument, and it should be its own slice.
+**The assumption this records, so it can be corrected rather than discovered:**
+"global or per project" is read as naming the two shapes rather than requesting
+both now, with picoclaw's behaviour as the anchor. Per-project is therefore
+**deliberately additive**: it is one more field in the token payload, with its
+own injectivity argument, and slice C is built so that adding it later changes
+the payload and nothing else. If the intent was to offer the member the choice in
+v1, that is a small extension of C and not a redesign of it.
 
-**Blocking for slice C only.** A and B do not depend on it.
-
-**OQ-2 — Which conversation does a scheduled job write into (FR-B5)?**
-
-Three shapes: (a) the conversation the member scheduled it from, (b) one
-conversation per job, created on first run, (c) a single "Scheduled" conversation
-per project. (a) is most natural to a member and drifts oddly when they delete
-that chat; (b) is tidy and makes the Tasks panel's "open the run" obvious; (c) is
-the smallest. **Recommendation: (b)**, with the job's name as the conversation
-title. Answering this is required before slice B is designed.
+**OQ-2 — RESOLVED, and it made slice B smaller.** See FR-B4. A fired job
+delivers to nobody; its run is stored and read from the Tasks panel, which
+already exists end to end. The three conversation-delivery shapes this section
+used to weigh are all withdrawn.
 
 **OQ-3 — Does the member see project files anywhere?**
 

--- a/.specs/features/ganglion-projects/spec.md
+++ b/.specs/features/ganglion-projects/spec.md
@@ -1,0 +1,472 @@
+# ganglion-projects — Specification
+
+**Status:** Draft
+**Size:** Complex — **three slices, each shippable alone**
+**Repos touched:** `crab-ganglion-harness`, `crab-shell-proxy`, `crab-exoskeleton-webapp`
+
+| Slice | What | Depends on |
+|---|---|---|
+| **A — scoped workspace** | A ganglion turn runs inside a project: its own files, transcripts, window and `MEMORY.md` | nothing |
+| **B — scheduled tasks** | Per-project schedules, with the clock in the **proxy** | A |
+| **C — the memory graph** | An MCP client in the harness, reaching the proxy's existing graph server | A |
+
+Slice A alone closes DF-3 and turns three `501`s into working routes. B closes
+DF-5 and fixes a defect picoclaw structurally cannot fix. C closes DF-1 and DF-2.
+
+---
+
+## Problem
+
+The request was for "projects with memory, a graph, scheduled tasks and separate
+files in an exclusive workspace, like picoclaw — but use a different mechanism if
+one is needed."
+
+Two corrections to the premise, both verified at source, and both in the
+requester's favour:
+
+**1. picoclaw has no projects.** A search of v0.3.1 for `project` as a type,
+field, config key or tool returns nothing but OAuth `project_id`. Its scoping
+units are *agents* — one workspace directory each, resolved by
+`resolveAgentWorkspace` (`pkg/agent/instance.go:365-377`) — and a `SessionScope`
+over channel/account/dimensions. **Projects are ours.** They live in
+`crab-shell-proxy/.specs/features/agent-projects/`, are built on picoclaw's
+`agents.list` plus a glob-matching patch to `agents.dispatch`, and are already
+shipped for picoclaw.
+
+**2. picoclaw has no knowledge graph either.** `grep -i 'knowledge.?graph'` over
+the tree returns zero. `pkg/seahorse` is a hierarchical **conversation-summary**
+DAG over SQLite with `short_grep`/`short_expand` — no entities, no relations. The
+graph is also ours: a proxy-hosted MCP server at `/v1/mcp` with fifteen tools
+(`crab-shell-proxy/.specs/features/memory-graph-mcp/`), injected into each
+picoclaw workspace as `tools.mcp.servers.memory`.
+
+So the ask is not "port a picoclaw feature". It is **give the ganglion harness
+what our own proxy already offers picoclaw**, which is exactly the DF-1/DF-2/DF-3/
+DF-5 row of `.specs/features/crab-ganglion-harness/spec.md`. Today
+`internal/httpapi/harness_gate.go` lists `featureProjects` and
+`featureMemoryGraph` as `picoclawOnly`, so a ganglion agent gets a `501` naming
+the harness — which is honest, and is the thing to remove.
+
+**And the invitation to use a different mechanism has two concrete targets.**
+
+---
+
+## The two places picoclaw's mechanism is the wrong one to copy
+
+**T-1 — picoclaw's cron is one store per container, and cannot be per project.**
+`pkg/gateway/gateway.go:843` builds the store path from `cfg.WorkspacePath()` —
+the **default** workspace, not the routed agent's — so every project's schedule
+lands in one `cron/jobs.json`. This is already recorded as defect **B1** in
+`agent-projects-scope-fixes`, with the root cause confirmed and marked
+unfixable from our side. A fired job also runs in a throwaway session
+(`agent:cron-<jobid>-<uuid>`), so it never joins the member's conversation.
+
+**T-2 — the ganglion runs `scale-to-zero`, so a clock inside it does not tick.**
+`crab-shell-proxy/config.yaml:126` sets `mode: "scale-to-zero"` for the `gamma`
+agent with a 15s idle timeout, and the comment there says exactly why: it is *the
+point* of the ganglion. A scheduler inside the harness would be asleep whenever it
+had work. This is the same wall `ganglion-evolution` hit, where
+`cmd/crab-ganglion/main.go` turns `cold_path_trigger: scheduled` under
+`scale-to-zero` into a boot refusal rather than a silent no-op.
+
+Both point the same way: **slice B puts the clock in the proxy**, which is awake,
+owns the container lifecycle, and can wake a stopped container to deliver a turn.
+That is the different mechanism the request invited, and it makes per-project
+schedules possible for the first time in this stack.
+
+---
+
+## Grounding in the harness (verified — do not re-derive)
+
+- The workspace is `filepath.Join(cfg.DataDir, "workspace")`
+  (`cmd/crab-ganglion/main.go:98`), and the `workspace` segment is mandatory
+  because the proxy reads transcripts there. Under it: `sessions/` (`main.go:110`),
+  `windows/` (`main.go:118`), `skills/`, `state/evolution/`, `media/`, `.tmp/`.
+- **The stores are keyed by `ConversationID` alone** (`jsonl.go:46`,
+  `window.go:27`). `domain.SessionKey` is carried through `Turn` and reaches the
+  `Learner` and the `Approver` but **keys nothing on disk**. There is no per-scope
+  directory concept today.
+- Scope arrives in headers the proxy sets, and `httpsse.go:205` states the rule:
+  *"The harness never derives them: the proxy owns the preimage, and computing it
+  twice is how two components silently disagree."*
+- The Landlock rule set is computed from **one** workspace root
+  (`exec/sandbox.go:38`).
+- The container mounts **one** bind, the workspace (`ganglionWorkspaceBind`), and
+  proxy-owned state is deliberately kept *above* it so the shell tool cannot read
+  it.
+- `go.mod` has **zero** requires.
+
+---
+
+## Decisions
+
+**D-1 — A project is a subdirectory of the existing workspace, not a new bind.**
+
+picoclaw's projects are one bind per project, and creating or deleting one
+**recreates the container** (`agent-projects` FR-10). Ganglion uses
+`workspace/projects/<id>/` under the bind it already has. Consequences, all of
+them intended:
+
+- No new mount, so **no container recreate** on project create or delete. For a
+  `scale-to-zero` agent whose container may not even exist, "recreate to add a
+  project" is a strange thing to have to do.
+- `SandboxRules` still computes from one root, so the sandbox needs no change.
+- **The cost, stated plainly: this is not a kernel boundary.** Landlock grants the
+  whole workspace tree, so the shell tool inside project A can `cd
+  ../b` and read project B. Isolation between projects is a harness-enforced
+  convention — the same kind of confinement `loadimage.go` documents when it says
+  `resolve()` *is* the whole boundary — not a container or LSM guarantee. It
+  separates a member's own work from their own other work. It is **not** a
+  security boundary and must not be described to a member as one.
+
+**D-2 — The project is a header. The harness never derives it.**
+
+`X-Ganglion-Project`, set by the proxy, following `httpsse.go:205` verbatim. The
+proxy's picoclaw path already encodes the project into the session id as
+`p.<id>.<key>` (`agent-projects` FR-8), and the harness deliberately does **not**
+parse that: it is picoclaw's routing convention, it would make the harness depend
+on a string format owned elsewhere, and two components deriving the same thing is
+the failure `httpsse.go` names.
+
+**D-3 — An unknown project is refused, never silently degraded to the main
+workspace.** Same rule as the proxy's FR-8a, for the same reason: writing a
+member's conversation into the wrong workspace is worse than an error.
+
+**D-4 — Memory is a file, and ganglion has none today.**
+
+picoclaw's memory is plain Markdown — `<workspace>/memory/MEMORY.md` plus daily
+notes — injected into the prompt and edited with the ordinary file tools. There is
+**no memory tool**. Ganglion gets the same: `MEMORY.md` at the project root,
+appended to the system prompt by `skills.Prompt`, edited by the `shell` tool the
+agent already has. No new tool, no new store, and a file the member can read.
+
+Worth naming: this is the **first memory the ganglion harness has ever had**. Its
+only persistence today is the transcript and the window.
+
+**D-5 — The graph is reached, not rebuilt.**
+
+The proxy already hosts the graph and its fifteen tools over MCP streamable HTTP.
+Slice C gives the harness a minimal MCP client — `initialize`, `tools/list`,
+`tools/call` over JSON-RPC — and registers the server's tools into the tool
+registry. Hand-written, because `go.mod` has zero requires and adding the MCP SDK
+to reach three methods would be the largest dependency decision in the project's
+history taken as a side effect of a memory feature.
+
+---
+
+## Requirements — Slice A: the scoped workspace
+
+### Harness
+
+**FR-A1** — `domain.Turn` gains `Project string`. Empty means the main workspace
+and today's behaviour, unchanged.
+
+**FR-A2** — The ingress reads `X-Ganglion-Project`, falling back to a `project`
+field on the JSON body, mirroring how `sessionID` already works.
+
+**FR-A3** — A project id is validated on arrival against
+`^[a-z0-9][a-z0-9_-]{0,63}$`, the same alphabet the proxy generates
+(`agent-projects` FR-5a). A value failing it is refused with 400. The id becomes a
+path segment, so this is the only thing standing between a header and a traversal.
+
+**FR-A4** — Layout, for project `<id>`:
+
+```
+workspace/
+  sessions/                     # unchanged: the main workspace
+  windows/
+  projects/<id>/
+    sessions/
+    windows/
+    files/                      # the member-visible working directory
+    media/
+    MEMORY.md
+```
+
+**FR-A5** — `jsonl.Store` and `window.Store` resolve their path from
+`(project, conversationID)` rather than from `conversationID` alone. A turn with
+no project reads and writes exactly the paths it does today — asserted
+byte-for-byte, because this is the change that could silently orphan every
+existing transcript.
+
+**FR-A6** — `projects` is a reserved name in the main workspace. A conversation id
+cannot produce a path under it, and `filepath.Clean` on the resolved path must
+still be inside the intended root or the store refuses.
+
+**FR-A7** — The system prompt for a project turn is the persona and skills as
+today, plus the project's `MEMORY.md` when it is non-empty, plus the project
+instructions the proxy seeds (FR-A11). Order: persona, project instructions,
+memory, skills index — persona first, as `skills.Prompt` already guarantees.
+
+**FR-A8** — `MEMORY.md` is read per turn through the same TTL cache
+`skills.Prompt` already uses, so a turn does not re-read the disk per iteration
+and an edit the agent makes is visible on the next turn.
+
+**FR-A9** — The `shell` tool's working directory for a project turn is
+`projects/<id>/files`. The Landlock domain is unchanged and still grants the whole
+workspace (D-1).
+
+**FR-A10** — `generate_image` writes to `projects/<id>/media` and `load_image`
+resolves against `projects/<id>` for a project turn. The two must agree, as they
+already do for the main workspace.
+
+### Proxy
+
+**FR-A11** — On every ensure for a **ganglion** workspace, the proxy creates
+`workspace/projects/<id>/{sessions,windows,files,media}` for each project in
+`.projects.json` and writes the project's instructions where FR-A7 reads them.
+This mirrors `composeProjectAgentMD` and is fully derived from the store, so an
+edit the agent makes to that file is reverted on the next ensure — the same
+tradeoff, documented in the same place.
+
+**FR-A12** — The chat path sends `X-Ganglion-Project` when the request names a
+project, and sends nothing when it does not.
+
+**FR-A13** — The history reader resolves a ganglion project transcript at
+`workspace/projects/<id>/sessions/<conversation>.jsonl`.
+
+**FR-A14** — `featureProjects` gains a `alsoServedBy` row for
+`config.HarnessGanglion`. The row is added rather than the `picoclawOnly` entry
+being deleted, so a fourth harness is still refused by default — the reason that
+table is structured that way.
+
+**FR-A15** — Creating or deleting a project for a ganglion agent **must not**
+recreate or restart the container (D-1). `ganglionBindDrift` must not see a
+difference, because there is none.
+
+### Webapp
+
+**FR-A16** — In the same change as FR-A14, `app/admin/agent-scope.ts` is checked
+and, if a projects section exists there, adjusted. This is not optional diligence:
+the last two gate changes — `persona`, then `model` — **both** leaked a tab to the
+legacy all-agents store, and both were caught by the same test after the fact. The
+question to answer explicitly is whether the section is withheld for a *harness*
+reason (`PICOCLAW_ONLY`) or an *address* reason (`LEGACY_TABS`), and to state it
+where it applies.
+
+**FR-A17** — The project selector already exists for picoclaw agents and is not
+harness-gated in the UI; the work is verifying it, not building it.
+
+---
+
+## Requirements — Slice B: scheduled tasks, with the clock in the proxy
+
+**FR-B1** — Schedules are stored **by the proxy**, per project, at
+`<user data dir>/.schedules.json` — beside `.projects.json`, above `workspace/`,
+and therefore unreachable by the agent. One file per (tenant, subscription, agent,
+user), with each record naming its project (or none, for the main workspace).
+
+**FR-B2** — The record shape is picoclaw's, verbatim, so the existing read-only
+`/v1/cron/*` surface and the webapp Tasks panel keep working unchanged:
+`{id, name, enabled, schedule{kind, expr|everyMs|atMs, tz}, payload{kind, message,
+channel, to}, state{nextRunAtMs, lastRunAtMs, lastStatus, lastError}, createdAtMs,
+updatedAtMs, deleteAfterRun}`, in an envelope `{version, jobs[]}`. One field is
+added: `project`.
+
+**FR-B3** — The proxy runs one scheduler. On a due job it **ensures the container
+is running** — waking a `scale-to-zero` agent — and delivers the job's message as
+an ordinary turn on the job's project.
+
+**FR-B4** — A fired job's turn is written into a **real conversation**, not a
+throwaway session. Which conversation is FR-B5. picoclaw's `agent:cron-<id>-<uuid>`
+sessions are why a member can never see what their schedule did; this is the
+second half of the different mechanism.
+
+**FR-B5** — A job carries the conversation it belongs to. Its output lands there,
+so the member opens the chat and finds it. A job with no conversation creates one
+named after the job, once, and reuses it.
+
+**FR-B6** — `lastStatus` and `lastError` are written on every run. The webapp's
+Tasks panel already renders them and `agent-projects-scope-fixes` records that
+their possible values were never observed; the proxy writing them makes them
+knowable.
+
+**FR-B7** — The write routes (`POST`/`PATCH`/`DELETE` on `/v1/cron/tasks`) are
+new. Reading stays as it is. Permissions match the surrounding surface: read
+requires `read`, mutation requires `write`.
+
+**FR-B8** — This slice is **ganglion-only in v1**. picoclaw keeps its own in-container
+cron, because moving it would mean two schedulers racing over one `jobs.json`.
+The spec records that unifying them later is the obvious follow-up and that B1
+would be fixed for picoclaw too by the same code.
+
+**FR-B9** — A schedule that fires while a turn is already running on that
+conversation is **queued, not dropped and not interleaved**. Two turns on one
+conversation would corrupt the window.
+
+---
+
+## Requirements — Slice C: the memory graph
+
+**FR-C1** — A minimal MCP client in the harness: `initialize`, `tools/list`,
+`tools/call` over JSON-RPC 2.0 on streamable HTTP `POST`, plus `DELETE` to close
+the session. Hand-written, stdlib only (D-5). It handles both a JSON response body
+and an SSE-framed one, because the transport permits either.
+
+**FR-C2** — Configuration is read from `tools.mcp.servers.<name>` in the same
+`config.json` the harness already reads — picoclaw's exact shape, `command: ""`
+included, so the proxy's existing writer serves both harnesses:
+
+```json
+"tools": { "mcp": { "enabled": true, "servers": { "memory": {
+  "enabled": true, "command": "", "type": "http",
+  "url": "http://crab-shell-proxy:8080/v1/mcp",
+  "headers": { "Authorization": "Bearer <token>" } } } } }
+```
+
+**FR-C3** — Only `type: "http"` is supported. A `command`-based (stdio) server is
+**refused at boot naming the server**, not ignored: the ganglion container has no
+package manager and no way to run one, and a silently absent memory is the failure
+mode this whole gate table exists to prevent.
+
+**FR-C4** — Tools discovered from the server are registered into the tool registry
+under their own names, with the server's own schemas. The harness does not
+re-declare the fifteen graph tools; a change on the server side reaches the agent
+without a harness release.
+
+**FR-C5** — A tool name collision with a built-in tool is refused at boot naming
+both. Silently shadowing `shell` from a remote server is not a thing that should
+be possible.
+
+**FR-C6** — An MCP call that fails returns a `domain.Result` describing the
+failure. It never fails the turn, and it never fails boot after boot succeeded —
+if the graph is unreachable mid-turn the agent is told and carries on.
+
+**FR-C7** — The proxy's per-workspace MCP writer runs for ganglion workspaces too,
+writing the block into the ganglion `config.json` via `ganglionConfigDoc`. The
+bearer token is minted exactly as it is for picoclaw, from the same secret, so no
+new credential path exists.
+
+**FR-C8** — `featureMemoryGraph` gains an `alsoServedBy` row for ganglion, under
+the same rule as FR-A14, and FR-A16's webapp check applies again.
+
+---
+
+## Non-functional
+
+**NFR-1** — A ganglion agent with **zero** projects behaves byte-identically to
+today: same paths, same files, same requests. This is the regression bar.
+
+**NFR-2** — Zero new dependencies in the harness. `go.mod` stays at zero requires,
+FR-C1 included.
+
+**NFR-3** — No slice requires a container recreate. A ganglion agent under
+`scale-to-zero` may have no container at all when a project is created.
+
+**NFR-4** — The isolation claim is accurate everywhere it appears. D-1 is a
+convention, and no requirement, API description or UI string may call it
+containment.
+
+**NFR-5** — `go test -race ./...` clean; the four CI steps unchanged.
+
+---
+
+## Acceptance criteria
+
+**AC-A1** — A turn with no project writes exactly the paths it writes today, with
+the same bytes. A mutation that changes the unscoped path makes this fail.
+
+**AC-A2** — A turn with `X-Ganglion-Project: demo` writes its transcript to
+`workspace/projects/demo/sessions/`, and the main `workspace/sessions/` is
+untouched.
+
+**AC-A3** — `X-Ganglion-Project: ../../etc` is refused with 400 and creates no
+directory (FR-A3, FR-A6).
+
+**AC-A4** — A project turn's system prompt contains the project's `MEMORY.md`
+content and the project instructions; the same agent's non-project turn contains
+neither.
+
+**AC-A5** — Two projects' transcripts do not mix: a conversation id used in both
+yields two files and two independent histories.
+
+**AC-A6** — `GET /v1/sessions/history?project=demo` against a ganglion agent
+returns the project transcript, and the unscoped call does not (matching the
+picoclaw AC-5 it mirrors).
+
+**AC-A7** — Creating a project on a ganglion agent does not restart the container
+(FR-A15) and does not 501 (FR-A14).
+
+**AC-A8** — `agentTabs` for a ganglion agent and for the legacy all-agents entry
+are both asserted after FR-A14, by the test that caught `persona` and `model`.
+
+**AC-B1** — A job due now on a **stopped** ganglion container starts it and
+delivers the turn (FR-B3). This is the acceptance criterion the whole slice
+exists for.
+
+**AC-B2** — Two projects each with a schedule produce two jobs whose runs write
+into their own project's transcript — the case picoclaw structurally cannot serve.
+
+**AC-B3** — A fired job's output is readable through
+`GET /v1/sessions/history` for the conversation it names (FR-B4, FR-B5).
+
+**AC-B4** — A job that fires while a turn is running on the same conversation runs
+**after** it, and the window contains both turns in order (FR-B9).
+
+**AC-C1** — With the MCP block present, `tools/list` results appear in the tool
+schemas the model sees, and a `tools/call` round-trips against a fake MCP server.
+
+**AC-C2** — A `command`-based server entry fails boot with a message naming the
+server and the reason (FR-C3). A mutation that ignores it instead makes this fail.
+
+**AC-C3** — A server offering a tool named `shell` fails boot naming both
+(FR-C5).
+
+**AC-C4** — An MCP server that returns 500 mid-turn produces a tool result the
+model can read, and the turn completes (FR-C6).
+
+**AC-C5** — The same `.security`-style bearer written for a picoclaw workspace
+authenticates a ganglion workspace's MCP calls, from the same secret (FR-C7).
+
+---
+
+## Out of scope
+
+- **Per-project model or skill overrides.** The proxy's own `agent-projects`
+  deferred both; the registry cascade has the levels, and a project would become a
+  fifth.
+- **Sharing a project between members.** A project belongs to one
+  `(tenant, subscription, agent, user)` tuple, like the workspace it lives in.
+- **Cross-project delegation.** `ganglion-subagents` leaves this out for the same
+  isolation reason the proxy leaves `subagents.allow_agents` unset.
+- **Moving picoclaw's cron into the proxy.** FR-B8.
+- **A kernel-level boundary between projects.** D-1, NFR-4. Doing it properly
+  means a Landlock root per project, which means the sandbox is rebuilt per turn
+  rather than at boot — a real option, and a separate feature with its own
+  measurements.
+
+---
+
+## Open questions
+
+**OQ-1 — Is the memory graph scoped per project or per member?**
+
+The MCP bearer's payload is `tenantID/subsAccID/role/userAccID` — there is **no
+project dimension** — and `memory-graph-mcp` FR-4.2 requires the payload→Scope
+mapping to stay injective, with `Mint` rejecting any field containing the
+delimiter. Adding a project field means changing a security-critical path that was
+specified carefully and is shared with picoclaw.
+
+**Recommendation: per member, shared across projects, in v1.** It is the cheap
+answer, it needs no proxy security change, and a graph that spans a member's
+projects is arguably the more useful one — "what do I know about this supplier"
+does not stop at a project boundary. If per-project is wanted, it is a token
+payload change with its own injectivity argument, and it should be its own slice.
+
+**Blocking for slice C only.** A and B do not depend on it.
+
+**OQ-2 — Which conversation does a scheduled job write into (FR-B5)?**
+
+Three shapes: (a) the conversation the member scheduled it from, (b) one
+conversation per job, created on first run, (c) a single "Scheduled" conversation
+per project. (a) is most natural to a member and drifts oddly when they delete
+that chat; (b) is tidy and makes the Tasks panel's "open the run" obvious; (c) is
+the smallest. **Recommendation: (b)**, with the job's name as the conversation
+title. Answering this is required before slice B is designed.
+
+**OQ-3 — Does the member see project files anywhere?**
+
+The webapp has a workspace/Files panel for picoclaw. FR-A4 puts a project's
+working files in `projects/<id>/files`, and whether that panel is pointed at it is
+a webapp question this spec does not answer. Named so it is not discovered as a
+gap after slice A ships.

--- a/.specs/features/ganglion-reasoning-depth/spec.md
+++ b/.specs/features/ganglion-reasoning-depth/spec.md
@@ -1,0 +1,341 @@
+# ganglion-reasoning-depth — Specification
+
+**Status:** Draft
+**Size:** Medium (one harness, one proxy field, one webapp input)
+**Repos touched:** `crab-ganglion-harness`, `crab-shell-proxy`, `crab-exoskeleton-webapp`
+
+---
+
+## Problem
+
+A ganglion turn always thinks the same amount. Whatever the question — "what time
+is it" or "reconcile these two schemas and tell me which migration is safe" — the
+same request goes on the wire with no depth parameter, and the model spends the
+same effort on both.
+
+The harness is closer to solving this than it looks, which is why the requirement
+below is narrow rather than broad. Two of the three pieces already exist:
+
+- **Reasoning already comes back.** `openai.go:240` decodes
+  `delta.reasoning_content` into `domain.Delta.Reasoning`, the loop coalesces it
+  at 1s and emits it as `ProgressThought` (`loop.go:513`), and
+  `domain.Message.Reasoning` persists it into the transcript.
+- **A depth field can already go out — statically.** `Client.ExtraBody` is merged
+  into the request body by `encode()` and only `model`, `stream`, `messages`,
+  `tools` and `stream_options` are reserved, so
+  `"extra_body": {"reasoning_effort": "high"}` on a `model_list` entry reaches the
+  wire today.
+
+What is missing is that the depth is **fixed at configuration time and identical
+for every turn**. An operator who wants a model to think hard on hard questions
+must make it think hard on every question, and pay for it.
+
+## Grounding (verified in source — do not re-derive)
+
+picoclaw v0.3.1 has exactly one knob: **`model_list[].thinking_level`**, a string
+of `off | low | medium | high | xhigh | adaptive` (`pkg/config/config.go:780`).
+
+- It is **per-model-entry only**. It does not exist in `agents.defaults`, does not
+  exist in `agents.list[]`, and there is no global.
+- Providers read it from an opaque options map (`pkg/agent/thinking.go:95`).
+  Anthropic maps it to `thinking:{type:"enabled",budget_tokens:N}` with budgets
+  4096/16384/32000/64000 and force-clears `temperature`. openai_compat emits
+  `reasoning_effort` **only for DeepSeek** (`SupportsThinking()` is literally
+  `providerName == "deepseek" || isDeepSeekHost(apiBase)`); for every other
+  OpenAI-compatible provider only the *disable* path exists. Gemini emits
+  `generationConfig.thinkingConfig`.
+- `extra_body` is merged **last** and overrides all of it
+  (`openai_compat/provider.go:217`).
+- **Nothing selects depth at runtime.** `grep -rniE
+  "deep_research|deepsearch|ultrathink|think harder"` over the whole tree returns
+  **zero hits**. There is no `/think` command. The `spawn`/`delegate`/`subagent`
+  schemas expose `task`, `label` and `agent_id` — no model, no effort. Depth is
+  reachable only as a side effect of routing to a different agent.
+- The web UI already renders the field (`edit-model-sheet.tsx:98,385`) and its
+  hint reads "Leave blank to omit `thinking_level` and use the provider default",
+  so **omitted ≠ off** at picoclaw's agent layer.
+
+**Consequence for compatibility:** the key and its six values are the contract.
+A seventh value would break picoclaw's own editor, so this feature adds none.
+
+---
+
+## Decisions
+
+**D-1 — `thinking_level` is adopted verbatim, with picoclaw's exact six values.**
+It is the static floor: what a model does when nothing else says otherwise. The
+harness reads it from `model_list[]`, the proxy projects it from the inventory,
+and the admin UI edits it. No new key, no new vocabulary.
+
+**D-2 — Declaring `thinking_level` on a model IS the capability declaration.**
+There is no built-in provider capability table in the harness, and this is
+deliberate. picoclaw needs one because it speaks four provider dialects; ganglion
+speaks exactly one wire (`internal/adapter/provider/openai` is the only provider
+adapter, `router` selects among instances of it), so the only question is whether
+*this endpoint* accepts a depth field — which the operator knows and the harness
+cannot discover. A model with no `thinking_level` is never sent a depth field, at
+any depth, by any path.
+
+The cost of this decision is stated rather than hidden: an operator who forgets
+the key gets a harness that silently never thinks deeply. AC-7 is the test that
+makes the omission visible in the boot log rather than only in the bill.
+
+**D-3 — Per-turn depth is chosen by the agent, through a tool, and is sticky for
+the remainder of the turn.**
+
+A model can only act through a tool call, so agent-selected depth costs one of the
+12 `MaxIterations`. Sticky rather than per-completion is what makes that one call
+worth paying for: the model raises the level once, and every subsequent completion
+of that turn — including the ones after tool results come back, which is where the
+hard reasoning usually happens — runs at the new level.
+
+Rejected alternatives, and why:
+- *Automatic classification by the harness* — the harness would have to judge
+  difficulty from the user's text with no model in the loop, which is the problem
+  the model is better at. It also makes the behaviour unexplainable.
+- *A user-visible prefix (`/think`)* — the request is explicitly that the **agent**
+  select according to the complexity of the problem.
+- *Per-completion* — a level that resets between iterations is a level the model
+  cannot use for the part of the turn that needs it.
+
+**D-4 — A depth field that the endpoint rejects degrades; it does not end the
+turn.** On a failed completion whose request carried a depth field, the harness
+retries **once on the same model with the field removed** before falling through
+to the next model in the chain. This is the same shape as the existing attachment
+degradation in `completeWithFallback`, and it exists for the same reason: the
+`vision-unsupported-glm` production failure, where an unsupported request field
+ended every turn on a model that would have answered fine without it.
+
+**D-5 — The level travels on `domain.Completion`, not in `extra_body`.**
+`extra_body` stays exactly what it is: an operator-owned escape hatch merged last
+and overriding everything, including this feature. An operator who pins
+`extra_body.reasoning_effort` has said "always this", and this feature must not
+quietly win that argument.
+
+---
+
+## Requirements
+
+### Harness: reading the level
+
+**FR-1** — `config.ModelSpec` gains `ThinkingLevel string`, read from
+`model_list[].thinking_level`. Values are parsed case-insensitively with
+surrounding whitespace trimmed, matching `pkg/agent/thinking.go:16-54`. An
+unrecognised value is treated as **absent** and logged once naming the model and
+the value — not as `off`, because `off` is a level a model can be sent and
+"unparseable" is an operator mistake that should be visible.
+
+**FR-2** — An absent or empty `thinking_level` means **the model is never sent a
+depth field**, by any path, at any level. This is D-2 as a testable rule.
+
+### Harness: the levels
+
+**FR-3** — The level vocabulary is exactly picoclaw's:
+`off`, `low`, `medium`, `high`, `xhigh`, `adaptive`. The harness defines no
+seventh value and rejects none of the six.
+
+**FR-4** — The default wire mapping, applied when the model declared a level and
+carries no override:
+
+| Level | Emitted on the request |
+|---|---|
+| `off` | `"reasoning_effort": "none"` |
+| `low` | `"reasoning_effort": "low"` |
+| `medium` | `"reasoning_effort": "medium"` |
+| `high` | `"reasoning_effort": "high"` |
+| `xhigh` | `"reasoning_effort": "high"` |
+| `adaptive` | nothing — the field is omitted and the provider decides |
+
+`xhigh` collapsing onto `high` is deliberate: `reasoning_effort` has no fourth
+step in the OpenAI-compatible vocabulary, and inventing one would send a value no
+endpoint recognises. An operator who has a provider with a higher step reaches it
+through FR-5, and the collapse is logged once per model at boot so it is a known
+ceiling rather than a silent one.
+
+**FR-5** — `model_list[].thinking_body` overrides the table per level:
+
+```json
+{ "model_name": "deepseek-reasoner", "thinking_level": "high",
+  "thinking_body": {
+    "xhigh": { "reasoning_effort": "max" },
+    "off":   { "thinking": { "type": "disabled" } } } }
+```
+
+The mapped object is merged into the request body at the top level under the same
+`reserved` rule `ExtraBody` already obeys — `model`, `stream`, `messages`,
+`tools` and `stream_options` cannot be overwritten. A level present in
+`thinking_body` fully replaces FR-4's row for that level, including replacing it
+with `{}` to emit nothing.
+
+This is the one mechanism by which a new provider dialect is taught to the
+harness without a code change, and it is why FR-4's table can stay this small.
+
+**FR-6** — `extra_body` is merged **after** the depth field, so an operator's
+pinned value wins (D-5). Ordering is asserted, not assumed.
+
+### Harness: per-turn selection
+
+**FR-7** — A tool named **`set_reasoning_depth`** is registered **only when at
+least one model in the resolved text chain declared a `thinking_level`**. With no
+such model the tool is absent from the schema list entirely.
+
+This follows `imagegen`'s precedent (`New` returns nil, and nil means absent from
+the tool list): a model told it can choose a depth, which then changes nothing, has
+spent a turn learning what boot already knew.
+
+Schema:
+
+```json
+{ "type": "object",
+  "properties": {
+    "level":  { "type": "string", "enum": ["off","low","medium","high","xhigh","adaptive"],
+                "description": "How much to think for the rest of this turn" },
+    "reason": { "type": "string", "description": "One line on why this problem needs that depth" } },
+  "required": ["level"] }
+```
+
+**FR-8** — The tool sets the level for the **remainder of the current turn** and
+returns immediately. It never calls a provider, so it costs one iteration and no
+tokens.
+
+**FR-9** — The level is **per turn**, not per conversation. A new turn starts at
+the model's configured `thinking_level`. A depth raised for one question does not
+silently bill every later one.
+
+**FR-10** — `reason` is not used for control flow. It is emitted as a
+`ProgressThought` so the member sees *why* the agent went deep, and it is recorded
+on the turn's `domain.TurnRecord` so `evolution` can observe whether depth
+correlates with success. A model that omits it is not refused.
+
+**FR-11** — The chosen level applies to **every subsequent completion of the
+turn**, including completions on fallback models — subject to FR-2, so a fallback
+model that declared no level is still sent nothing.
+
+### Harness: plumbing
+
+**FR-12** — `domain.Completion` gains `ThinkingLevel string`. It is the only new
+field on the domain type and it carries a level name, not a wire shape: the
+mapping from name to JSON is the provider adapter's business (AR-2).
+
+**FR-13** — `wireRequest` gains no typed field. The depth object is merged into
+the encoded body by `encode()`, the same two-pass merge `ExtraBody` already uses,
+because FR-5 means the shape is not fixed at compile time.
+
+**FR-14** — On a completion error where the request carried a depth field, the
+harness retries **once, on the same model, with the depth field removed**, before
+moving to the next model in the chain (D-4). The retry is logged. If the retry
+also fails, the chain proceeds normally.
+
+**FR-15** — A model that has degraded under FR-14 is remembered **for the rest of
+the turn only**: the same model is not re-sent a depth field on a later iteration
+of the same turn. It is not remembered across turns, because the failure may have
+been the endpoint's and not the model's.
+
+### Proxy
+
+**FR-16** — `registry.Model` gains `ThinkingLevel string`
+(`json:"thinking_level,omitempty"`), validated against the six values on write and
+rejected with 400 otherwise.
+
+**FR-17** — `ganglionConfigDoc` projects `thinking_level` onto each `model_list`
+entry when the record carries one, and omits the key otherwise. Omitted rather
+than written empty, matching the file's existing rule for `model_fallbacks`.
+
+**FR-18** — `materializeModels` projects the same field into a **picoclaw**
+workspace's `model_list`, because the key is picoclaw's own and a value set in the
+inventory should reach whichever harness the agent runs. This is the compatibility
+requirement in the original ask, made concrete.
+
+### Webapp
+
+**FR-19** — The model editor gains a `thinking_level` select with the six values
+plus an explicit empty option, whose helper text says what omitted means: the
+provider's own default, and no depth field on the wire.
+
+**FR-20** — The field is offered for **every inventory-governed harness**
+(`INVENTORY_GOVERNED`), not gated to picoclaw. It is a property of the model
+record, not of the harness that reads it.
+
+---
+
+## Non-functional
+
+**NFR-1** — A deployment that sets no `thinking_level` anywhere behaves exactly as
+today, byte-identically on the wire. This is the regression bar for the whole
+feature.
+
+**NFR-2** — The feature adds no dependency. `go.mod` stays at zero requires.
+
+**NFR-3** — `set_reasoning_depth` must not be able to make a turn fail. Like every
+other tool in this harness, its `Invoke` returns a `domain.Result` and never an
+error, including for an unknown level (which is refused in the result text and
+leaves the current level untouched).
+
+---
+
+## Acceptance criteria
+
+**AC-1** — A model with `thinking_level: "high"` sends `reasoning_effort: "high"`
+on every completion of a turn; the same model with the key removed sends a request
+body byte-identical to today's.
+
+**AC-2** — A model with no `thinking_level` is sent no depth field even after the
+agent calls `set_reasoning_depth` with `xhigh` (FR-2 beats FR-11).
+
+**AC-3** — `set_reasoning_depth{level:"xhigh"}` called at iteration 2 changes the
+body of iterations 3..n of the same turn, and iteration 1 of the *next* turn is
+back at the configured level (FR-8, FR-9).
+
+**AC-4** — `thinking_body:{"xhigh":{"reasoning_effort":"max"}}` sends `"max"`;
+`thinking_body:{"high":{}}` sends nothing for `high` while `low` still sends
+`"low"` (FR-5).
+
+**AC-5** — `extra_body:{"reasoning_effort":"low"}` with `thinking_level:"high"`
+sends `"low"` — the operator's pin wins (FR-6, D-5).
+
+**AC-6** — A server that 400s on `reasoning_effort` gets a second request from the
+same model without the field, and the turn **answers**. A mutation that removes the
+retry makes this test fail with the turn ending in an error.
+
+**AC-7** — With no model declaring a level, `set_reasoning_depth` is absent from
+the tool schemas, and boot logs one line saying depth selection is unavailable and
+naming the key that would enable it.
+
+**AC-8** — A `thinking_level` set through the admin UI reaches a **picoclaw**
+workspace's `config.json` and a **ganglion** workspace's `config.json` from the
+same inventory record (FR-17, FR-18).
+
+**AC-9** — An unparseable `thinking_level` (`"HIGH!"`) is treated as absent and
+logged; it is **not** silently read as `off`. This discriminates the failure mode
+that would otherwise look like a working configuration that never thinks.
+
+---
+
+## Out of scope
+
+- **Deep research and deepsearch.** They were part of the same request and they
+  are not this mechanism: a depth field is one wire parameter, and research is a
+  multi-step procedure (decompose → search → read → synthesize). Specified in
+  `ganglion-subagents`, built on the fan-out that feature introduces. Putting a
+  research loop behind `reasoning_effort` would be the wrong shape.
+- Anthropic's native `thinking:{budget_tokens}` and Gemini's `thinkingConfig` as
+  built-in mappings. Ganglion has one wire; FR-5 is how those are reached, and a
+  second provider adapter is the moment to revisit it.
+- A token budget for a turn. The harness has no token accounting today, and
+  `xhigh` on a 12-iteration turn can be expensive. Named in
+  `ganglion-subagents` NFR, where the same gap has teeth.
+- Re-sending reasoning blocks on the next turn (`reasoning_content` replay,
+  Anthropic signatures, Gemini `thoughtSignature`). Ganglion persists reasoning
+  but never replays it, and this feature does not change that.
+
+---
+
+## Open questions
+
+**OQ-1 — Should `set_reasoning_depth` be able to *lower* the level below the
+model's configured floor?** The schema allows `off`, so an agent can decide a
+question is trivial and save the operator money. It can also decide wrongly and
+answer a hard question shallowly, and the operator who paid for `high` has no way
+to see it happened. Recommendation: allow it, because FR-10 makes the choice and
+its reason visible in the progress stream and the turn record — the operator can
+see it. Revisit if the record shows the agent lowering more than it raises.

--- a/.specs/features/ganglion-subagents/spec.md
+++ b/.specs/features/ganglion-subagents/spec.md
@@ -1,0 +1,436 @@
+# ganglion-subagents — Specification
+
+**Status:** Draft
+**Size:** Large (one harness; no proxy or webapp change in v1)
+**Repos touched:** `crab-ganglion-harness`
+
+---
+
+## Problem
+
+A ganglion turn is one model, one context, one thread. Everything the agent needs
+to know has to fit in the window it already has, and everything it does happens in
+sequence. There is no way to say "read these six documents and tell me what they
+disagree about" without reading all six into one window, and no way to explore two
+approaches without doing one after the other.
+
+The request is for the harness to have **native, programmatic sub-agent dispatch**
+— parallel and sequential — so the behaviour is predictable rather than emergent.
+
+## Grounding (verified in picoclaw v0.3.1 source — do not re-derive)
+
+picoclaw has four tools: `subagent{task,label}` (synchronous), `spawn{task,label,
+agent_id}` (asynchronous), `spawn_status{task_id?}`, and `delegate{agent_id,task}`
+(synchronous, to a named registry agent). A child is **not** a process or a
+container: `spawnSubTurn` (`pkg/agent/subturn.go:269-515`) shallow-copies the
+`AgentInstance`, swaps in an ephemeral in-memory session store capped at 50
+messages, sets `NoHistory: true`, and calls the ordinary turn loop in a goroutine.
+The child returns its **final assistant message only**.
+
+**Three of those four are wired wrong, and this spec exists partly to not copy
+them.** All three were confirmed at source level:
+
+1. **`spawn_status` is dead.** `SubagentManager.tasks` is written only in
+   `SubagentManager.Spawn`, and `grep -rn "\.Spawn(" --include='*.go' . | grep -v
+   _test.go` returns **nothing** — no non-test caller. In the shipped wiring the
+   tool always answers `"No subagents have been spawned yet."`
+2. **`spawn`'s result never reaches the turn that spawned it.** `asyncCallback`
+   (`pipeline_execute.go:515-553`) republishes the child's output as a **new
+   inbound message** on channel `"system"`, sender `async:spawn` — a fresh turn.
+   The `pendingResults` channel that would inject it into the running turn is
+   `nil` at depth 0, because `newTurnState` sets neither `concurrencySem` nor
+   `pendingResults`; `deliverSubTurnResult` therefore takes the `resultChan ==
+   nil` branch and emits `agent.subturn.orphan`.
+3. **The concurrency cap does not apply at the depth that matters.** `max_concurrent`
+   (default 5) is enforced on `parentTS.concurrencySem`, which is nil at depth 0 —
+   so **first-level sub-agents are uncapped**. The cap bites only from depth 1
+   down. `max_depth` (default 3) does hold. Separately, `cfg.Tools` filtering is
+   documented in `docs/architecture/subturn.md:252-261` and **never read** by
+   `spawnSubTurn`.
+
+Also: the child's context is `context.WithTimeout(context.Background(), …)`, so
+**cancelling the parent does not cancel the child**.
+
+**What that means for this spec.** "Compatible with picoclaw" is the standing
+constraint for anything the webapp or the proxy manages — model records, search
+providers, config keys. Sub-agent *tools* are managed by neither: they are names
+in a schema the model sees, and nothing outside the harness reads them. So the
+compatibility surface here is the **config keys**, which are adopted verbatim
+(FR-14), and the tool shape is chosen for the property the request actually asked
+for — *previsível*.
+
+## Grounding (verified in the harness — do not re-derive)
+
+- Tool calls are dispatched **strictly sequentially** (`loop.go:217`), and
+  `compact`/`dropOrphanTools` enforce that every tool call is followed by its
+  result. Making the loop itself concurrent would break that invariant.
+- `domain.Sink` is a **struct of nil-able func fields** with no mutex, and the
+  content/reasoning coalescers have no mutex either. CI runs `go test -race`.
+  N children streaming into one parent sink is a race the gate would catch.
+- The tool port is inward (`internal/adapter/tool/registry.go:18`); the outward
+  port is `domain.ToolExecutor`. AR-4 forbids an adapter importing another
+  adapter — and `internal/runtime` is not an adapter, so a tool importing the
+  loop would pass the machine check while inverting the hexagon anyway.
+- The tool set is fixed at boot (`cmd/crab-ganglion/main.go:264-279`).
+- `MaxIterations` defaults to **12** and is the **only** bound on a turn. There is
+  no token budget anywhere in the harness.
+
+---
+
+## Decisions
+
+**D-1 — One tool, taking a batch, with an explicit mode.**
+
+`subagents{mode, tasks[]}` replaces picoclaw's four. One tool call fans out
+internally and returns **one** tool result, which is what keeps `loop.go:217`
+sequential and the call↔result pairing intact. Parallelism inside one call is
+also the only way to get it: the loop dispatches tool calls one after another, so
+"the model emits four tool calls" would be four serial children.
+
+A one-element `tasks` list is the synchronous single-child case, so nothing is
+lost by not having a second tool.
+
+**D-2 — Everything is synchronous. There is no `spawn_status`.**
+
+The tool returns when the batch is done. This is the whole of "previsível": the
+model reads the result in the same turn it asked for it, and a batch's outcome is
+a function of the batch, not of when the model happens to poll. picoclaw's async
+path is the one that leaks results into a different turn and the one whose status
+tool is dead; neither is worth reproducing.
+
+The cost is stated: a batch that takes four minutes holds the turn for four
+minutes. FR-9's per-child timeout and FR-12's progress line are what make that
+tolerable, and OQ-2 records the case this does not serve.
+
+**D-3 — Children stream nothing. The dispatcher narrates, from one goroutine.**
+
+Children run with a **silent sink**. The dispatcher owns a single collector that
+emits one `ProgressThought` per child as it starts and finishes, serialised
+through the dispatcher's own goroutine — so exactly one goroutine ever touches the
+parent's sink, and `-race` stays green.
+
+Interleaving four children's token streams into one transcript would be
+unreadable anyway; what a member needs is to know the fan-out is alive.
+
+**D-4 — A child's transcript is in memory and is never persisted.**
+
+Children use in-memory transcript and window stores. Two reasons, and the second
+is the load-bearing one: a child writing `<id>.jsonl` into `workspace/sessions/`
+would make the proxy's history endpoint report conversations no member ever had;
+and the child's *finding* is already persisted — it is inside the parent's tool
+result, which is in the parent's transcript.
+
+**D-5 — Parent cancellation cancels the children.**
+
+The child context derives from the parent's. picoclaw deliberately does the
+opposite (`context.Background()`), which is how it ends up with orphaned results
+and `Critical: true` children outliving the turn that made them. A member who
+stops a turn expects the work to stop.
+
+**D-6 — The bounds are enforced at depth 0, and the worst case is arithmetic
+somebody wrote down.**
+
+See NFR-1. This is the direct answer to picoclaw defect 3.
+
+---
+
+## Requirements
+
+### The dispatch port
+
+**FR-1** — A new outward port, `domain.SubAgent`:
+
+```go
+// SubAgent runs one child turn to completion and returns what it concluded.
+type SubAgent interface {
+    Run(ctx context.Context, task SubTask) (SubReport, error)
+}
+
+type SubTask struct {
+    Label   string
+    Task    string
+    Context string // findings handed down in sequential mode; empty in parallel
+}
+
+type SubReport struct {
+    Label      string
+    Answer     string
+    Iterations int
+    Usage      Usage
+    Err        error
+}
+```
+
+The tool holds this port; the implementation over `runtime.Loop` is constructed in
+`cmd/crab-ganglion/main.go`, the composition root and the only place adapters
+meet. The tool does **not** import `internal/runtime`.
+
+**FR-2** — Depth travels in the context: `domain.WithDepth(ctx, n)` and
+`domain.Depth(ctx) int`. `domain.Turn` is not widened, because depth is a property
+of *how this turn was started*, not of the turn the ingress received. `context` is
+stdlib, so AR-1 holds.
+
+**FR-3** — The sink travels the same way: `domain.WithSink(ctx, Sink)` and
+`domain.SinkFrom(ctx) Sink`, set by `Loop.runTool` before it invokes a tool. A
+tool that does not ask for it is unaffected; `SinkFrom` on a context without one
+returns the zero `Sink`, whose emit helpers are already nil-safe.
+
+### The tool
+
+**FR-4** — Tool name **`subagents`**. Schema:
+
+```json
+{ "type": "object",
+  "properties": {
+    "mode": { "type": "string", "enum": ["parallel", "sequential"],
+              "description": "parallel: every task runs at once, independently. sequential: each task runs after the previous one and receives its findings." },
+    "tasks": { "type": "array", "minItems": 1, "maxItems": 8,
+      "items": { "type": "object",
+        "properties": {
+          "task":  { "type": "string", "description": "The complete instruction. The sub-agent sees NONE of this conversation, so say everything it needs." },
+          "label": { "type": "string", "description": "Short name for this task, shown to the member and used to label the result." } },
+        "required": ["task"] } } },
+  "required": ["mode", "tasks"] }
+```
+
+**FR-5** — `mode: "parallel"` runs all tasks concurrently, bounded by
+`max_concurrent` (FR-14). Each child's `SubTask.Context` is empty. Results are
+returned **in the order the tasks were given**, never in completion order, so the
+same batch produces the same result text twice.
+
+**FR-6** — `mode: "sequential"` runs tasks in order, and each child after the
+first receives the previous children's answers in `SubTask.Context`. This is what
+makes the mode different from a serialised parallel batch, and it is the mode for
+a plan whose later steps depend on earlier ones.
+
+**FR-7** — In sequential mode a **failed or timed-out child stops the sequence**.
+The result reports which step failed, and the remaining tasks are reported as not
+run. A step that depends on a step that failed cannot produce a trustworthy
+answer, and running it anyway is how a chain produces a confident wrong result.
+
+**FR-8** — In parallel mode a failed child **does not fail the batch**. Its slot
+reports the failure and the others report their answers.
+
+**FR-9** — Each child has its own timeout (`default_timeout_minutes`, FR-14). A
+child that exceeds it is cancelled and reported as timed out; in parallel mode the
+batch continues.
+
+**FR-10** — The result text is deterministic and labelled:
+
+```
+Ran 3 sub-agents (parallel).
+
+[1] schema-drift — ok (4 steps)
+<answer>
+
+[2] migration-risk — ok (6 steps)
+<answer>
+
+[3] rollback-plan — FAILED: context deadline exceeded after 5m0s
+```
+
+Each answer is truncated at `max_answer_runes` (default 4000) **by rune, not by
+byte** — picoclaw truncates `ForUser` with a byte slice on a UTF-8 string
+(`subagent.go:436-439`) and can split a rune. Truncation is marked in the text.
+
+**FR-11** — `Invoke` returns a `domain.Result` and **never** an error, including
+when every child fails. This is the rule every tool in this harness follows.
+
+**FR-12** — The dispatcher emits, through the sink obtained in FR-3 and from its
+own single goroutine: one line when the batch starts naming the mode and count,
+one line per child on completion naming its label and outcome. No child token ever
+reaches the parent's sink (D-3).
+
+### Bounds
+
+**FR-13** — A child inherits: the system prompt (persona and skills), the
+workspace, the model chain, and the tool set. A child does **not** inherit the
+conversation window — it starts with its task and nothing else. `SubTask.Task` is
+the whole of what it knows about why it exists, which is why FR-4's schema says so
+in the description the model reads.
+
+**FR-14** — Configuration, using picoclaw's key paths verbatim so a single
+`config.json` serves both harnesses:
+
+| Key | Default | Meaning |
+|---|---|---|
+| `tools.subagent.enabled` | `true` | Registers the tool at all |
+| `agents.defaults.subturn.max_depth` | `1` | Depth at which a child may itself dispatch |
+| `agents.defaults.subturn.max_concurrent` | `5` | Children running at once, **enforced at depth 0** |
+| `agents.defaults.subturn.default_timeout_minutes` | `5` | Per child |
+| `agents.defaults.subturn.max_child_iterations` | `6` | A child's `MaxIterations` |
+| `agents.defaults.subturn.max_children_per_turn` | `16` | Whole-turn budget across the tree |
+
+`max_depth` defaults to **1**, not picoclaw's 3: at depth 1 a child cannot
+dispatch, which is what makes NFR-1's arithmetic small enough to state. Raising it
+is allowed and its cost is documented there.
+
+`max_concurrent` keeps picoclaw's default of 5, and — unlike picoclaw's — is
+enforced at depth 0, where every real fan-out happens.
+
+**FR-15** — When a child is at `max_depth`, the `subagents` tool is **absent from
+its schema list**, not present-and-refusing. A tool the model can see and cannot
+use costs a turn to discover.
+
+**FR-16** — `max_children_per_turn` is a counter for the **whole turn across the
+whole tree**, not per call. A call that would exceed it runs the children that fit
+and reports the rest as not run, naming the budget. A model that calls `subagents`
+on every one of its 12 iterations cannot start 96 children.
+
+**FR-17** — Exhausting `max_concurrent` **queues**; it does not fail. picoclaw
+returns `ErrConcurrencyTimeout` after 30s; a batch of 8 with a cap of 5 is an
+ordinary request, not an error.
+
+### research
+
+**FR-18** — A tool named **`research`**, registered **only when `web_search` is
+configured** (nil means absent, the `imagegen` precedent). Schema:
+
+```json
+{ "type": "object",
+  "properties": {
+    "question": { "type": "string" },
+    "mode": { "type": "string", "enum": ["quick", "deep"],
+              "description": "quick: search and read directly. deep: break the question into sub-questions, research each in parallel, and return the findings together." },
+    "breadth": { "type": "integer", "minimum": 2, "maximum": 6,
+                 "description": "Sub-questions in deep mode. Default 4." } },
+  "required": ["question"] }
+```
+
+**FR-19** — `quick` runs one child with the question, `web_search` and
+`web_fetch`, and a prompt that tells it to search, read the most promising
+results, and report with URLs.
+
+**FR-20** — `deep` runs three phases: one child decomposes the question into
+`breadth` sub-questions; those are researched by a **parallel** batch; the
+findings are returned to the **parent**, labelled and with their sources.
+
+**FR-21** — The parent writes the answer. `research` returns findings, never
+prose addressed to the member. The parent is the only participant that has the
+conversation, and a synthesis written by a child that has never seen it will
+answer a question nobody asked.
+
+**FR-22** — Every finding carries the URLs it came from, and the result says so
+in a line the model can quote. A research tool whose output cannot be checked is
+worse than a search tool whose output can.
+
+**FR-23** — `research` spends from the same `max_children_per_turn` budget as
+`subagents`. It is a caller of the same dispatcher, not a second one.
+
+---
+
+## Non-functional
+
+**NFR-1 — The worst case is stated, not discovered.** At the defaults, one turn
+is bounded by: 12 parent completions + 16 children × 6 iterations = **108 model
+calls**. Raising `max_depth` to picoclaw's 3 makes the tree three levels deep and
+the bound is then `max_children_per_turn` × `max_child_iterations` per level —
+which is why the default is 1 and why raising it belongs to an operator who has
+read this line.
+
+There is no token budget, because the harness has none to build on. That gap is
+named here rather than half-solved: `max_children_per_turn` bounds *calls*, and a
+call with a 200k window is not the same size as one with 2k.
+
+**NFR-2** — `go test -race ./...` passes. This is not a formality: D-3 exists
+because of it, and a test that runs a parallel batch under `-race` is the check.
+
+**NFR-3** — Zero new dependencies. `go.mod` stays at zero requires.
+
+**NFR-4** — With `tools.subagent.enabled: false` the harness behaves exactly as
+today, and no code on the turn path is reached.
+
+**NFR-5** — A child never writes to `workspace/sessions/` or `workspace/windows/`
+(D-4). A proxy history call after a fan-out returns the same conversations it
+would have returned without one.
+
+---
+
+## Acceptance criteria
+
+**AC-1** — A parallel batch of three tasks against three fake providers produces
+one tool result naming all three, **in task order**, and the same batch run twice
+produces the same text.
+
+**AC-2** — A parallel batch of three, where the second child's provider always
+errors, still reports the first and third answers (FR-8).
+
+**AC-3** — A sequential batch of three, where the second fails, reports step 2 as
+failed and step 3 as **not run**, and the third child's provider is never called.
+A mutation that continues the sequence makes this fail.
+
+**AC-4** — In sequential mode, the second child's prompt **contains the first
+child's answer**; in parallel mode it does not. This is the assertion that
+discriminates the two modes — a test that only checks timing would pass for a
+sequential implementation of both.
+
+**AC-5** — A batch of 8 with `max_concurrent: 2` never has more than 2 children
+running at once (asserted with a counter inside the fake provider), and all 8
+complete (FR-17).
+
+**AC-6** — A child at `max_depth` receives a tool schema list that does **not**
+contain `subagents` (FR-15).
+
+**AC-7** — With `max_children_per_turn: 3`, a call requesting 5 tasks runs 3 and
+reports 2 as not run naming the budget; a second call in the same turn runs none.
+
+**AC-8** — Cancelling the parent context mid-batch cancels the children: the fake
+providers observe a cancelled context, and the tool returns a result rather than
+an error (D-5, FR-11).
+
+**AC-9** — After a batch, `workspace/sessions/` contains exactly the parent
+conversation's file and nothing else (NFR-5).
+
+**AC-10** — `go test -race` on a test that runs a 6-way parallel batch while the
+parent sink records emissions is clean, and the recorded emissions contain one
+line per child (D-3, FR-12).
+
+**AC-11** — An answer containing multi-byte characters truncated at the limit ends
+on a rune boundary and is valid UTF-8 (FR-10).
+
+**AC-12** — With no web provider configured, `research` is absent from the tool
+schemas while `subagents` is present (FR-18).
+
+**AC-13** — `research{mode:"deep",breadth:3}` produces one decomposition child, 3
+research children, and **no** synthesis child; the tool result contains the three
+findings and their URLs (FR-20, FR-21, FR-22).
+
+---
+
+## Out of scope
+
+- **Asynchronous dispatch and a status tool.** D-2. The case it would serve is
+  OQ-2.
+- **Cross-agent delegation** (picoclaw's `delegate`, `subagents.allow_agents`).
+  A ganglion container runs one agent; there is no registry of others to delegate
+  to. If `ganglion-projects` gives a container more than one project scope, that
+  is the moment to revisit, and the proxy's `agent-projects` spec already
+  deliberately leaves `subagents.allow_agents` unset for the same isolation
+  reason.
+- **A different model for children.** picoclaw's `subagents.model` exists;
+  ganglion's children use the same chain. A cheaper model for fan-out work is an
+  obvious next step and an easy one — it is left out so that v1 has one variable.
+- **Per-child tool restriction.** picoclaw documents `cfg.Tools` and never reads
+  it; implementing it correctly means deciding what a child may do to the
+  workspace, which is a security question and not a scheduling one.
+- **A token budget.** NFR-1.
+
+---
+
+## Open questions
+
+**OQ-1 — Should a child be able to write to the workspace?** Today it inherits
+the full tool set, which includes `shell`. Two children writing the same file
+concurrently is a data race the harness cannot see, and the Landlock domain will
+not stop it because both are inside the workspace. Recommendation for v1: leave it
+inherited and document it, because the alternative — a read-only child — makes the
+most obvious use ("go fix the tests in these four packages") impossible. Revisit
+with `ganglion-projects`, which introduces per-project subtrees and therefore a
+natural place to give a child a narrower root.
+
+**OQ-2 — What serves a genuinely long fan-out?** D-2 holds the turn for the
+duration of the batch. A twenty-minute research job wants to be a background task
+whose result arrives later — which is `scheduled-tasks` shaped, not `subagents`
+shaped, and is why `ganglion-projects` puts the scheduler in the proxy. If that
+lands, "run this batch as a scheduled task" is the answer and no async tool is
+needed here.

--- a/.specs/project/ROADMAP.md
+++ b/.specs/project/ROADMAP.md
@@ -263,3 +263,36 @@ metrics survive the proxy being down). See
   thing it constrains now:** that feature's Group C frame log is keyed per conversation,
   which is only safe while the webapp queue holds — see its OQ-4. See
   `.specs/features/steering-messages/investigation.md`.
+
+- **ganglion-reasoning-depth** (IMPLEMENTED 2026-09-10) — depth the agent chooses,
+  per turn. picoclaw's `model_list[].thinking_level` adopted verbatim as the static
+  floor (its six values; a seventh would break the model editor that already renders
+  the field), plus `set_reasoning_depth`, which is sticky for the rest of the turn
+  and dies with it. Declaring a level IS the capability declaration — there is no
+  provider table, because this harness speaks one wire to every endpoint — and a
+  request whose depth field an endpoint rejects is retried once without it rather
+  than ending the turn. `crab-ganglion-harness#5`, `crab-shell-proxy#43`,
+  `crab-exoskeleton-webapp#58`. See `.specs/features/ganglion-reasoning-depth/`.
+- **ganglion-subagents** (SPEC READY) — one tool, `subagents{mode, tasks[]}`,
+  taking a batch and fanning out inside a single tool call so the turn loop stays
+  sequential and the call↔result pairing `compact` enforces stays intact.
+  Synchronous by design: picoclaw's async path returns its result as a *different
+  turn* and its status tool polls a map nothing writes. `research{question, mode}`
+  is built on the same dispatcher rather than being a second mechanism — deep
+  research is a fan-out plus a synthesis the PARENT performs, not a wire
+  parameter. Bounds are stated as arithmetic (108 model calls at the defaults) and
+  enforced at depth 0, which is where picoclaw's are not. See
+  `.specs/features/ganglion-subagents/`.
+- **ganglion-projects** (SPEC READY, three slices) — closes DF-3, DF-5, DF-1 and
+  DF-2, which are four `501`s in `harness_gate.go` today. **A** gives a ganglion
+  turn its own files, transcripts, window and `MEMORY.md` under
+  `workspace/projects/<id>/` — a subdirectory of the bind it already has, so no
+  new mount and **no container recreate**, at the stated cost that isolation
+  between projects is a harness convention and not a kernel boundary. **B** puts
+  the scheduler in the PROXY, because the ganglion runs `scale-to-zero` and a
+  clock inside it would sleep through its own work — which also makes
+  per-project schedules possible for the first time, something picoclaw's
+  one-store-per-container cron structurally cannot do (defect B1). **C** gives the
+  harness a hand-written MCP client so it reaches the graph the proxy already
+  hosts. Two open questions block B and C respectively. See
+  `.specs/features/ganglion-projects/` and STATE.md AD-026.

--- a/.specs/project/STATE.md
+++ b/.specs/project/STATE.md
@@ -1,7 +1,14 @@
 # State
 
 **Last Updated:** 2026-09-10T00:00:00-03:00
-**Current Work:** **All four harness-parity features implemented.** The fourth,
+**Current Work:** **Round 3 specified; the first of its three features is
+implemented across all three repositories.** `ganglion-reasoning-depth` ships as
+`crab-ganglion-harness#5`, `crab-shell-proxy#43` and
+`crab-exoskeleton-webapp#58`. `ganglion-subagents` and `ganglion-projects` are
+specified — the second in three slices, two of which carry open questions only
+the owner can answer (AD-026).
+
+**Previously in this session:** **All four harness-parity features implemented.** The fourth,
 `ganglion-evolution`, was unblocked the same day by the owner answering its two
 open questions — yes, admin-managed shared skills mount into ganglion
 containers; yes, `apply` requires approval. The second answer had a consequence
@@ -86,6 +93,87 @@ still operator-gated (needs the backend stack). M4 (crab-shell-proxy) live-conta
 ---
 
 ## Recent Decisions (Last 60 days)
+
+### AD-026: round 3's premise was wrong in the requester's favour — projects and the graph are OURS, not picoclaw's (2026-09-10)
+
+**Context.** Three features were asked for: reasoning-depth modes the agent
+selects, sub-agent dispatch (parallel and sequential) with a native programmatic
+mechanism, and "the projects picoclaw has — memory, a graph, scheduled tasks and
+separate files in an exclusive workspace — but use a different mechanism if one
+is needed."
+
+**Three findings, each verified at source in picoclaw v0.3.1 before anything was
+designed.**
+
+**1. picoclaw has no projects.** A search for `project` as a type, field, config
+key or tool returns nothing but OAuth `project_id`. Its scoping units are
+*agents* (one workspace directory each, `resolveAgentWorkspace`,
+`pkg/agent/instance.go:365-377`) and a `SessionScope` over
+channel/account/dimensions. **Projects are ours** —
+`crab-shell-proxy/.specs/features/agent-projects/`, already shipped for picoclaw,
+built on `agents.list` plus a glob patch to `agents.dispatch`.
+
+**2. picoclaw has no knowledge graph.** `grep -i 'knowledge.?graph'` over the
+tree returns zero. `pkg/seahorse` is a hierarchical conversation-SUMMARY DAG over
+SQLite with `short_grep`/`short_expand` — no entities, no relations. The graph is
+ours too: the proxy hosts an MCP server at `/v1/mcp` with fifteen tools and
+injects it into each picoclaw workspace.
+
+So feature 3 is not "port a picoclaw feature". It is **give the ganglion harness
+what our own proxy already offers picoclaw** — precisely the DF-1/DF-2/DF-3/DF-5
+row of `.specs/features/crab-ganglion-harness/spec.md`, where
+`harness_gate.go` answers `501` today.
+
+**3. The invitation to use a different mechanism has two concrete targets, and
+both are load-bearing.**
+
+- picoclaw's cron is **one store per container**: `gateway.go:843` builds the path
+  from `cfg.WorkspacePath()`, the *default* workspace, not the routed agent's. Per-project
+  schedules are structurally impossible there, which is already recorded as defect
+  B1 in `agent-projects-scope-fixes`. A fired job also runs in a throwaway
+  session, so it never joins the member's conversation.
+- **The ganglion runs `scale-to-zero`** (`crab-shell-proxy/config.yaml:126`,
+  agent `gamma`, 15s idle). A scheduler inside the harness would be asleep
+  whenever it had work — the same wall `ganglion-evolution` hit, where
+  `cold_path_trigger: scheduled` under `scale-to-zero` became a boot refusal.
+
+**Decision: the clock goes in the proxy**, which is awake and owns the container
+lifecycle, and can wake a stopped container to deliver a turn. That is the
+different mechanism the request invited, and it makes per-project schedules
+possible for the first time in this stack.
+
+**And on reasoning depth, the premise was also partly wrong.** picoclaw has one
+knob, `model_list[].thinking_level`, per model entry, with six values. There is
+no deep research, no deepsearch, no `/think`, and the spawn/delegate/subagent
+schemas expose no effort parameter — `grep -rniE
+"deep_research|deepsearch|ultrathink"` returns **zero hits**. Meanwhile ganglion
+could *already* put `reasoning_effort` on the wire through `extra_body` and
+already decoded reasoning deltas. So the work was never "add a field": it was
+moving depth from static-per-model to chosen-per-turn. The key and its six values
+are adopted verbatim, because the admin editor already renders that field.
+
+**One decision inside it worth recording.** There is deliberately **no provider
+capability table** in the harness. picoclaw needs one because it speaks four
+dialects; ganglion speaks one wire to every endpoint and cannot tell them apart.
+So **declaring `thinking_level` IS the capability declaration**, and a model that
+declared none is never sent a depth field whatever the agent asks for — because
+sending a field an endpoint rejects would turn depth selection into a turn
+failure, which is exactly what `vision-unsupported-glm.patch` already cost us.
+The cost is an operator who forgets the key gets a harness that never thinks
+deeply, so boot says so in a line naming the key.
+
+**Also recorded: picoclaw's sub-agent wiring is three-quarters dead, and this is
+why `ganglion-subagents` does not copy its shape.** `spawn_status` polls a map no
+live caller ever writes (`grep "\.Spawn(" | grep -v _test` returns nothing), so
+it always answers "No subagents have been spawned yet." `spawn`'s result is
+republished as a NEW inbound turn on channel `system` rather than returned to the
+turn that asked, because the `pendingResults` channel is nil at depth 0. And
+`max_concurrent` is enforced on a semaphore that is also nil at depth 0, so
+first-level fan-out is uncapped. Ganglion's answer is one synchronous tool taking
+a batch, with the bounds enforced where the fan-out actually happens.
+
+**Status.** `ganglion-reasoning-depth` implemented (harness#5, proxy#43,
+webapp#58). `ganglion-subagents` and `ganglion-projects` specified.
 
 ### AD-025: evolution ships as a ladder whose top rung cannot yet be climbed (2026-09-10)
 

--- a/.specs/project/STATE.md
+++ b/.specs/project/STATE.md
@@ -172,8 +172,32 @@ turn that asked, because the `pendingResults` channel is nil at depth 0. And
 first-level fan-out is uncapped. Ganglion's answer is one synchronous tool taking
 a batch, with the bounds enforced where the fan-out actually happens.
 
+**Two open questions answered the same day (2026-09-10), and the first made the
+work smaller.**
+
+*Scheduled tasks:* "a tarefa não responde a ninguém. Elas ficam salvas e posso
+visualizar na sidebar igual no picoclaw." So a fired job delivers to nobody and
+its RUN is stored and read from the Tasks panel — which already exists end to
+end: `history.CronRuns` discovers runs, `ReadCronRun` serves one transcript,
+`/v1/cron/runs` exposes both, and the webapp renders them, all harness-blind.
+The three conversation-delivery shapes the spec weighed are withdrawn. What
+remains is that the proxy runs the turn under picoclaw's own
+`agent:cron-<jobID>-<runID>` conversation id and writes the run's `.meta.json`
+itself — the one part of that reader's contract a harness does not satisfy,
+because a harness writes transcripts and never metas.
+
+*The memory graph:* "igual no picoclaw, global ou por projeto." picoclaw's graph
+is ours, and it is scoped per MEMBER — the MCP bearer's payload is
+`tenant/subs/role/user` with no project dimension. So matching picoclaw means per
+member, and slice C touches no security-critical path. The assumption recorded in
+the spec, so it can be corrected rather than discovered: "global or per project"
+is read as naming the two shapes rather than requesting both now, and per-project
+is built to be additive — one more field in the token payload, nothing else.
+
 **Status.** `ganglion-reasoning-depth` implemented (harness#5, proxy#43,
-webapp#58). `ganglion-subagents` and `ganglion-projects` specified.
+webapp#58). `ganglion-subagents` implemented (harness#6). `ganglion-projects`
+slice A implemented in the harness (harness#7), proxy half in progress; slices B
+and C unblocked by the answers above.
 
 ### AD-025: evolution ships as a ladder whose top rung cannot yet be climbed (2026-09-10)
 


### PR DESCRIPTION
Three specs and one decision record. **The decision record is the load-bearing
part**, because two of the three premises were wrong — both in the requester's
favour.

## picoclaw has no projects

A search of v0.3.1 for `project` as a type, field, config key or tool returns
nothing but OAuth `project_id`. Its scoping units are *agents* (one workspace
directory each) and a `SessionScope` over channel/account/dimensions.
**Projects are ours** — `crab-shell-proxy/.specs/features/agent-projects/`,
already shipped for picoclaw on top of `agents.list` plus a glob patch to
`agents.dispatch`.

**And picoclaw has no knowledge graph.** `grep -i 'knowledge.?graph'` returns
zero; `pkg/seahorse` is a conversation-**summary** DAG over SQLite — no entities,
no relations. The graph is ours too, hosted by the proxy at `/v1/mcp`.

So feature 3 is not porting anything. It is **giving the ganglion harness what
our own proxy already offers picoclaw** — the DF-1/DF-2/DF-3/DF-5 row of the
harness spec, where `harness_gate.go` answers `501` today.

## The invitation to "use a different mechanism" has two real targets

- picoclaw's cron is **one store per container** — `gateway.go:843` builds the
  path from `cfg.WorkspacePath()`, the *default* workspace, not the routed
  agent's. Per-project schedules are structurally impossible there, already
  recorded as defect **B1**. A fired job also runs in a throwaway session, so it
  never joins the member's conversation.
- **The ganglion runs `scale-to-zero`** (`config.yaml:126`, 15s idle). A
  scheduler inside it would be asleep whenever it had work — the same wall
  `ganglion-evolution`'s `cold_path_trigger` hit.

**So the clock goes in the proxy**, which is awake and owns the container
lifecycle. That makes per-project schedules possible for the first time in this
stack.

## Reasoning depth was also partly mis-premised — and is already implemented

picoclaw's one knob is `model_list[].thinking_level`, per model entry. There is
no deep research, no deepsearch, no `/think`: `grep -rniE
"deep_research|deepsearch|ultrathink"` returns **zero hits**. Meanwhile ganglion
could *already* emit `reasoning_effort` through `extra_body` and already decoded
reasoning deltas. The work was moving depth from static-per-model to
**chosen-per-turn**.

Shipped as `crab-ganglion-harness#5`, `crab-shell-proxy#43`,
`crab-exoskeleton-webapp#58`.

## And picoclaw's sub-agent wiring is three-quarters dead

`spawn_status` polls a map no live caller writes; `spawn`'s result is republished
as a **different turn**; and `max_concurrent` is enforced on a semaphore that is
nil at depth 0, so first-level fan-out is uncapped. Recorded so the ganglion
spec's divergences read as deliberate rather than careless.

## Contents

- `.specs/features/ganglion-reasoning-depth/spec.md` — implemented
- `.specs/features/ganglion-subagents/spec.md`
- `.specs/features/ganglion-projects/spec.md` — three slices, two open questions
- `.specs/project/STATE.md` **AD-026** and three `ROADMAP.md` entries

**No submodule pointer moves in this PR** — the pointers advance once the code
PRs merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)